### PR TITLE
feat: add DELETE endpoint for PDS member deletion

### DIFF
--- a/inc/dsapi.h
+++ b/inc/dsapi.h
@@ -136,4 +136,19 @@ int datasetCreateHandler(Session *session) asm("DAPI0004");
  */
 int datasetDeleteHandler(Session *session) asm("DAPI0005");
 
+/**
+ * @brief Deletes a PDS member
+ *
+ * Removes a member from a partitioned dataset. Checks that the
+ * member exists before attempting deletion.
+ *
+ * @param session Current session context
+ * @return 0 on success, negative value on error
+ *
+ * Error cases:
+ * - HTTP 404 if member not found
+ * - HTTP 500 if delete operation fails
+ */
+int memberDeleteHandler(Session *session) asm("DAPI0013");
+
 #endif // DSAPI_H

--- a/inc/dsapi_err.h
+++ b/inc/dsapi_err.h
@@ -15,11 +15,13 @@
 #define REASON_DATASET_ALLOC_FAILED		2	// Dataset allocation failed
 #define REASON_INVALID_ALLOC_PARAMS		3	// Invalid or missing allocation parameters
 #define REASON_DATASET_NOT_FOUND		4	// Dataset not found
+#define REASON_MEMBER_NOT_FOUND			5	// PDS member not found
 
 // Error messages for Category 6
 #define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
 #define ERR_MSG_DATASET_ALLOC_FAILED	"Dataset allocation failed"
 #define ERR_MSG_INVALID_ALLOC_PARAMS	"Invalid or missing allocation parameters"
 #define ERR_MSG_DATASET_NOT_FOUND	"Dataset not found"
+#define ERR_MSG_MEMBER_NOT_FOUND	"PDS member not found"
 
 #endif // DSAPI_ERR_H

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -73,6 +73,7 @@ int main(int argc, char **argv)
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}/member", memberListHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberGetHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberPutHandler);
+	add_route(&router, DELETE, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberDeleteHandler);
 
 	/* dispatch the request */
 	irc = handle_request(&router, &session);


### PR DESCRIPTION
## Summary
- Adds `DELETE /zosmf/restfiles/ds/{dataset-name}({member-name})` route for PDS member deletion
- Verifies member exists via `fopen()` before deleting — returns 404 if not found
- Calls `remove()` to delete the PDS directory entry, returns 204 on success

## Test plan
- [x] Create PDS, upload member, delete it via `zowe zos-files delete` — expect HTTP 204
- [x] Delete non-existent member — expect HTTP 404 with reason code 5

Closes #16