### PR TITLE
fix: support job submit from dataset (application/json)

### DIFF
--- a/inc/jobsapi_msg.h
+++ b/inc/jobsapi_msg.h
@@ -37,6 +37,12 @@
 #define CATEGORY_VSAM 7         /**< VSAM related error */
 #define CATEGORY_UNEXPECTED 8   /**< Unexpected error */
 
+/** @brief Error message for missing file field in JSON body */
+#define ERR_MSG_MISSING_FILE_FIELD "Missing or invalid 'file' field in request body"
+
+/** @brief Error message for dataset open failure */
+#define ERR_MSG_SUBMIT_FILE_OPEN "Cannot open dataset: %s"
+
 /** @brief Error reason codes */
 #define REASON_SERVER_ERROR 1           /**< Internal server error */
 #define REASON_JOB_NOT_FOUND 2         /**< Job not found */
@@ -44,5 +50,7 @@
 #define REASON_INVALID_REQUEST 4       /**< Invalid request content */
 #define REASON_STC_PURGE 5            /**< Cannot purge STC */
 #define REASON_INCORRECT_JES_VSAM_HANDLE 6  /**< JES VSAM handle error */
+#define REASON_MISSING_FILE_FIELD 7    /**< Missing file field in JSON */
+#define REASON_SUBMIT_FILE_OPEN 8      /**< Cannot open dataset */
 
-#endif // JOBSAPI_MSG_H 
+#endif // JOBSAPI_MSG_H


### PR DESCRIPTION
## Summary

- Add Content-Type dispatch in `jobSubmitHandler()`: `application/json` extracts the `"file"` path from the JSON body and reads the dataset via `submit_file()`, while `text/plain` continues through the existing `submit_jcl_content()` path unchanged
- Rewrite `submit_file()` (previously dead code) to read dataset into lines, call `process_jobcard()` for USER/PASSWORD injection, and properly close the internal reader
- Add `extract_file_value()` helper to parse `{"file":"//'DSN(MBR)'"}` from the request body
- Add proper intrdr cleanup in handler for early-exit error paths

Fixes #6

## Test plan

- [x] `zowe jobs submit data-set "MIG.CNTL(BR14)"` → MIGBR14A submitted
- [x] `zowe jobs submit stdin < iefbr14.jcl` → MIGBR14B submitted
- [x] `curl` inline JCL submit → MIGBR14B submitted
- [x] Non-existent dataset → HTTP 404, "Cannot open dataset: ..."
- [x] JSON body without `"file"` field → HTTP 400, "Missing or invalid 'file' field"
- [x] Zowe Explorer: Submit Job from dataset tree