### PR TITLE
fix: split two-level dataset names for correct catalog lookup

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -418,13 +418,13 @@ extract_level_prefix(const char *dslevel, char *level_out, char **filter_out)
 	}
 
 	if (!has_wildcard) {
-		if (dots >= 2 && last_dot) {
-			/* 3+ qualifiers, exact name: use up to last dot as LEVEL */
+		if (last_dot) {
+			/* 2+ qualifiers, exact name: use up to last dot as LEVEL */
 			memcpy(level_out, dslevel, last_dot - dslevel);
 			level_out[last_dot - dslevel] = '\0';
 			*filter_out = (char *) dslevel;
 		} else {
-			/* 1-2 qualifiers: pass through as-is */
+			/* single qualifier: pass through as-is */
 			strcpy(level_out, dslevel);
 		}
 		return;

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -208,6 +208,17 @@ CONTENT=$(echo "$BODY" | sed '$d')
 assert_http_status "200" "$HTTP_CODE" "list datasets (exact name)"
 assert_json_field "$CONTENT" '.items[0].dsname' "$TEST_SEQ" "exact name match"
 
+# --- List datasets (exact two-level name, issue #61) ---
+echo ""
+echo "--- List Datasets (exact two-level name) ---"
+
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=SYS1.MACLIB")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "200" "$HTTP_CODE" "list datasets (exact two-level name)"
+assert_json_field "$CONTENT" '.items[0].dsname' "SYS1.MACLIB" "two-level exact name match"
+
 # --- List datasets (wildcard *) ---
 echo ""
 echo "--- List Datasets (wildcard *) ---"


### PR DESCRIPTION
## Summary

- Two-qualifier exact names (e.g. `CRENT370.MACLIB`) were passed as-is to `LISTC LEVEL`, which treats them as a prefix search and misses the dataset itself
- Changed `extract_level_prefix()` to split at the last dot for any multi-qualifier name, not just 3+ qualifiers
- Added integration test for exact two-level name lookup (`SYS1.MACLIB`)

Closes #61

## Test plan

- [x] `make compiledb` — no new errors
- [x] `./tests/curl-datasets.sh` — new test passes, no regressions