### PR TITLE
feat: add DELETE /zosmf/restfiles/ds/{dataset-name} endpoint

### DIFF
--- a/inc/dsapi.h
+++ b/inc/dsapi.h
@@ -121,4 +121,19 @@ int memberPutHandler(Session *session) asm("DAPI0012");
  */
 int datasetCreateHandler(Session *session) asm("DAPI0004");
 
+/**
+ * @brief Deletes (uncatalogs and scratches) a dataset
+ *
+ * Removes a dataset from the system. Checks that the dataset
+ * exists before attempting deletion.
+ *
+ * @param session Current session context
+ * @return 0 on success, negative value on error
+ *
+ * Error cases:
+ * - HTTP 404 if dataset not found
+ * - HTTP 500 if delete operation fails
+ */
+int datasetDeleteHandler(Session *session) asm("DAPI0005");
+
 #endif // DSAPI_H

--- a/inc/dsapi_err.h
+++ b/inc/dsapi_err.h
@@ -14,10 +14,12 @@
 #define REASON_PDS_NOT_SEQUENTIAL		1	// Dataset is PDS, not sequential
 #define REASON_DATASET_ALLOC_FAILED		2	// Dataset allocation failed
 #define REASON_INVALID_ALLOC_PARAMS		3	// Invalid or missing allocation parameters
+#define REASON_DATASET_NOT_FOUND		4	// Dataset not found
 
 // Error messages for Category 6
 #define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
 #define ERR_MSG_DATASET_ALLOC_FAILED	"Dataset allocation failed"
 #define ERR_MSG_INVALID_ALLOC_PARAMS	"Invalid or missing allocation parameters"
+#define ERR_MSG_DATASET_NOT_FOUND	"Dataset not found"
 
 #endif // DSAPI_ERR_H

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -69,6 +69,7 @@ int main(int argc, char **argv)
 	add_route(&router, PUT, "/zosmf/restfiles/ds/{dataset-name}", datasetPutHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}", datasetPutHandler);
 	add_route(&router, POST, "/zosmf/restfiles/ds/{dataset-name}", datasetCreateHandler);
+	add_route(&router, DELETE, "/zosmf/restfiles/ds/{dataset-name}", datasetDeleteHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}/member", memberListHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberGetHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberPutHandler);


### PR DESCRIPTION
## Summary
- Adds `DELETE /zosmf/restfiles/ds/{dataset-name}` route so `zowe zos-files delete` works
- Checks catalog existence via `__locate()` before deleting — returns 404 if not found
- Calls `remove()` to uncatalog and scratch the dataset, returns 204 on success

## Test plan
- [x] Create a sequential dataset, then delete it via `zowe zos-files delete` — expect HTTP 204
- [x] Delete a non-existent dataset — expect HTTP 404 with reason code 4

Closes #15