### PR TITLE
build: add libufs (ufsd) as MBT dependency

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -41,6 +41,7 @@ space = ["TRK", 5, 2, 5]
 [dependencies]
 "mvslovers/crent370" = ">=1.0.6"
 "mvslovers/httpd" = "=3.3.1-dev"
+"mvslovers/ufsd" = "=1.0.0-dev"
 
 [link.module]
 name = "MVSMF"


### PR DESCRIPTION
## Summary

- Add `mvslovers/ufsd =1.0.0-dev` to `project.toml` dependencies
- `make bootstrap` resolves headers to `contrib/ufsd-1.0.0-dev/include/libufs.h`
- NCALIB dataset provisioned on MVS for link-time resolution

Fixes #78

## Test plan

- [x] `make bootstrap` succeeds with MVS connectivity
- [x] `#include "libufs.h"` resolves in subsequent USS handler code