### PR TITLE
feat: add {*var} wildcard pattern support to router

### DIFF
--- a/include/testapi.h
+++ b/include/testapi.h
@@ -9,4 +9,9 @@
 */
 int testHandler(Session *session) asm("TAPI0000");
 
+/* Wildcard route test — echoes the captured {*filepath} variable.
+** GET /zosmf/test/wildcard/{*filepath}
+*/
+int testWildcardHandler(Session *session) asm("TAPI0001");
+
 #endif

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -62,6 +62,7 @@ int main(int argc, char **argv)
 	/* add the URL mappings */
 	add_route(&router, GET, "/zosmf/info", infoHandler);
 	add_route(&router, GET, "/zosmf/test", testHandler);
+	add_route(&router, GET, "/zosmf/test/wildcard/{*filepath}", testWildcardHandler);
 
 	add_route(&router, GET, "/zosmf/restjobs/jobs", jobListHandler);
 	add_route(&router, GET, "/zosmf/restjobs/jobs/{job-name}/{jobid}/files", jobFilesHandler);

--- a/src/router.c
+++ b/src/router.c
@@ -224,15 +224,22 @@ Route *find_route(Router *router, HttpMethod method, const char *path)
 }
 
 __asm__("\n&FUNC	SETC 'is_pattern_match'");
-static 
-int is_pattern_match(const char *pattern, const char *path) 
+static
+int is_pattern_match(const char *pattern, const char *path)
 {
     while (*pattern && *path) {
         if (*pattern == '{') {
+            int is_wildcard = (*(pattern + 1) == '*');
+            if (is_wildcard) pattern++;
             while (*pattern && *pattern != '}') pattern++;
             if (*pattern == '}') pattern++;
 
-            while (*path && *path != '/' && *path != '(' && *path != ')') path++;
+            if (is_wildcard) {
+                /* {*var} consumes entire remaining path including slashes */
+                while (*path) path++;
+            } else {
+                while (*path && *path != '/' && *path != '(' && *path != ')') path++;
+            }
         } else {
             if (*pattern == *path) {
                 pattern++;
@@ -247,8 +254,8 @@ int is_pattern_match(const char *pattern, const char *path)
 }
 
 __asm__("\n&FUNC	SETC 'extract_path_vars'");
-static 
-int extract_path_vars(Session *session, const char *pattern, const char *path) 
+static
+int extract_path_vars(Session *session, const char *pattern, const char *path)
 {
     if (session == NULL || pattern == NULL || path == NULL) {
         return -1;
@@ -260,6 +267,8 @@ int extract_path_vars(Session *session, const char *pattern, const char *path)
     while (*pattern) {
         if (*pattern == '{') {
             pattern++;
+            int is_wildcard = (*pattern == '*');
+            if (is_wildcard) pattern++;
             const char *var_start = pattern;
             while (*pattern && *pattern != '}') pattern++;
             int var_name_len = pattern - var_start;
@@ -268,11 +277,18 @@ int extract_path_vars(Session *session, const char *pattern, const char *path)
             var_name[var_name_len] = '\0';
             if (*pattern == '}') pattern++;
 
-            const char *pattern_next = pattern;
-            while (*pattern_next && *pattern_next != '/' && *pattern_next != '(' && *pattern_next != ')') pattern_next++;
-
             const char *value_start = path;
-            while (*path && *path != *pattern_next) path++;
+
+            if (is_wildcard) {
+                /* {*var} captures entire remaining path */
+                while (*path) path++;
+            } else {
+                const char *pattern_next = pattern;
+                while (*pattern_next && *pattern_next != '/' && *pattern_next != '(' && *pattern_next != ')') pattern_next++;
+
+                while (*path && *path != *pattern_next) path++;
+            }
+
             int value_len = path - value_start;
             char value[1024];
             strncpy(value, value_start, value_len);

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -90,3 +90,24 @@ int testHandler(Session *session)
 quit:
 	return rc;
 }
+
+int testWildcardHandler(Session *session)
+{
+	int rc = 0;
+	char *filepath = NULL;
+
+	filepath = (char *) http_get_env(session->httpc,
+		(const UCHAR *) "HTTP_filepath");
+	if (!filepath) filepath = "(null)";
+
+	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit2;
+	if ((rc = http_printf(session->httpc,
+		"Content-Type: application/json\r\n\r\n")) < 0) goto quit2;
+
+	rc = http_printf(session->httpc,
+		"{ \"handler\": \"testWildcard\", \"filepath\": \"%s\" }\n",
+		filepath);
+
+quit2:
+	return rc;
+}


### PR DESCRIPTION
## Summary

Adds `{*var}` wildcard pattern support to the router's `is_pattern_match()` and `extract_path_vars()` functions. This allows a single route parameter to capture the entire remaining path including `/` characters.

- `{*filepath}` in a route pattern like `/zosmf/restfiles/fs/{*filepath}` will match `/u/user/dir/file.txt` as a single variable
- Regular `{var}` patterns are unchanged — they still stop at `/`, `(`, `)`
- No changes to the public router API

## Why

USS file paths contain multiple `/` segments after the route prefix. Without wildcard support, `{filepath}` would only capture the first segment, making USS endpoint routing impossible.

Fixes #77

## Test plan

- [x] Build and deploy to MVS — verify existing dataset and job routes still work
- [x] Register a test route with `{*filepath}` and verify full path capture
- [x] Verify path variable extraction sets the correct `HTTP_filepath` env value