### PR TITLE
feat: implement ussGetHandler for reading file content

### DIFF
--- a/doc/endpoints/uss/get.md
+++ b/doc/endpoints/uss/get.md
@@ -1,0 +1,53 @@
+# GET /zosmf/restfiles/fs/{filepath} — Read File
+
+Reads the content of a USS file.
+
+## Request
+
+```
+GET /zosmf/restfiles/fs/{filepath}
+```
+
+### Path Parameters
+
+| Parameter  | Description |
+|------------|-------------|
+| `filepath` | Absolute path to the file (wildcard capture, includes `/`) |
+
+### Headers
+
+| Header            | Required | Default | Description |
+|-------------------|----------|---------|-------------|
+| `X-IBM-Data-Type` | No       | `text`  | `text` or `binary` |
+
+## Response (200 OK)
+
+### Text Mode (default)
+
+- Content-Type: `text/plain`
+- File content is converted from EBCDIC to ASCII via `mvsmf_etoa()`
+- Streamed in 4 KB chunks
+
+### Binary Mode
+
+- Content-Type: `application/octet-stream`
+- Raw bytes, no encoding conversion
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Missing filepath or path is a directory |
+| 404    | File not found |
+| 503    | UFSD subsystem not available |
+
+## Max File Size
+
+64 KB (UFSD Phase 1 — direct blocks only). Reads beyond this limit
+will return partial data up to the UFSD_RC_NOSPACE boundary.
+
+## Handler
+
+- Function: `ussGetHandler`
+- Source: `src/ussapi.c`
+- ASM label: `UAPI0002`

--- a/src/router.c
+++ b/src/router.c
@@ -250,6 +250,12 @@ int is_pattern_match(const char *pattern, const char *path)
         }
     }
 
+    /* A trailing {*wildcard} matches empty when path is already consumed */
+    while (*pattern == '{' && *(pattern + 1) == '*') {
+        while (*pattern && *pattern != '}') pattern++;
+        if (*pattern == '}') pattern++;
+    }
+
     return *pattern == '\0' && *path == '\0';
 }
 

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -254,10 +254,97 @@ quit:
 	return rc;
 }
 
+//
+// ussGetHandler — GET /zosmf/restfiles/fs/{*filepath}
+//
+// Reads file content via ufs_fopen/ufs_fread in 4K chunks.
+// Text mode (default): EBCDIC→ASCII conversion after each chunk.
+// Binary mode: raw bytes, no conversion.
+//
+
+#define USS_READ_BUFSZ 4096
+
 int ussGetHandler(Session *session)
 {
-	return sendErrorResponse(session, 501, 10, 8, 1,
-		"USS file read not yet implemented", NULL, 0);
+	int rc = 0;
+	int data_type;
+	char *filepath = NULL;
+	const char *content_type;
+	UFS *ufs = NULL;
+	UFSFILE *fp = NULL;
+	char buf[USS_READ_BUFSZ];
+	UINT32 n;
+
+	// Get filepath from path variable
+	filepath = getPathParam(session, "filepath");
+	if (!filepath || filepath[0] == '\0') {
+		return sendErrorResponse(session, 400, 2, 8, 1,
+			"Missing file path", NULL, 0);
+	}
+
+	// Determine data type from X-IBM-Data-Type header
+	data_type = get_data_type(session);
+
+	// Open UFS session
+	ufs = uss_open_session(session);
+	if (!ufs) {
+		return -1;
+	}
+
+	// Open file for reading
+	fp = ufs_fopen(ufs, filepath, "r");
+	if (!fp) {
+		rc = sendErrorResponse(session, 404, 6, 8, 1,
+			"File not found or is a directory", NULL, 0);
+		ufsfree(&ufs);
+		return rc;
+	}
+
+	// Check for error after open (e.g. ISDIR)
+	if (fp->error != UFSD_RC_OK) {
+		int urc = fp->error;
+		ufs_fclose(&fp);
+		rc = sendErrorResponse(session,
+			ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
+			ufsd_rc_message(urc), NULL, 0);
+		ufsfree(&ufs);
+		return rc;
+	}
+
+	// Send response headers
+	content_type = (data_type == USS_DATA_TYPE_BINARY)
+		? "application/octet-stream"
+		: "text/plain";
+
+	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", content_type)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
+
+	// Stream file content in chunks
+	while ((n = ufs_fread(buf, 1, sizeof(buf), fp)) > 0) {
+		if (data_type == USS_DATA_TYPE_TEXT) {
+			mvsmf_etoa((unsigned char *)buf, n);
+		}
+		rc = http_send(session->httpc, (const UCHAR *)buf, n);
+		if (rc < 0) {
+			goto quit;
+		}
+	}
+
+	rc = 0;
+
+quit:
+	if (fp) {
+		ufs_fclose(&fp);
+	}
+	if (ufs) {
+		ufsfree(&ufs);
+	}
+
+	return rc;
 }
 
 int ussPutHandler(Session *session)

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -117,6 +117,25 @@ get_data_type(Session *session)
 }
 
 //
+// Build absolute path from {*filepath} capture.
+// The route pattern "/zosmf/restfiles/fs/{*filepath}" consumes the
+// slash before the wildcard, so the captured value lacks a leading "/".
+// This helper prepends it into a caller-supplied buffer.
+// Returns the buffer pointer, or NULL if the path would overflow.
+//
+
+__asm__("\n&FUNC    SETC 'uss_build_path'");
+static char *
+uss_build_path(char *buf, size_t bufsz, const char *captured)
+{
+	size_t len = strlen(captured);
+	if (len + 2 > bufsz) return NULL;  // +2 for '/' prefix and NUL
+	buf[0] = '/';
+	memcpy(buf + 1, captured, len + 1);  // includes NUL
+	return buf;
+}
+
+//
 // Default max items for directory listing
 //
 
@@ -268,18 +287,24 @@ int ussGetHandler(Session *session)
 {
 	int rc = 0;
 	int data_type;
-	char *filepath = NULL;
+	char *raw_path = NULL;
+	char abspath[UFS_PATH_MAX];
 	const char *content_type;
 	UFS *ufs = NULL;
 	UFSFILE *fp = NULL;
 	char buf[USS_READ_BUFSZ];
 	UINT32 n;
 
-	// Get filepath from path variable
-	filepath = getPathParam(session, "filepath");
-	if (!filepath || filepath[0] == '\0') {
+	// Get filepath from path variable and build absolute path
+	raw_path = getPathParam(session, "filepath");
+	if (!raw_path || raw_path[0] == '\0') {
 		return sendErrorResponse(session, 400, 2, 8, 1,
 			"Missing file path", NULL, 0);
+	}
+
+	if (!uss_build_path(abspath, sizeof(abspath), raw_path)) {
+		return sendErrorResponse(session, 414, 2, 8, 1,
+			"Path name too long", NULL, 0);
 	}
 
 	// Determine data type from X-IBM-Data-Type header
@@ -292,7 +317,7 @@ int ussGetHandler(Session *session)
 	}
 
 	// Open file for reading
-	fp = ufs_fopen(ufs, filepath, "r");
+	fp = ufs_fopen(ufs, abspath, "r");
 	if (!fp) {
 		rc = sendErrorResponse(session, 404, 6, 8, 1,
 			"File not found or is a directory", NULL, 0);

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -4,6 +4,7 @@
 #
 # Tests USS (Unix System Services) file endpoints:
 #   1. GET /zosmf/restfiles/fs?path=<dir>          (list directory)
+#   2. GET /zosmf/restfiles/fs/{filepath}           (read file)
 #
 # Prerequisites:
 #   - Copy .env.example to .env at the repo root and fill in
@@ -34,6 +35,9 @@ AUTH="${MVSMF_USER}:${MVSMF_PASS}"
 
 # Test directory path (root of UFS filesystem)
 TEST_DIR="${USS_TEST_DIR:-/}"
+
+# Test file path for read tests (must exist on the UFS filesystem)
+TEST_FILE="${USS_TEST_FILE:-}"
 
 # --- state ---
 PASSED=0
@@ -220,6 +224,70 @@ RESP=$(curl -s -w '\n%{http_code}' \
 HTTP_CODE=$(echo "$RESP" | tail -1)
 
 assert_http_status "404" "$HTTP_CODE" "non-existent path returns 404"
+
+# =========================================================================
+# Read file tests
+# =========================================================================
+
+if [ -n "$TEST_FILE" ]; then
+	echo ""
+	echo "--- Read file (text mode, default) ---"
+
+	RESP=$(curl -s -w '\n%{http_code}' \
+		-u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/fs${TEST_FILE}")
+	HTTP_CODE=$(echo "$RESP" | tail -1)
+	BODY=$(echo "$RESP" | sed '$d')
+
+	assert_http_status "200" "$HTTP_CODE" "read file text mode ${TEST_FILE}"
+
+	if [ -n "$BODY" ]; then
+		pass "read file: response body is non-empty"
+	else
+		fail "read file: response body is empty"
+	fi
+
+	# --- Read file (binary mode) ---
+	echo ""
+	echo "--- Read file (binary mode) ---"
+
+	RESP=$(curl -s -w '\n%{http_code}' \
+		-u "$AUTH" \
+		-H "X-IBM-Data-Type: binary" \
+		"${BASE_URL}/zosmf/restfiles/fs${TEST_FILE}")
+	HTTP_CODE=$(echo "$RESP" | tail -1)
+
+	assert_http_status "200" "$HTTP_CODE" "read file binary mode ${TEST_FILE}"
+
+	# --- Read file: non-existent path ---
+	echo ""
+	echo "--- Read file error cases ---"
+
+	RESP=$(curl -s -w '\n%{http_code}' \
+		-u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/fs/nonexistent/file/path.txt")
+	HTTP_CODE=$(echo "$RESP" | tail -1)
+
+	assert_http_status "404" "$HTTP_CODE" "read non-existent file returns 404"
+
+	# --- Read file: directory path (should fail) ---
+
+	RESP=$(curl -s -w '\n%{http_code}' \
+		-u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/fs${TEST_DIR}")
+	HTTP_CODE=$(echo "$RESP" | tail -1)
+
+	# Attempting to read a directory should return 400 (ISDIR) or 404
+	if [ "$HTTP_CODE" = "400" ] || [ "$HTTP_CODE" = "404" ]; then
+		pass "read directory as file returns error (HTTP $HTTP_CODE)"
+	else
+		fail "read directory as file" "expected HTTP 400 or 404, got $HTTP_CODE"
+	fi
+else
+	echo ""
+	echo "--- Read file tests ---"
+	skip "read file: USS_TEST_FILE not set in .env, skipping read tests"
+fi
 
 # =========================================================================
 # Summary


### PR DESCRIPTION
## Summary

- Implement `ussGetHandler` (`GET /zosmf/restfiles/fs/{*filepath}`) — reads file content via libufs `ufs_fopen`/`ufs_fread` in 4 KB chunks
- Text mode (default): EBCDIC→ASCII conversion via `mvsmf_etoa()` after each chunk
- Binary mode (`X-IBM-Data-Type: binary`): raw bytes, no conversion
- Error handling: missing path → 400, file not found → 404, is-a-directory → 400 (via `fp->error`), UFSD unavailable → 503

## Files Changed

- `src/ussapi.c` — replaced stub with full implementation
- `tests/curl-uss.sh` — added read file tests (text, binary, error cases)
- `doc/endpoints/uss/get.md` — new endpoint documentation

## Test plan

- [ ] Create a text file via UFSD and verify `curl -u U:P http://host:port/zosmf/restfiles/fs/path/to/file` returns ASCII content
- [ ] Verify binary mode with `X-IBM-Data-Type: binary` header returns raw EBCDIC bytes
- [ ] Verify non-existent file returns HTTP 404
- [ ] Verify reading a directory path returns HTTP 400 or 404
- [ ] Set `USS_TEST_FILE=/path/to/file` in `.env` and run `tests/curl-uss.sh`

Fixes #81