### PR TITLE
feat: implement ussListHandler for directory listing

### DIFF
--- a/doc/endpoints/uss/list.md
+++ b/doc/endpoints/uss/list.md
@@ -1,0 +1,78 @@
+# GET /zosmf/restfiles/fs — List Directory
+
+Lists files and directories at the specified USS path.
+
+## Request
+
+```
+GET /zosmf/restfiles/fs?path=<filepath>
+```
+
+### Query Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `path`    | Yes      | Absolute path to the directory to list |
+
+### Headers
+
+| Header            | Required | Default | Description |
+|-------------------|----------|---------|-------------|
+| `X-IBM-Max-Items` | No       | 1000    | Maximum items to return. 0 = unlimited |
+
+## Response (200 OK)
+
+```json
+{
+  "items": [
+    {
+      "name": "myfile.txt",
+      "mode": "-rw-r--r--",
+      "size": 1234,
+      "user": "IBMUSER",
+      "group": "SYS1",
+      "links": 1,
+      "mtime": "2026-03-15T14:30:00Z",
+      "inode": 42
+    }
+  ],
+  "returnedRows": 1,
+  "totalRows": 1,
+  "moreRows": false,
+  "JSONversion": 1
+}
+```
+
+### Item Fields
+
+| Field   | Source            | Type   | Description |
+|---------|-------------------|--------|-------------|
+| `name`  | UFSDLIST.name     | string | File or directory name |
+| `mode`  | UFSDLIST.attr     | string | Unix permission string (e.g. `drwxr-xr-x`) |
+| `size`  | UFSDLIST.filesize | number | File size in bytes |
+| `user`  | UFSDLIST.owner    | string | Owner name |
+| `group` | UFSDLIST.group    | string | Group name |
+| `links` | UFSDLIST.nlink    | number | Hard link count |
+| `mtime` | UFSDLIST.mtime    | string | Last modified time (ISO 8601 UTC) |
+| `inode` | UFSDLIST.inode_number | number | Inode number |
+
+### Pagination
+
+When `X-IBM-Max-Items` is set and the directory contains more entries:
+- `returnedRows` = number of items in the response
+- `totalRows` = total entries in the directory (excluding `.` and `..`)
+- `moreRows` = `true` when results were truncated
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Missing `path` query parameter |
+| 404    | Path not found or not a directory |
+| 503    | UFSD subsystem not available |
+
+## Handler
+
+- Function: `ussListHandler`
+- Source: `src/ussapi.c`
+- ASM label: `UAPI0001`

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -1,8 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <clibwto.h>
 #include <libufs.h>
+#include <time64.h>
 
 #include "ussapi.h"
 #include "common.h"
@@ -115,13 +117,141 @@ get_data_type(Session *session)
 }
 
 //
-// Handler stubs — return 501 Not Implemented
+// Default max items for directory listing
+//
+
+#define USS_LIST_DEFAULT_MAX_ITEMS 1000
+
+//
+// ussListHandler — GET /zosmf/restfiles/fs?path=<filepath>
+//
+// Lists files and directories at the given path, returning
+// z/OSMF-compatible JSON with file metadata from UFSDLIST entries.
 //
 
 int ussListHandler(Session *session)
 {
-	return sendErrorResponse(session, 501, 10, 8, 1,
-		"USS list not yet implemented", NULL, 0);
+	int rc = 0;
+	int first = 1;
+	unsigned maxitems = USS_LIST_DEFAULT_MAX_ITEMS;
+	unsigned emitted = 0;
+	unsigned total = 0;
+	char *path = NULL;
+	char *maxitems_str = NULL;
+	UFS *ufs = NULL;
+	UFSDDESC *dd = NULL;
+	UFSDLIST *entry = NULL;
+
+	// Get required path query parameter
+	path = getQueryParam(session, "path");
+	if (!path || path[0] == '\0') {
+		return sendErrorResponse(session, 400, 2, 8, 1,
+			"Missing required query parameter 'path'", NULL, 0);
+	}
+
+	// Parse optional X-IBM-Max-Items header (0 = unlimited)
+	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
+	if (maxitems_str) {
+		maxitems = (unsigned) atoi(maxitems_str);
+	}
+
+	// Open UFS session
+	ufs = uss_open_session(session);
+	if (!ufs) {
+		return -1;
+	}
+
+	// Open directory
+	dd = ufs_diropen(ufs, path, NULL);
+	if (!dd) {
+		rc = sendErrorResponse(session, 404, 6, 8, 1,
+			"Path not found or is not a directory", NULL, 0);
+		ufsfree(&ufs);
+		return rc;
+	}
+
+	// Send response headers (streaming JSON like dsapi.c)
+	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
+
+	if ((rc = http_printf(session->httpc, "{\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"items\": [\n")) < 0) goto quit;
+
+	// Read directory entries
+	while ((entry = ufs_dirread(dd)) != NULL) {
+		struct tm *tm_info;
+		char mtime_buf[32];
+
+		// Skip . and ..
+		if (strcmp(entry->name, ".") == 0 ||
+			strcmp(entry->name, "..") == 0) {
+			continue;
+		}
+
+		total++;
+
+		// Enforce max items limit (0 = unlimited)
+		if (maxitems > 0 && emitted >= maxitems) {
+			continue;  // keep counting total
+		}
+
+		// Emit JSON object separator
+		if (first) {
+			if ((rc = http_printf(session->httpc, "    {\n")) < 0) goto quit;
+			first = 0;
+		} else {
+			if ((rc = http_printf(session->httpc, "   ,{\n")) < 0) goto quit;
+		}
+
+		// Format mtime as ISO 8601 (mtime is milliseconds since epoch)
+		tm_info = mgmtime64(&entry->mtime);
+		if (tm_info) {
+			snprintf(mtime_buf, sizeof(mtime_buf),
+				"%04d-%02d-%02dT%02d:%02d:%02dZ",
+				tm_info->tm_year + 1900, tm_info->tm_mon + 1,
+				tm_info->tm_mday, tm_info->tm_hour,
+				tm_info->tm_min, tm_info->tm_sec);
+		} else {
+			snprintf(mtime_buf, sizeof(mtime_buf), "1970-01-01T00:00:00Z");
+		}
+
+		// Emit fields matching UFSDLIST → JSON mapping from issue spec
+		if ((rc = http_printf(session->httpc, "      \"name\": \"%s\",\n", entry->name)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc, "      \"mode\": \"%s\",\n", entry->attr)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc, "      \"size\": %u,\n", entry->filesize)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc, "      \"user\": \"%s\",\n", entry->owner)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc, "      \"group\": \"%s\",\n", entry->group)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc, "      \"links\": %u,\n", (unsigned) entry->nlink)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc, "      \"mtime\": \"%s\",\n", mtime_buf)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc, "      \"inode\": %u\n", entry->inode_number)) < 0) goto quit;
+
+		if ((rc = http_printf(session->httpc, "    }\n")) < 0) goto quit;
+
+		emitted++;
+	}
+
+	// Close JSON array and add metadata
+	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %u,\n", emitted)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"totalRows\": %u,\n", total)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
+		(maxitems > 0 && emitted < total) ? "true" : "false")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "}\n")) < 0) goto quit;
+
+quit:
+	if (dd) {
+		ufs_dirclose(&dd);
+	}
+	if (ufs) {
+		ufsfree(&ufs);
+	}
+
+	return rc;
 }
 
 int ussGetHandler(Session *session)

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# =========================================================================
+# mvsMF USS File REST API - curl test suite
+#
+# Tests USS (Unix System Services) file endpoints:
+#   1. GET /zosmf/restfiles/fs?path=<dir>          (list directory)
+#
+# Prerequisites:
+#   - Copy .env.example to .env at the repo root and fill in
+#   - curl and jq must be installed
+#   - UFSD subsystem must be running on the target MVS system
+#
+# Usage:
+#   ./tests/curl-uss.sh
+# =========================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+BASE_URL="http://${MVSMF_HOST}:${MVSMF_PORT}"
+AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+
+# Test directory path (root of UFS filesystem)
+TEST_DIR="${USS_TEST_DIR:-/}"
+
+# --- state ---
+PASSED=0
+FAILED=0
+SKIPPED=0
+TOTAL=0
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+pass() {
+	PASSED=$((PASSED + 1))
+	TOTAL=$((TOTAL + 1))
+	echo "  PASS: $1"
+}
+
+fail() {
+	FAILED=$((FAILED + 1))
+	TOTAL=$((TOTAL + 1))
+	echo "  FAIL: $1"
+	if [ -n "${2:-}" ]; then
+		echo "        $2"
+	fi
+}
+
+skip() {
+	SKIPPED=$((SKIPPED + 1))
+	TOTAL=$((TOTAL + 1))
+	echo "  SKIP: $1"
+}
+
+assert_http_status() {
+	local expected="$1"
+	local actual="$2"
+	local label="$3"
+	if [ "$actual" = "$expected" ]; then
+		pass "$label (HTTP $actual)"
+	else
+		fail "$label" "expected HTTP $expected, got $actual"
+	fi
+}
+
+assert_json_field() {
+	local json="$1"
+	local field="$2"
+	local expected="$3"
+	local label="$4"
+	local actual
+	actual=$(echo "$json" | jq -r "$field" 2>/dev/null) || actual=""
+	if [ "$actual" = "$expected" ]; then
+		pass "$label ($field=$actual)"
+	else
+		fail "$label" "$field: expected '$expected', got '$actual'"
+	fi
+}
+
+assert_json_field_exists() {
+	local json="$1"
+	local field="$2"
+	local label="$3"
+	local val rc=0
+	val=$(echo "$json" | jq -e "$field" 2>/dev/null) || rc=$?
+	if [ $rc -eq 0 ] && [ "$val" != "null" ]; then
+		pass "$label ($field present)"
+	else
+		fail "$label" "$field missing or null"
+	fi
+}
+
+assert_json_field_gte() {
+	local json="$1"
+	local field="$2"
+	local min="$3"
+	local label="$4"
+	local actual
+	actual=$(echo "$json" | jq -r "$field" 2>/dev/null) || actual=""
+	if [ -n "$actual" ] && [ "$actual" -ge "$min" ] 2>/dev/null; then
+		pass "$label ($field=$actual >= $min)"
+	else
+		fail "$label" "$field: expected >= $min, got '$actual'"
+	fi
+}
+
+# =========================================================================
+# Tests
+# =========================================================================
+
+echo ""
+echo "========================================"
+echo " mvsMF USS File API - curl test suite"
+echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
+echo " User: ${MVSMF_USER}"
+echo " Test dir: ${TEST_DIR}"
+echo "========================================"
+
+# --- 1. List directory (basic) ---
+echo ""
+echo "--- List directory ---"
+
+RESP=$(curl -s -w '\n%{http_code}' \
+	-u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/fs?path=${TEST_DIR}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+
+assert_http_status "200" "$HTTP_CODE" "list directory ${TEST_DIR}"
+assert_json_field_exists "$BODY" ".items" "list: items array present"
+assert_json_field_exists "$BODY" ".returnedRows" "list: returnedRows present"
+assert_json_field_exists "$BODY" ".totalRows" "list: totalRows present"
+assert_json_field "$BODY" ".JSONversion" "1" "list: JSONversion is 1"
+
+# Check that items have the expected fields
+FIRST_ITEM=$(echo "$BODY" | jq '.items[0]' 2>/dev/null)
+if [ "$FIRST_ITEM" != "null" ] && [ -n "$FIRST_ITEM" ]; then
+	assert_json_field_exists "$BODY" '.items[0].name' "list: item has name"
+	assert_json_field_exists "$BODY" '.items[0].mode' "list: item has mode"
+	assert_json_field_exists "$BODY" '.items[0].size' "list: item has size"
+	assert_json_field_exists "$BODY" '.items[0].user' "list: item has user"
+	assert_json_field_exists "$BODY" '.items[0].group' "list: item has group"
+	assert_json_field_exists "$BODY" '.items[0].mtime' "list: item has mtime"
+	assert_json_field_exists "$BODY" '.items[0].inode' "list: item has inode"
+	assert_json_field_exists "$BODY" '.items[0].links' "list: item has links"
+else
+	skip "list: no items returned, skipping field checks"
+fi
+
+# --- 2. List with X-IBM-Max-Items ---
+echo ""
+echo "--- List with X-IBM-Max-Items ---"
+
+RESP=$(curl -s -w '\n%{http_code}' \
+	-u "$AUTH" \
+	-H "X-IBM-Max-Items: 2" \
+	"${BASE_URL}/zosmf/restfiles/fs?path=${TEST_DIR}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+
+assert_http_status "200" "$HTTP_CODE" "list with max-items=2"
+
+RETURNED=$(echo "$BODY" | jq -r '.returnedRows' 2>/dev/null)
+TOTAL_ROWS=$(echo "$BODY" | jq -r '.totalRows' 2>/dev/null)
+if [ -n "$RETURNED" ] && [ "$RETURNED" -le 2 ] 2>/dev/null; then
+	pass "list max-items: returnedRows ($RETURNED) <= 2"
+else
+	fail "list max-items: returnedRows" "expected <= 2, got '$RETURNED'"
+fi
+
+if [ -n "$TOTAL_ROWS" ] && [ -n "$RETURNED" ] && [ "$TOTAL_ROWS" -gt 2 ] 2>/dev/null; then
+	assert_json_field "$BODY" ".moreRows" "true" "list max-items: moreRows is true when truncated"
+fi
+
+# --- 3. List with X-IBM-Max-Items: 0 (unlimited) ---
+echo ""
+echo "--- List with X-IBM-Max-Items: 0 ---"
+
+RESP=$(curl -s -w '\n%{http_code}' \
+	-u "$AUTH" \
+	-H "X-IBM-Max-Items: 0" \
+	"${BASE_URL}/zosmf/restfiles/fs?path=${TEST_DIR}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+
+assert_http_status "200" "$HTTP_CODE" "list with max-items=0 (unlimited)"
+assert_json_field "$BODY" ".moreRows" "false" "list unlimited: moreRows is false"
+
+# --- 4. Error: missing path parameter ---
+echo ""
+echo "--- Error cases ---"
+
+RESP=$(curl -s -w '\n%{http_code}' \
+	-u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/fs")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+
+assert_http_status "400" "$HTTP_CODE" "missing path returns 400"
+
+# --- 5. Error: non-existent path ---
+
+RESP=$(curl -s -w '\n%{http_code}' \
+	-u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/fs?path=/nonexistent/path/that/does/not/exist")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+
+assert_http_status "404" "$HTTP_CODE" "non-existent path returns 404"
+
+# =========================================================================
+# Summary
+# =========================================================================
+
+echo ""
+echo "========================================"
+echo " Results: ${PASSED} passed, ${FAILED} failed, ${SKIPPED} skipped (${TOTAL} total)"
+echo "========================================"
+
+if [ "$FAILED" -gt 0 ]; then
+	exit 1
+fi


### PR DESCRIPTION
## Summary

- Implement `ussListHandler` (`GET /zosmf/restfiles/fs?path=<dir>`) — lists files and directories via libufs `ufs_diropen`/`ufs_dirread`/`ufs_dirclose`
- Returns z/OSMF-compatible JSON with all UFSDLIST fields mapped: `name`, `mode`, `size`, `user`, `group`, `links`, `mtime` (ISO 8601), `inode`
- Supports `X-IBM-Max-Items` header for pagination (default 1000, 0=unlimited) with `moreRows`/`totalRows`/`returnedRows` metadata
- Error handling: missing path → 400, path not found → 404, UFSD unavailable → 503
- Streams JSON directly via `http_printf` (same pattern as `dsapi.c` dataset list)

## Files Changed

- `src/ussapi.c` — replaced stub with full implementation
- `tests/curl-uss.sh` — new curl test suite for USS list endpoint
- `doc/endpoints/uss/list.md` — new endpoint documentation

## Test plan

- [ ] Deploy to MVS and verify `curl -u U:P 'http://host:port/zosmf/restfiles/fs?path=/'` returns directory listing
- [ ] Verify `X-IBM-Max-Items: 2` truncates results and sets `moreRows: true`
- [ ] Verify `X-IBM-Max-Items: 0` returns all entries
- [ ] Verify missing `path` parameter returns HTTP 400
- [ ] Verify non-existent path returns HTTP 404
- [ ] Verify UFSD not running returns HTTP 503
- [ ] Run `tests/curl-uss.sh` against live system

Fixes #80