### PR TITLE
Fix dslevel pattern matching and X-IBM-Max-Items support

### DIFF
--- a/doc/endpoints/datasets/list.md
+++ b/doc/endpoints/datasets/list.md
@@ -9,9 +9,12 @@ GET
 `/zosmf/restfiles/ds`
 
 ## Query Parameters
-- `dslevel` (required): Dataset name filter pattern (e.g. `USER.**`, `SYS1.MAC*`)
+- `dslevel` (required): Dataset name filter pattern. Supports exact names (`USER.TEST.DATA`), hierarchical prefixes (`USER.TEST`), and wildcard patterns (`USER.*`, `USER.**`, `USER.C*`). Internally, the longest concrete prefix is used for the catalog lookup and any wildcard or extra-qualifier filtering is applied afterwards.
 - `volser` (optional): Filter by volume serial
 - `start` (optional): Starting dataset name for pagination
+
+## Request Headers
+- `X-IBM-Max-Items` (optional): Maximum number of items to return. Value `0` means unlimited (default behavior). When the result set is truncated, `moreRows` is set to `true`.
 
 ## Response
 On successful completion, this request returns HTTP status code 200 (OK) and a JSON object:
@@ -51,7 +54,8 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
 
 ## Limitations
 - Only NONVSAM datasets are listed
-- `moreRows` is always `false` (no pagination support yet)
+- `*` and `**` wildcards are treated identically (both match any number of qualifiers)
+- `start` parameter is not yet implemented
 
 ## Examples
 

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -388,33 +388,126 @@ static int write_record(Session *session, FILE *fp, char *record_buffer, size_t 
     return 0;
 }
 
+/*
+** extract_level_prefix - split a dslevel pattern into a catalog LEVEL
+** prefix and an optional wildcard filter for __listds().
+**
+** level_out must be at least 45 bytes. *filter_out is set to the
+** original dslevel when post-filtering is needed, NULL otherwise.
+*/
+static void
+extract_level_prefix(const char *dslevel, char *level_out, char **filter_out)
+{
+	const char	*p;
+	const char	*last_dot = NULL;
+	int		has_wildcard = 0;
+	int		dots = 0;
+
+	*filter_out = NULL;
+	level_out[0] = '\0';
+
+	if (!dslevel || !*dslevel) return;
+
+	/* scan for wildcards and count qualifiers */
+	for (p = dslevel; *p; p++) {
+		if (*p == '*' || *p == '?') has_wildcard = 1;
+		if (*p == '.') {
+			dots++;
+			last_dot = p;
+		}
+	}
+
+	if (!has_wildcard) {
+		if (dots >= 2 && last_dot) {
+			/* 3+ qualifiers, exact name: use up to last dot as LEVEL */
+			memcpy(level_out, dslevel, last_dot - dslevel);
+			level_out[last_dot - dslevel] = '\0';
+			*filter_out = (char *) dslevel;
+		} else {
+			/* 1-2 qualifiers: pass through as-is */
+			strcpy(level_out, dslevel);
+		}
+		return;
+	}
+
+	/* has wildcards — find longest prefix before first wild qualifier */
+	{
+		const char	*src = dslevel;
+		const char	*seg_start = dslevel;
+		const char	*prefix_end = NULL;
+		int		seg_has_wild;
+
+		while (*src) {
+			seg_start = src;
+			seg_has_wild = 0;
+
+			/* scan one qualifier */
+			while (*src && *src != '.') {
+				if (*src == '*' || *src == '?') seg_has_wild = 1;
+				src++;
+			}
+
+			if (seg_has_wild) break;
+
+			prefix_end = src;  /* end of this clean segment */
+
+			if (*src == '.') src++;  /* skip dot */
+		}
+
+		if (prefix_end && prefix_end > dslevel) {
+			memcpy(level_out, dslevel, prefix_end - dslevel);
+			level_out[prefix_end - dslevel] = '\0';
+		} else {
+			/* wildcard in first qualifier — use full dslevel */
+			strcpy(level_out, dslevel);
+		}
+
+		/* HLQ.** is equivalent to bare HLQ, no filter needed */
+		if (seg_start && strcmp(seg_start, "**") == 0 &&
+			prefix_end == seg_start - 1) {
+			*filter_out = NULL;
+		} else {
+			*filter_out = (char *) dslevel;
+		}
+	}
+}
+
 int datasetListHandler(Session *session)
 {
 	unsigned	rc		= 0;
 	unsigned	count		= 0;
 	unsigned	first		= 1;
 	unsigned	i		= 0;
+	unsigned	maxitems	= 0;
+	unsigned	emitted		= 0;
 
 	char		*method		= NULL;
 	char		*path		= NULL;
 	char		*verb		= NULL;
+	char		*maxitems_str	= NULL;
 
 	DSLIST		**dslist	= NULL;
 
 	char		*dslevel	= NULL;
 	char		*volser		= NULL;
 	char		*start		= NULL;
+	char		*filter		= NULL;
+	char		level_buf[45]	= {0};
 
 	method	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_METHOD");
 	path	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_PATH");
 
 	verb	= strrchr(path, '/');
 
-	dslevel = (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_DSLEVEL"); 
-	volser	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_VOLSER"); 
-	start 	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_START"); 
+	dslevel = (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_DSLEVEL");
+	volser	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_VOLSER");
+	start 	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_START");
 
-	dslist = __listds(dslevel, "NONVSAM VOLUME", NULL);
+	extract_level_prefix(dslevel, level_buf, &filter);
+	dslist = __listds(level_buf, "NONVSAM VOLUME", filter);
+
+	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
+	if (maxitems_str) maxitems = (unsigned) atoi(maxitems_str);
 	
 	if ((rc = http_resp(session->httpc,200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
@@ -432,9 +525,11 @@ int datasetListHandler(Session *session)
 
 	for(i=0; i < count; i++) {
 		DSLIST *ds = dslist[i];
-		
+
 		if (!ds) continue;
-		
+
+		if (maxitems > 0 && emitted >= maxitems) break;
+
 		if (first) {
 			/* first time we're printing this '{' so no ',' needed */
 			if ((rc = http_printf(session->httpc, "    {\n")) < 0) goto quit;
@@ -445,7 +540,7 @@ int datasetListHandler(Session *session)
 		}
 
 		if ((rc = http_printf(session->httpc, "      \"dsname\": \"%.44s\",\n", ds->dsn)) < 0) goto quit;
-		
+
 		// TODO: the following fields should only be generated if X-IBM-Attributes == base
 		// TODO: add vol field only if X-IBM-Attributes has 'vol'
 		if (strcmp(ds->dsorg, "PO") == 0) {
@@ -464,15 +559,18 @@ int datasetListHandler(Session *session)
 		if ((rc = http_printf(session->httpc, "      \"dsorg\": \"%.2s\",\n", ds->dsorg)) < 0) goto quit;
 		if ((rc = http_printf(session->httpc, "      \"cdate\": \"%u-%02u-%02u\",\n", ds->cryear, ds->crmon, ds->crday)) < 0) goto quit;
 		if ((rc = http_printf(session->httpc, "      \"rdate\": \"%u-%02u-%02u\"\n", ds->rfyear, ds->rfmon, ds->rfday)) < 0) goto quit;
-		
+
 		if ((rc = http_printf(session->httpc, "    }\n")) < 0) goto quit;
+
+		emitted++;
 	}
 
 end:
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", count)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", emitted)) < 0) goto quit;
 	// TODO: add totalRows if X-IBM-Attributes has ',total'
-	if ((rc = http_printf(session->httpc, "  \"moreRows\": false,\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
+		(maxitems > 0 && emitted < count) ? "true" : "false")) < 0) goto quit;
 
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -175,19 +175,113 @@ else
 	fail "read content matches" "expected 'LINE 1 TEST DATA' in output"
 fi
 
-# --- List datasets ---
+# --- List datasets (two-level prefix) ---
 echo ""
-echo "--- List Datasets ---"
+echo "--- List Datasets (two-level prefix) ---"
 
 BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVS_USER}.CURL")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
-assert_http_status "200" "$HTTP_CODE" "list datasets"
+assert_http_status "200" "$HTTP_CODE" "list datasets (two-level prefix)"
+
+ITEMS=$(echo "$CONTENT" | jq '.items | length' 2>/dev/null) || ITEMS=0
+if [ "$ITEMS" -gt 0 ] 2>/dev/null; then
+	pass "list returned results ($ITEMS items)"
+else
+	fail "list returned results" "expected >0 items"
+fi
 
 # Extract volume serial for later volume-prefix tests
 VOLUME=$(echo "$CONTENT" | jq -r --arg dsn "$TEST_SEQ" \
 	'.items[] | select(.dsname == $dsn) | .vol // empty' 2>/dev/null) || VOLUME=""
+
+# --- List datasets (exact three-level name) ---
+echo ""
+echo "--- List Datasets (exact name) ---"
+
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${TEST_SEQ}")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "200" "$HTTP_CODE" "list datasets (exact name)"
+assert_json_field "$CONTENT" '.items[0].dsname' "$TEST_SEQ" "exact name match"
+
+# --- List datasets (wildcard *) ---
+echo ""
+echo "--- List Datasets (wildcard *) ---"
+
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVS_USER}.*")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "200" "$HTTP_CODE" "list datasets (wildcard *)"
+
+ITEMS=$(echo "$CONTENT" | jq '.items | length' 2>/dev/null) || ITEMS=0
+if [ "$ITEMS" -gt 0 ] 2>/dev/null; then
+	pass "wildcard * returned results ($ITEMS items)"
+else
+	fail "wildcard * returned results" "expected >0 items"
+fi
+
+# --- List datasets (wildcard **) ---
+echo ""
+echo "--- List Datasets (wildcard **) ---"
+
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVS_USER}.**")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "200" "$HTTP_CODE" "list datasets (wildcard **)"
+
+ITEMS=$(echo "$CONTENT" | jq '.items | length' 2>/dev/null) || ITEMS=0
+if [ "$ITEMS" -gt 0 ] 2>/dev/null; then
+	pass "wildcard ** returned results ($ITEMS items)"
+else
+	fail "wildcard ** returned results" "expected >0 items"
+fi
+
+# --- List datasets (partial wildcard) ---
+echo ""
+echo "--- List Datasets (partial wildcard) ---"
+
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVS_USER}.CURL*")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "200" "$HTTP_CODE" "list datasets (partial wildcard)"
+
+ITEMS=$(echo "$CONTENT" | jq '.items | length' 2>/dev/null) || ITEMS=0
+if [ "$ITEMS" -gt 0 ] 2>/dev/null; then
+	pass "partial wildcard returned results ($ITEMS items)"
+else
+	fail "partial wildcard returned results" "expected >0 items"
+fi
+
+# --- List datasets (X-IBM-Max-Items) ---
+echo ""
+echo "--- List Datasets (X-IBM-Max-Items) ---"
+
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	-H "X-IBM-Max-Items: 1" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVS_USER}.CURL")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "200" "$HTTP_CODE" "list datasets (max-items=1)"
+
+RETURNED=$(echo "$CONTENT" | jq '.returnedRows' 2>/dev/null) || RETURNED=0
+if [ "$RETURNED" -eq 1 ] 2>/dev/null; then
+	pass "max-items limited to 1 row"
+else
+	fail "max-items limited to 1 row" "expected returnedRows=1, got $RETURNED"
+fi
+
+MORE_ROWS=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null) || MORE_ROWS=""
+if [ "$MORE_ROWS" = "true" ]; then
+	pass "moreRows=true when truncated"
+else
+	fail "moreRows=true when truncated" "expected true, got $MORE_ROWS"
+fi
 
 # --- Read with volume prefix ---
 echo ""

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -179,19 +179,79 @@ else
 	fail "read content matches" "expected 'LINE 1 TEST DATA' in output"
 fi
 
-# --- List datasets ---
+# --- List datasets (two-level prefix) ---
 echo ""
-echo "--- List Datasets ---"
+echo "--- List Datasets (two-level prefix) ---"
 
 RC=0
 OUTPUT=$(run_zowe_json files list ds "${MVS_USER}.ZOWE") || RC=$?
-assert_rc 0 "$RC" "list datasets"
+assert_rc 0 "$RC" "list datasets (two-level prefix)"
 
 ITEMS=$(echo "$OUTPUT" | jq -r '.data.apiResponse.items | length' 2>/dev/null) || ITEMS=0
 if [ "$ITEMS" -gt 0 ] 2>/dev/null; then
 	pass "list returned results ($ITEMS)"
 else
 	fail "list returned results" "expected >0 items"
+fi
+
+# --- List datasets (exact three-level name) ---
+echo ""
+echo "--- List Datasets (exact name) ---"
+
+RC=0
+OUTPUT=$(run_zowe_json files list ds "${TEST_SEQ}") || RC=$?
+assert_rc 0 "$RC" "list datasets (exact name)"
+
+DSN=$(echo "$OUTPUT" | jq -r '.data.apiResponse.items[0].dsname' 2>/dev/null) || DSN=""
+if [ "$DSN" = "$TEST_SEQ" ]; then
+	pass "exact name returned correct dataset"
+else
+	fail "exact name returned correct dataset" "expected '$TEST_SEQ', got '$DSN'"
+fi
+
+# --- List datasets (wildcard *) ---
+echo ""
+echo "--- List Datasets (wildcard *) ---"
+
+RC=0
+OUTPUT=$(run_zowe_json files list ds "${MVS_USER}.*") || RC=$?
+assert_rc 0 "$RC" "list datasets (wildcard *)"
+
+ITEMS=$(echo "$OUTPUT" | jq -r '.data.apiResponse.items | length' 2>/dev/null) || ITEMS=0
+if [ "$ITEMS" -gt 0 ] 2>/dev/null; then
+	pass "wildcard * returned results ($ITEMS)"
+else
+	fail "wildcard * returned results" "expected >0 items"
+fi
+
+# --- List datasets (wildcard **) ---
+echo ""
+echo "--- List Datasets (wildcard **) ---"
+
+RC=0
+OUTPUT=$(run_zowe_json files list ds "${MVS_USER}.**") || RC=$?
+assert_rc 0 "$RC" "list datasets (wildcard **)"
+
+ITEMS=$(echo "$OUTPUT" | jq -r '.data.apiResponse.items | length' 2>/dev/null) || ITEMS=0
+if [ "$ITEMS" -gt 0 ] 2>/dev/null; then
+	pass "wildcard ** returned results ($ITEMS)"
+else
+	fail "wildcard ** returned results" "expected >0 items"
+fi
+
+# --- List datasets (max-items) ---
+echo ""
+echo "--- List Datasets (max-items) ---"
+
+RC=0
+OUTPUT=$(run_zowe_json files list ds "${MVS_USER}.ZOWE" --max 1) || RC=$?
+assert_rc 0 "$RC" "list datasets (max-items=1)"
+
+RETURNED=$(echo "$OUTPUT" | jq -r '.data.apiResponse.returnedRows' 2>/dev/null) || RETURNED=0
+if [ "$RETURNED" -eq 1 ] 2>/dev/null; then
+	pass "max-items limited to 1 row"
+else
+	fail "max-items limited to 1 row" "expected returnedRows=1, got $RETURNED"
 fi
 
 # --- Delete sequential dataset ---


### PR DESCRIPTION
## Summary

Closes #49

- Fix dslevel pattern matching for wildcard `*`, `**`, and partial patterns
- Add `X-IBM-Max-Items` header support to limit dataset list results
- Update endpoint documentation and integration tests

## Test plan

- [x] `tests/curl-datasets.sh` — wildcard `*`, `**`, partial patterns, max-items all pass
- [x] `tests/zowe-datasets.sh` — all dataset list tests pass