### PR TITLE
feat: POST /zosmf/restfiles/ds/{dataset-name} dataset create

### DIFF
--- a/inc/dsapi.h
+++ b/inc/dsapi.h
@@ -105,4 +105,20 @@ int memberGetHandler(Session *session) asm("DAPI0011");
  */
 int memberPutHandler(Session *session) asm("DAPI0012");
 
+/**
+ * @brief Creates a new dataset with specified allocation parameters
+ *
+ * Allocates a new dataset using attributes from the JSON request body
+ * (dsorg, recfm, lrecl, blksize, space, etc.). Used by Zowe CLI/Explorer
+ * before uploading data to ensure correct dataset characteristics.
+ *
+ * @param session Current session context
+ * @return 0 on success, negative value on error
+ *
+ * Error cases:
+ * - HTTP 400 if invalid or missing allocation parameters
+ * - HTTP 500 if dataset allocation fails
+ */
+int datasetCreateHandler(Session *session) asm("DAPI0004");
+
 #endif // DSAPI_H

--- a/inc/dsapi_err.h
+++ b/inc/dsapi_err.h
@@ -12,8 +12,12 @@
 
 // Reason codes for Category 6 (Service error)
 #define REASON_PDS_NOT_SEQUENTIAL		1	// Dataset is PDS, not sequential
+#define REASON_DATASET_ALLOC_FAILED		2	// Dataset allocation failed
+#define REASON_INVALID_ALLOC_PARAMS		3	// Invalid or missing allocation parameters
 
 // Error messages for Category 6
 #define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
+#define ERR_MSG_DATASET_ALLOC_FAILED	"Dataset allocation failed"
+#define ERR_MSG_INVALID_ALLOC_PARAMS	"Invalid or missing allocation parameters"
 
 #endif // DSAPI_ERR_H

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -68,6 +68,7 @@ int main(int argc, char **argv)
 	add_route(&router, GET, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}", datasetGetHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/{dataset-name}", datasetPutHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}", datasetPutHandler);
+	add_route(&router, POST, "/zosmf/restfiles/ds/{dataset-name}", datasetCreateHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}/member", memberListHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberGetHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberPutHandler);


### PR DESCRIPTION
## Summary
- Implements POST `/zosmf/restfiles/ds/{dataset-name}` endpoint (closes #14) for dataset creation with caller-specified attributes (DSORG, RECFM, LRECL, BLKSIZE, SPACE)
- Adds JSON parsing helpers (`extract_json_string`, `extract_json_int`) for request body processing
- Fixes `handle_error()` to use `sendErrorResponse()` instead of `http_resp_internal_error()`, resolving ECONNRESET on error conditions (e.g. ENQ conflicts)

## Test plan
Tested on MVS 3.8j via Zowe CLI against `FIX0MIG.DUMMY.*`:
- [x] Create PS dataset (FB 80/3120) — HTTP 201, attributes verified via LIST
- [x] Create PO dataset (FB 80/3120, 5 dirblks) — HTTP 201, attributes verified via LIST
- [x] Write to PS + read back — roundtrip OK
- [x] Write member to PDS + read back — roundtrip OK
- [x] Write to ENQ-locked dataset — clean HTTP 500 JSON error (was ECONNRESET before)