### PR TITLE
fix: dataset PUT returns 404 if dataset does not exist

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -820,6 +820,17 @@ int datasetPutHandler(Session *session)
         snprintf(mode_str, sizeof(mode_str), "%s", "wb");
     }
 
+    /* Verify dataset exists - do not auto-create with wrong DCB (issue #65) */
+    {
+        FILE *chk = fopen(dsname, "r");
+        if (!chk) {
+            return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+                CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_NOT_FOUND,
+                ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
+        }
+        fclose(chk);
+    }
+
     fp = fopen(dsname, mode_str);
     if (!fp) {
         wtof("MVSMF34E Failed to open dataset for writing: %s (errno=%d)", dsname, errno);


### PR DESCRIPTION
## Summary

- Before writing, `datasetPutHandler` now checks whether the target sequential dataset exists by opening it read-only (DISP=SHR)
- If the dataset is not found, HTTP 404 is returned immediately using the existing `REASON_DATASET_NOT_FOUND` / `ERR_MSG_DATASET_NOT_FOUND` constants
- If the dataset exists, the read handle is closed and the write proceeds normally with DISP=OLD — no auto-creation path is reached

The PDS member upload handler is unaffected: it uses `__fpshr` (DISP=SHR) which already fails correctly when the PDS does not exist.

Closes #65

## Test plan

- [ ] Upload to a non-existent dataset → expect HTTP 404 with dataset-not-found message
- [ ] Upload to a pre-allocated dataset → expect success as before
- [ ] Upload to a non-existent PDS member (existing PDS) → expect success as before
- [ ] Upload to a non-existent PDS → expect failure (unchanged behaviour)