### PR TITLE
fix: return HTTP 400 for unsupported Content-Type on job submit (#41)

### DIFF
--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -411,6 +411,16 @@ int jobSubmitHandler(Session *session)
 	{
 		const char *content_type = getHeaderParam(session, "Content-Type");
 		int is_json = (content_type && strstr(content_type, "application/json") != NULL);
+		int is_text = (!content_type || strstr(content_type, "text/plain") != NULL);
+
+		if (!is_json && !is_text) {
+			sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
+							RC_ERROR, REASON_INVALID_REQUEST,
+							"Unsupported Content-Type for job submission. "
+							"Use application/json or text/plain", NULL, 0);
+			rc = -1;
+			goto quit;
+		}
 
 		if (is_json) {
 			/* convert ASCII request body to EBCDIC so strstr/strchr work */
@@ -1909,6 +1919,9 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
     rc = process_jobcard(lines, num_lines, jobname, jobclass, user, password);
     if (rc < 0) {
         wtof("MVSMF22E Failed to analyze job card");
+        sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
+                        RC_ERROR, REASON_INVALID_REQUEST,
+                        "No valid JOB card found in submitted JCL", NULL, 0);
         goto quit;
     }
 


### PR DESCRIPTION
## Summary

- Validate Content-Type before dispatching: reject anything other than `application/json` or `text/plain` with HTTP 400
- Add missing `sendErrorResponse` in `submit_jcl_content` when `process_jobcard` fails (no JOB card found) — previously the handler returned without sending any response, causing the connection to drop

Closes #41

## Test plan

- [x] `./tests/curl-jobs.sh` — 59 passed, 1 failed (pre-existing #42), 1 skipped
- [x] `test_submit_invalid_content_type` now passes (was HTTP 000, now HTTP 400)