### PR TITLE
fix: reduce MAX_JCL_LINES to 2500 and fix memory leaks

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -469,6 +469,10 @@ end:
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;
 
 quit:
+	if (dslist) {
+		__freeds(&dslist);
+	}
+
 	return rc;
 }
 
@@ -913,6 +917,10 @@ end:
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;
 
 quit:
+	if (pdslist) {
+		__freepd(&pdslist);
+	}
+
 	return rc;
 }
 

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -26,7 +26,7 @@
 #define MAX_JOBS_LIMIT 1000
 #define MAX_URL_LENGTH 256
 #define MAX_ERR_MSG_LENGTH 256
-#define MAX_JCL_LINES 5000
+#define MAX_JCL_LINES 2500
 
 #define JES_INFO_SIZE   20 + 1
 #define TYPE_STR_SIZE    3 + 1
@@ -138,6 +138,10 @@ jobListHandler(Session *session)
 	sendJSONResponse(session, HTTP_STATUS_OK, builder);
 
 quit:
+	if (joblist) {
+		jesjobfr(&joblist);
+	}
+
 	if (builder) {
 		freeJsonBuilder(builder);
 	}
@@ -149,7 +153,7 @@ quit:
 	return 0;
 }
 
-int 
+int
 jobFilesHandler(Session *session) 
 {
 	int rc = 0;

--- a/src/router.c
+++ b/src/router.c
@@ -284,9 +284,9 @@ int extract_path_vars(Session *session, const char *pattern, const char *path)
 
             char env_name[256];
             sprintf(env_name, "HTTP_%s", var_name);
+            /* strdup required: http_set_env stores the pointer,
+               freed when HTTPD tears down the request environment */
             http_set_env(httpc, (UCHAR *) env_name, (UCHAR *) strdup(value));
-            
-            //insert(vars, strdup(var_name), strdup(value));
 
         } else {
             if (*pattern == *path) {


### PR DESCRIPTION
## Summary

- **S878 ABEND fix**: `MAX_JCL_LINES=5000` caused ~1.275 MB peak allocation across 4 buffers (5000x81 bytes each) in `submit_jcl_content` + `process_jobcard`, exhausting 24-bit virtual storage. Reduced to 2500 (~640 KB peak), still sufficient for the largest known .s file (1930 lines + ~40 JCL overhead).

- **Memory leaks fixed**:
  - `jobListHandler`: `jesjob()` result never freed → added `jesjobfr(&joblist)`
  - `datasetListHandler`: `__listds()` result never freed → added `__freeds(&dslist)`
  - `memberListHandler`: `__listpd()` result never freed → added `__freepd(&pdslist)`

## Test plan
- [ ] Submit large JCL (>1000 lines inline source) without S878
- [ ] Verify dataset list, member list, and job list endpoints still work
- [ ] Monitor virtual storage usage across repeated requests