### PR TITLE
fix: trim trailing spaces from URL path variables

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1004,10 +1004,10 @@ int memberPutHandler(Session *session)
     // Validate parameters
     dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
     member = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_member-name");
-    
+
     if (!dsname || !member) {
-        wtof("MVSMF02E Missing required parameters: dsname=%s, member=%s, Data-Type=%s", 
-             dsname ? dsname : "NULL", 
+        wtof("MVSMF02E Missing required parameters: dsname=%s, member=%s, Data-Type=%s",
+             dsname ? dsname : "NULL",
              member ? member : "NULL",
              data_type_str ? data_type_str : "NULL");
 

--- a/src/router.c
+++ b/src/router.c
@@ -282,6 +282,12 @@ int extract_path_vars(Session *session, const char *pattern, const char *path)
             strncpy(value, value_start, value_len);
             value[value_len] = '\0';
 
+            /* Trim trailing spaces - clients like Zowe Explorer
+               may pad names with spaces (e.g. member names to 8 chars) */
+            while (value_len > 0 && value[value_len - 1] == ' ') {
+                value[--value_len] = '\0';
+            }
+
             char env_name[256];
             sprintf(env_name, "HTTP_%s", var_name);
             /* strdup required: http_set_env stores the pointer,


### PR DESCRIPTION
## Summary
- Fixes #37
- Zowe Explorer pads member names with spaces up to 8 characters, causing DELETE (and other) operations to fail with HTTP 500
- Trimming is done centrally in `extract_path_vars()` in `router.c` so all handlers benefit automatically

## Test plan
- [ ] DELETE member with padded name via Zowe Explorer
- [ ] GET/PUT member operations with padded names
- [ ] Verify unpadded names still work correctly