### PR TITLE
fix: prevent ABEND U0123 on PDS write, add URL percent-decoding

### DIFF
--- a/inc/dsapi_err.h
+++ b/inc/dsapi_err.h
@@ -1,0 +1,19 @@
+#ifndef DSAPI_ERR_H
+#define DSAPI_ERR_H
+
+/**
+ * @file dsapi_err.h
+ * @brief Dataset REST API error reason codes and messages
+ *
+ * Service-specific reason codes for z/OSMF Dataset REST interface.
+ */
+
+#include "zosmferr.h"
+
+// Reason codes for Category 6 (Service error)
+#define REASON_PDS_NOT_SEQUENTIAL		1	// Dataset is PDS, not sequential
+
+// Error messages for Category 6
+#define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
+
+#endif // DSAPI_ERR_H

--- a/inc/jobsapi_err.h
+++ b/inc/jobsapi_err.h
@@ -1,11 +1,7 @@
 #ifndef JOBSAPI_ERR_H
 #define JOBSAPI_ERR_H
 
-// Job API Categories
-#define CATEGORY_VSAM					 3  // VSAM error
-#define CATEGORY_SERVICE				 6  // Service error
-#define CATEGORY_UNEXPECTED				 7  // Unexpected error
-#define CATEGORY_CIM					 9  // Common Information Model (CIM) error
+#include "zosmferr.h"
 
 // Reason codes for Category 3 (VSAM error)
 #define REASON_INCORRECT_JES_VSAM_HANDLE 1  // Incorrect JesVsam handle
@@ -40,7 +36,7 @@
 #define REASON_STC_PURGE				51  // STC purge
 
 // Reason codes for Category 7 (Server error)
-#define REASON_SERVER_ERROR				0  // Server error
+// REASON_SERVER_ERROR defined in zosmferr.h
 
 // Error messages for Category 6
 #define ERR_MSG_INVALID_INTRDR_MODE		"Incorrect Internal Reader mode: %s. Must be one of TEXT | RECORD | BINARY"
@@ -66,7 +62,7 @@
 #define ERR_MSG_STC_PURGE				"Purge of a STC or a TSO useris not allowed"
 
 // Category 7 error messages
-#define ERR_MSG_SERVER_ERROR			"Server error occurred"
+// ERR_MSG_SERVER_ERROR defined in zosmferr.h
 
 // Category 9 error messages
 #define ERR_MSG_INVALID_JOBNAME			"Incorrect jobname: \"%s\""

--- a/inc/zosmferr.h
+++ b/inc/zosmferr.h
@@ -1,0 +1,24 @@
+#ifndef ZOSMFERR_H
+#define ZOSMFERR_H
+
+/**
+ * @file zosmferr.h
+ * @brief z/OSMF standard error categories and reason codes
+ *
+ * Shared error constants used across all API modules.
+ * Category and reason code values follow IBM z/OSMF conventions.
+ */
+
+// z/OSMF error categories (standard across all services)
+#define CATEGORY_VSAM					3	// VSAM error
+#define CATEGORY_SERVICE				6	// Service error
+#define CATEGORY_UNEXPECTED				7	// Unexpected error
+#define CATEGORY_CIM					9	// Common Information Model (CIM) error
+
+// Category 7 reason codes (server errors, common to all services)
+#define REASON_SERVER_ERROR				0	// Server error
+
+// Category 7 error messages
+#define ERR_MSG_SERVER_ERROR			"Server error occurred"
+
+#endif // ZOSMFERR_H


### PR DESCRIPTION
## Summary
- Add `is_pds()` helper using VTOC DSCB lookup (`__locate` + `__dscbdv`) to detect partitioned datasets
- Reject PDS in `datasetGetHandler`/`datasetPutHandler` with HTTP 400 instead of passing to `fopen()` which causes ABEND U0123
- Add URL percent-decoding in router for `%XX` sequences (ASCII→EBCDIC conversion)
- Extract shared z/OSMF error categories into `zosmferr.h`, add `dsapi_err.h` for dataset-specific error codes

## Known limitation

Zowe CLI sends literal parentheses in the URL path (e.g. `PUT /ds/MY.PDS(MEMBER)`), because `encodeURIComponent()` does not encode `(` and `)` per ECMAScript spec. The HTTPD on MVS 3.8j strips literal parentheses from `REQUEST_PATH`, so member routes never match. PDS member upload via Zowe CLI will not work until the HTTPD is patched to preserve parentheses in URL paths. The `is_pds()` check prevents the ABEND as a safety net.

Closes #9

## Test plan
- [x] `curl` with `%28MEMBER%29` → routes correctly to `memberPutHandler` (HTTP 204)
- [x] `zowe files upload ftds` to PDS → returns HTTP 400 instead of ABEND
- [x] `is_pds()` correctly identifies PDS via VTOC DSCB (dsorg=0x02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)