### PR TITLE
Harden ESTAE recovery against partial responses and secondary abends

### DIFF
--- a/include/router.h
+++ b/include/router.h
@@ -91,11 +91,13 @@ struct session {
     char *session_id;      /**< Unique session identifier */
     time_t created_at;     /**< Session creation timestamp */
     time_t last_accessed;  /**< Last access timestamp */
+    int headers_sent;      /**< Non-zero after HTTP headers written to socket */
     // Resource tracking for ESTAE abend recovery
     FILE *open_files[MAX_SESSION_FILES];  /**< Tracked FILE handles */
     int open_file_count;                  /**< Number of tracked files */
     void *ufs;             /**< UFS session (opaque, libufs UFS *) */
     void *ufs_file;        /**< UFS file handle (opaque, libufs UFSFILE *) */
+    void (*ufs_cleanup)(struct session *s); /**< UFS cleanup callback (set by ussapi) */
 } __attribute__((aligned(FULL_WORD_ALIGNMENT)));
 
 /**
@@ -156,8 +158,9 @@ int handle_request(Router *router, Session *session) asm("RTR0005");
 
 /**
  * @brief Register a FILE handle for ESTAE recovery cleanup
+ * @return 0 on success, -1 if tracking table is full
  */
-void session_register_file(Session *session, FILE *fp) asm("RTR0006");
+int session_register_file(Session *session, FILE *fp) asm("RTR0006");
 
 /**
  * @brief Unregister a FILE handle after successful fclose
@@ -167,7 +170,7 @@ void session_unregister_file(Session *session, FILE *fp) asm("RTR0007");
 /**
  * @brief Unregister and close a tracked FILE handle
  */
-void session_fclose(Session *session, FILE *fp) asm("RTR0009");
+void session_fclose(Session *session, FILE *fp) asm("RTR0008");
 
 /**
  * @brief Close all tracked resources (ESTAE recovery)
@@ -175,6 +178,6 @@ void session_fclose(Session *session, FILE *fp) asm("RTR0009");
  * Closes all registered FILE handles, UFS file handles and UFS sessions.
  * Called by the router after catching a handler abend.
  */
-void session_cleanup(Session *session) asm("RTR0008");
+void session_cleanup(Session *session) asm("RTR0009");
 
 #endif // ROUTER_H

--- a/include/router.h
+++ b/include/router.h
@@ -25,6 +25,9 @@
 /** @brief Maximum number of middlewares that can be registered */
 #define MAX_MIDDLEWARES 10
 
+/** @brief Maximum number of tracked open files per session (ESTAE recovery) */
+#define MAX_SESSION_FILES 4
+
 #define httpx http_get_httpx(session->httpd)
 
 // Forward declarations
@@ -88,6 +91,11 @@ struct session {
     char *session_id;      /**< Unique session identifier */
     time_t created_at;     /**< Session creation timestamp */
     time_t last_accessed;  /**< Last access timestamp */
+    // Resource tracking for ESTAE abend recovery
+    FILE *open_files[MAX_SESSION_FILES];  /**< Tracked FILE handles */
+    int open_file_count;                  /**< Number of tracked files */
+    void *ufs;             /**< UFS session (opaque, libufs UFS *) */
+    void *ufs_file;        /**< UFS file handle (opaque, libufs UFSFILE *) */
 } __attribute__((aligned(FULL_WORD_ALIGNMENT)));
 
 /**
@@ -145,5 +153,28 @@ void add_middleware(Router *router, const char *middleware_name, MiddlewareHandl
  * @return 0 on success, negative value on error
  */
 int handle_request(Router *router, Session *session) asm("RTR0005");
+
+/**
+ * @brief Register a FILE handle for ESTAE recovery cleanup
+ */
+void session_register_file(Session *session, FILE *fp) asm("RTR0006");
+
+/**
+ * @brief Unregister a FILE handle after successful fclose
+ */
+void session_unregister_file(Session *session, FILE *fp) asm("RTR0007");
+
+/**
+ * @brief Unregister and close a tracked FILE handle
+ */
+void session_fclose(Session *session, FILE *fp) asm("RTR0009");
+
+/**
+ * @brief Close all tracked resources (ESTAE recovery)
+ *
+ * Closes all registered FILE handles, UFS file handles and UFS sessions.
+ * Called by the router after catching a handler abend.
+ */
+void session_cleanup(Session *session) asm("RTR0008");
 
 #endif // ROUTER_H

--- a/project.toml
+++ b/project.toml
@@ -12,7 +12,7 @@ dsorg = "PO"
 recfm = "FB"
 lrecl = 80
 blksize = 19040
-space = ["TRK", 10, 5, 15]
+space = ["TRK", 20, 10, 20]
 
 [mvs.build.datasets.punch]
 suffix = "OBJECT"

--- a/src/common.c
+++ b/src/common.c
@@ -43,6 +43,8 @@ sendDefaultHeaders(Session *session, int status, const char *content_type,
 {
 	int irc = 0;
 
+	session->headers_sent = 1;
+
 	irc = http_resp(session->httpc, status);
 	if (irc < 0) {
 		goto quit;

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -749,10 +749,11 @@ int datasetGetHandler(Session *session)
     if (!fp) {
         return handle_error(session, ERR_IO, "Cannot open dataset");
     }
+    session_register_file(session, fp);
 
     rc = read_and_send_dataset(session, fp, data_type, max_records);
 
-    fclose(fp);
+    session_fclose(session, fp);
     return rc;
 }
 
@@ -838,18 +839,19 @@ int datasetPutHandler(Session *session)
         wtof("MVSMF34E Failed to open dataset for writing: %s (errno=%d)", dsname, errno);
         return handle_error(session, ERR_IO, "Cannot open dataset for writing");
     }
+    session_register_file(session, fp);
 
     /* For RECFM=U (undefined record format), lrecl is 0. Use blksize instead. */
     is_undefined = ((fp->recfm & _FILE_RECFM_TYPE) == _FILE_RECFM_U);
     eff_lrecl = is_undefined ? (size_t)fp->blksize : (size_t)fp->lrecl;
     if (eff_lrecl == 0) {
         wtof("MVSMF34E Dataset has zero record length: %s", dsname);
-        fclose(fp);
+        session_fclose(session, fp);
         return handle_error(session, ERR_IO, "Dataset has zero record length");
     }
     record_buffer = calloc(1, eff_lrecl);
     if (!record_buffer) {
-        fclose(fp);
+        session_fclose(session, fp);
         return handle_error(session, ERR_MEMORY, "Memory allocation failed");
     }
 
@@ -866,7 +868,7 @@ int datasetPutHandler(Session *session)
                 if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                     wtof("MVSMF36E Error reading chunk size");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading chunk size");
                 }
                 if (c == 0x0D) { // ASCII CR \r
@@ -894,7 +896,7 @@ int datasetPutHandler(Session *session)
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF39E Error writing final record");
                         free(record_buffer);
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing final record");
                     }
                 }
@@ -904,14 +906,14 @@ int datasetPutHandler(Session *session)
                 if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
                     wtof("MVSMF40E Error reading final line ending");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading final line ending");
                 }
 
                 if (crlf[0] != 0x0d || crlf[1] != 0x0a) {
                     wtof("MVSMF41E Final line ending not CRLF");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Final line ending not CRLF");
                 }
 
@@ -932,7 +934,7 @@ int datasetPutHandler(Session *session)
                     if (n <= 0) {
                         wtof("MVSMF38E Error reading chunk data");
                         free(record_buffer);
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error reading chunk data");
                     }
                     bytes_read += n;
@@ -942,7 +944,7 @@ int datasetPutHandler(Session *session)
                         if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                             wtof("MVSMF42E Error writing record");
                             free(record_buffer);
-                            fclose(fp);
+                            session_fclose(session, fp);
                             return handle_error(session, ERR_IO, "Error writing record");
                         }
                         record_pos = 0;
@@ -955,7 +957,7 @@ int datasetPutHandler(Session *session)
                     if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                         wtof("MVSMF38E Error reading chunk data");
                         free(record_buffer);
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error reading chunk data");
                     }
                     bytes_read++;
@@ -963,7 +965,7 @@ int datasetPutHandler(Session *session)
                     if (record_pos >= eff_lrecl - 1) {
                         wtof("MVSMF43E Record too long");
                         free(record_buffer);
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Record too long");
                     }
                     record_buffer[record_pos++] = c;
@@ -972,7 +974,7 @@ int datasetPutHandler(Session *session)
                         if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                             wtof("MVSMF42E Error writing record");
                             free(record_buffer);
-                            fclose(fp);
+                            session_fclose(session, fp);
                             return handle_error(session, ERR_IO, "Error writing record");
                         }
                         record_pos = 0;
@@ -984,7 +986,7 @@ int datasetPutHandler(Session *session)
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF39E Error writing final record");
                         free(record_buffer);
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing final record");
                     }
                     record_pos = 0;
@@ -996,7 +998,7 @@ int datasetPutHandler(Session *session)
             if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
                 wtof("MVSMF43E Error reading chunk trailer");
                 free(record_buffer);
-                fclose(fp);
+                session_fclose(session, fp);
                 return handle_error(session, ERR_IO, "Error reading chunk trailer");
             }
         }
@@ -1016,7 +1018,7 @@ int datasetPutHandler(Session *session)
                 if (n <= 0) {
                     wtof("MVSMF45E Error reading data in Content-Length mode");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading data");
                 }
                 bytes_remaining -= n;
@@ -1026,7 +1028,7 @@ int datasetPutHandler(Session *session)
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF46E Error writing record");
                         free(record_buffer);
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing record");
                     }
                     record_pos = 0;
@@ -1042,7 +1044,7 @@ int datasetPutHandler(Session *session)
                 if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                     wtof("MVSMF39E Error writing final record");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error writing final record");
                 }
             }
@@ -1053,7 +1055,7 @@ int datasetPutHandler(Session *session)
                 if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                     wtof("MVSMF45E Error reading data in Content-Length mode");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading data");
                 }
                 bytes_remaining--;
@@ -1061,7 +1063,7 @@ int datasetPutHandler(Session *session)
                 if (record_pos >= eff_lrecl - 1) {
                     wtof("MVSMF43E Record too long");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Record too long");
                 }
                 record_buffer[record_pos++] = c;
@@ -1070,7 +1072,7 @@ int datasetPutHandler(Session *session)
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF46E Error writing record");
                         free(record_buffer);
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing record");
                     }
                     record_pos = 0;
@@ -1093,7 +1095,7 @@ int datasetPutHandler(Session *session)
                 if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                     wtof("MVSMF39E Error writing final record");
                     free(record_buffer);
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error writing final record");
                 }
             }
@@ -1102,7 +1104,7 @@ int datasetPutHandler(Session *session)
 
     free(record_buffer);
     record_buffer = NULL;
-    fclose(fp);
+    session_fclose(session, fp);
     fp = NULL;
 
     /* Send response */
@@ -1121,7 +1123,7 @@ error:
     wtof("MVSMF50E Error sending response: rc=%d", rc);
     free(record_buffer);
     if (fp) {
-        fclose(fp);
+        session_fclose(session, fp);
     }
     return rc;
 }
@@ -1250,11 +1252,12 @@ int memberGetHandler(Session *session)
     if (!fp) {
         return handle_error(session, ERR_IO, "Cannot open dataset member");
     }
+    session_register_file(session, fp);
 
     // PDS member: record count unknown, pass -1 (no limit)
     rc = read_and_send_dataset(session, fp, data_type, -1);
 
-    fclose(fp);
+    session_fclose(session, fp);
     return rc;
 }
 
@@ -1329,6 +1332,7 @@ int memberPutHandler(Session *session)
         wtof("MVSMF06E Failed to open dataset member for writing: %s (errno=%d)", dataset, errno);
         return handle_error(session, ERR_IO, "Cannot open dataset member for writing");
     }
+    session_register_file(session, fp);
 
     if (is_chunked) {
         // Handle chunked transfer encoding
@@ -1342,7 +1346,7 @@ int memberPutHandler(Session *session)
             while (i < sizeof(chunk_size_str)-1) {
                 if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                     wtof("MVSMF08E Error reading chunk size");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading chunk size");
                 }
                 if (c == '\r') {
@@ -1369,7 +1373,7 @@ int memberPutHandler(Session *session)
                     }
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF11E Error writing final record");
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing final record");
                     }
                 }
@@ -1378,13 +1382,13 @@ int memberPutHandler(Session *session)
                 char crlf[2] = {0};
                 if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
                     wtof("MVSMF40E Error reading final line ending");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading final line ending");
                 }
 
                 if (crlf[0] != 0x0d || crlf[1] != 0x0a) {
                     wtof("MVSMF41E Final line ending not CRLF");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Final line ending not CRLF");
                 }
 
@@ -1404,7 +1408,7 @@ int memberPutHandler(Session *session)
                     n = recv(session->httpc->socket, record_buffer + record_pos, to_read, 0);
                     if (n <= 0) {
                         wtof("MVSMF13E Error reading chunk data");
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error reading chunk data");
                     }
                     bytes_read += n;
@@ -1413,7 +1417,7 @@ int memberPutHandler(Session *session)
                     if (record_pos >= fp->lrecl) {
                         if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                             wtof("MVSMF14E Error writing record");
-                            fclose(fp);
+                            session_fclose(session, fp);
                             return handle_error(session, ERR_IO, "Error writing record");
                         }
                         record_pos = 0;
@@ -1425,14 +1429,14 @@ int memberPutHandler(Session *session)
                 while (bytes_read < chunk_size) {
                     if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                         wtof("MVSMF13E Error reading chunk data");
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error reading chunk data");
                     }
                     bytes_read++;
 
                     if (record_pos >= sizeof(record_buffer) - 1) {
                         wtof("MVSMF43E Record too long");
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Record too long");
                     }
                     record_buffer[record_pos++] = c;
@@ -1440,7 +1444,7 @@ int memberPutHandler(Session *session)
                     if (c == 0x0A) {
                         if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                             wtof("MVSMF14E Error writing record");
-                            fclose(fp);
+                            session_fclose(session, fp);
                             return handle_error(session, ERR_IO, "Error writing record");
                         }
                         record_pos = 0;
@@ -1451,7 +1455,7 @@ int memberPutHandler(Session *session)
                 if (record_pos > 0) {
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF39E Error writing final record");
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing final record");
                     }
                     record_pos = 0;
@@ -1462,7 +1466,7 @@ int memberPutHandler(Session *session)
             char crlf[2];
             if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
                 wtof("MVSMF15E Error reading chunk trailer");
-                fclose(fp);
+                session_fclose(session, fp);
                 return handle_error(session, ERR_IO, "Error reading chunk trailer");
             }
         }
@@ -1481,7 +1485,7 @@ int memberPutHandler(Session *session)
                 n = recv(session->httpc->socket, record_buffer + record_pos, to_read, 0);
                 if (n <= 0) {
                     wtof("MVSMF17E Error reading data in Content-Length mode");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading data");
                 }
                 bytes_remaining -= n;
@@ -1490,7 +1494,7 @@ int memberPutHandler(Session *session)
                 if (record_pos >= fp->lrecl) {
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF18E Error writing record");
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing record");
                     }
                     record_pos = 0;
@@ -1503,7 +1507,7 @@ int memberPutHandler(Session *session)
                 record_pos = fp->lrecl;
                 if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                     wtof("MVSMF19E Error writing final record");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error writing final record");
                 }
             }
@@ -1513,14 +1517,14 @@ int memberPutHandler(Session *session)
             while (bytes_remaining > 0) {
                 if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                     wtof("MVSMF17E Error reading data in Content-Length mode");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading data");
                 }
                 bytes_remaining--;
 
                 if (record_pos >= sizeof(record_buffer) - 1) {
                     wtof("MVSMF43E Record too long");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Record too long");
                 }
                 record_buffer[record_pos++] = c;
@@ -1528,7 +1532,7 @@ int memberPutHandler(Session *session)
                 if (c == 0x0A || c == 0x0D) {
                     if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                         wtof("MVSMF18E Error writing record");
-                        fclose(fp);
+                        session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing record");
                     }
                     record_pos = 0;
@@ -1550,14 +1554,14 @@ int memberPutHandler(Session *session)
                 }
                 if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type) < 0) {
                     wtof("MVSMF19E Error writing final record");
-                    fclose(fp);
+                    session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error writing final record");
                 }
             }
         }
     }
 
-    fclose(fp);
+    session_fclose(session, fp);
     fp = NULL;
 
     // Send response
@@ -1575,7 +1579,7 @@ int memberPutHandler(Session *session)
 error:
     wtof("MVSMF22E Error sending response: rc=%d", rc);
     if (fp) {
-        fclose(fp);
+        session_fclose(session, fp);
     }
     return rc;
 }

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -74,7 +74,8 @@ static char* allocate_buffer(FILE* fp, int* rc) {
 // Helper function for HTTP headers
 static int send_standard_headers(Session *session, const char* content_type) {
     int rc = 0;
-    
+
+    session->headers_sent = 1;
     if ((rc = http_resp(session->httpc, HTTP_OK)) < 0) return rc;
     if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) return rc;
     if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", content_type)) < 0) return rc;
@@ -626,7 +627,8 @@ int datasetListHandler(Session *session)
 
 	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
 	if (maxitems_str) maxitems = (unsigned) atoi(maxitems_str);
-	
+
+	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc,200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
@@ -849,6 +851,9 @@ int datasetPutHandler(Session *session)
         session_fclose(session, fp);
         return handle_error(session, ERR_IO, "Dataset has zero record length");
     }
+    // NOTE: record_buffer is not tracked by session for ESTAE recovery.
+    // On abend, this allocation leaks. Acceptable since abends are rare
+    // and the leak is bounded by eff_lrecl bytes per occurrence.
     record_buffer = calloc(1, eff_lrecl);
     if (!record_buffer) {
         session_fclose(session, fp);
@@ -1108,6 +1113,7 @@ int datasetPutHandler(Session *session)
     fp = NULL;
 
     /* Send response */
+    session->headers_sent = 1;
     if ((rc = http_resp(session->httpc, 204)) < 0) {
         wtof("MVSMF48E Error sending response status: rc=%d", rc);
         return rc;
@@ -1163,6 +1169,7 @@ int memberListHandler(Session *session)
 
 	pdslist = __listpd(dsname, NULL);
 
+	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc,200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
@@ -1565,6 +1572,7 @@ int memberPutHandler(Session *session)
     fp = NULL;
 
     // Send response
+    session->headers_sent = 1;
     if ((rc = http_resp(session->httpc, 204)) < 0) {
         wtof("MVSMF20E Error sending response status: rc=%d", rc);
         return rc;

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -1118,6 +1118,7 @@ submit_file(Session *session, VSFILE *intrdr, const char *filename,
 		rc = -1;
 		goto quit;
 	}
+	session_register_file(session, fp);
 
 	buffer_size = fp->lrecl + 2;
 	buffer = calloc(1, buffer_size);
@@ -1176,7 +1177,7 @@ submit_file(Session *session, VSFILE *intrdr, const char *filename,
 		num_lines++;
 	}
 
-	fclose(fp);
+	session_fclose(session, fp);
 	fp = NULL;
 
 	/* ensure room for 2 extra lines added by process_jobcard */
@@ -1244,7 +1245,7 @@ quit:
 	}
 
 	if (fp) {
-		fclose(fp);
+		session_fclose(session, fp);
 	}
 
 	if (buffer) {

--- a/src/router.c
+++ b/src/router.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <clibwto.h>
+#include <clibtry.h>
+#include <libufs.h>
 
 #include "router.h"
 #include "common.h"
@@ -10,9 +12,19 @@
 
 #define INITIAL_BUFFER_SIZE 4096
 
-//	
+// Context for ESTAE-protected handler invocation.
+// Captures the handler's return code since try() only returns 0/abend.
+struct handler_ctx {
+    RouteHandler handler;
+    Session *session;
+    int rc;
+};
+
+//
 // private function prototypes
 //
+
+static int handler_thunk(struct handler_ctx *ctx);
 
 static int route_matching_middleware(Session *session);
 static int path_vars_extracting_middleware(Session *session);
@@ -122,8 +134,113 @@ int handle_request(Router *router, Session *session)
 
     extract_path_vars(session, route->pattern, path);
 
-    // call the handler
-    return route->handler(session);
+    // call the handler with ESTAE protection
+    struct handler_ctx ctx;
+    int try_rc;
+
+    ctx.handler = route->handler;
+    ctx.session = session;
+    ctx.rc = 0;
+
+    try_rc = try(handler_thunk, &ctx);
+    if (try_rc != 0) {
+        unsigned abend = tryrc();
+        unsigned sys = (abend >> 12) & 0xFFF;
+        unsigned usr = abend & 0xFFF;
+        wtof("MVSMF99E Handler abend S%03X U%04d for %s %s",
+             sys, usr, method, path);
+        session_cleanup(session);
+        sendErrorResponse(session, 500, 6, 8, 99,
+            "Internal server error (abend recovery)", NULL, 0);
+        return -1;
+    }
+    return ctx.rc;
+}
+
+// Thunk for ESTAE-protected handler invocation.
+// Called by try(), stores the handler's return value in ctx->rc.
+__asm__("\n&FUNC    SETC 'handler_thunk'");
+static int handler_thunk(struct handler_ctx *ctx)
+{
+    ctx->rc = ctx->handler(ctx->session);
+    return 0;
+}
+
+//
+// session resource tracking
+//
+
+__asm__("\n&FUNC    SETC 'ses_reg_file'");
+void session_register_file(Session *session, FILE *fp)
+{
+    if (!session || !fp) return;
+    if (session->open_file_count >= MAX_SESSION_FILES) {
+        wtof("MVSMF98W session file tracking full, cannot register");
+        return;
+    }
+    session->open_files[session->open_file_count++] = fp;
+}
+
+__asm__("\n&FUNC    SETC 'ses_unreg_file'");
+void session_unregister_file(Session *session, FILE *fp)
+{
+    int i;
+    if (!session || !fp) return;
+    for (i = 0; i < session->open_file_count; i++) {
+        if (session->open_files[i] == fp) {
+            // shift remaining entries down
+            session->open_file_count--;
+            for (; i < session->open_file_count; i++) {
+                session->open_files[i] = session->open_files[i + 1];
+            }
+            session->open_files[session->open_file_count] = NULL;
+            return;
+        }
+    }
+}
+
+__asm__("\n&FUNC    SETC 'ses_fclose'");
+void session_fclose(Session *session, FILE *fp)
+{
+    if (!session || !fp) return;
+    session_unregister_file(session, fp);
+    fclose(fp);
+}
+
+__asm__("\n&FUNC    SETC 'ses_cleanup'");
+void session_cleanup(Session *session)
+{
+    int i;
+    if (!session) return;
+
+    // Close tracked FILE handles.
+    // Reset buffer pointer so fclose does NOT flush dirty data —
+    // the original I/O error (e.g. D37) would re-abend on flush.
+    for (i = 0; i < session->open_file_count; i++) {
+        FILE *fp = session->open_files[i];
+        if (fp) {
+            wtof("MVSMF99I Recovery: closing %s (DD:%s)",
+                 fp->dataset, fp->ddname);
+            fp->upto = fp->buf;  // discard buffer — no flush
+            fclose(fp);
+            session->open_files[i] = NULL;
+        }
+    }
+    session->open_file_count = 0;
+
+    // close UFS file handle (UFSFILE *) if tracked
+    if (session->ufs_file) {
+        wtof("MVSMF99I Recovery: closing UFS file at %p",
+             session->ufs_file);
+        ufs_fclose((void *)&session->ufs_file);
+    }
+
+    // close UFS session if tracked
+    if (session->ufs) {
+        wtof("MVSMF99I Recovery: freeing UFS session at %p",
+             session->ufs);
+        ufsfree((void *)&session->ufs);
+    }
 }
 
 //

--- a/src/router.c
+++ b/src/router.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <clibwto.h>
 #include <clibtry.h>
-#include <libufs.h>
 
 #include "router.h"
 #include "common.h"
@@ -25,6 +24,7 @@ struct handler_ctx {
 //
 
 static int handler_thunk(struct handler_ctx *ctx);
+static int safe_fclose_thunk(FILE *fp);
 
 static int route_matching_middleware(Session *session);
 static int path_vars_extracting_middleware(Session *session);
@@ -115,7 +115,9 @@ int handle_request(Router *router, Session *session)
         return -1;
     }
 
-    // Execute all middlewares in sequence
+    // Execute middlewares in sequence.
+    // NOTE: middlewares run outside ESTAE protection — they must be
+    // crash-safe. An abend here will not be caught by the try() below.
     size_t i = 0;
     for (i = 0; i < router->middleware_count; i++) {
         int rc = router->middlewares[i].handler(session);
@@ -150,8 +152,12 @@ int handle_request(Router *router, Session *session)
         wtof("MVSMF99E Handler abend S%03X U%04d for %s %s",
              sys, usr, method, path);
         session_cleanup(session);
-        sendErrorResponse(session, 500, 6, 8, 99,
-            "Internal server error (abend recovery)", NULL, 0);
+        if (!session->headers_sent) {
+            sendErrorResponse(session, 500, 6, 8, 99,
+                "Internal server error (abend recovery)", NULL, 0);
+        } else {
+            wtof("MVSMF99W Headers already sent, cannot send error response");
+        }
         return -1;
     }
     return ctx.rc;
@@ -171,14 +177,15 @@ static int handler_thunk(struct handler_ctx *ctx)
 //
 
 __asm__("\n&FUNC    SETC 'ses_reg_file'");
-void session_register_file(Session *session, FILE *fp)
+int session_register_file(Session *session, FILE *fp)
 {
-    if (!session || !fp) return;
+    if (!session || !fp) return -1;
     if (session->open_file_count >= MAX_SESSION_FILES) {
         wtof("MVSMF98W session file tracking full, cannot register");
-        return;
+        return -1;
     }
     session->open_files[session->open_file_count++] = fp;
+    return 0;
 }
 
 __asm__("\n&FUNC    SETC 'ses_unreg_file'");
@@ -207,39 +214,44 @@ void session_fclose(Session *session, FILE *fp)
     fclose(fp);
 }
 
+// Thunk for ESTAE-protected fclose during recovery.
+// Returns 0 on success; a secondary abend is caught by try().
+__asm__("\n&FUNC    SETC 'safe_fclose'");
+static int safe_fclose_thunk(FILE *fp)
+{
+    if (fp->buf) {
+        fp->upto = fp->buf;  // discard buffer — no flush
+    }
+    fclose(fp);
+    return 0;
+}
+
 __asm__("\n&FUNC    SETC 'ses_cleanup'");
 void session_cleanup(Session *session)
 {
     int i;
     if (!session) return;
 
-    // Close tracked FILE handles.
-    // Reset buffer pointer so fclose does NOT flush dirty data —
-    // the original I/O error (e.g. D37) would re-abend on flush.
+    // Close tracked FILE handles under individual ESTAE protection.
+    // A corrupted pointer from the original abend must not prevent
+    // cleanup of the remaining resources.
     for (i = 0; i < session->open_file_count; i++) {
         FILE *fp = session->open_files[i];
         if (fp) {
             wtof("MVSMF99I Recovery: closing %s (DD:%s)",
                  fp->dataset, fp->ddname);
-            fp->upto = fp->buf;  // discard buffer — no flush
-            fclose(fp);
+            if (try(safe_fclose_thunk, fp) != 0) {
+                wtof("MVSMF99W Recovery: fclose abended for slot %d", i);
+            }
             session->open_files[i] = NULL;
         }
     }
     session->open_file_count = 0;
 
-    // close UFS file handle (UFSFILE *) if tracked
-    if (session->ufs_file) {
-        wtof("MVSMF99I Recovery: closing UFS file at %p",
-             session->ufs_file);
-        ufs_fclose((void *)&session->ufs_file);
-    }
-
-    // close UFS session if tracked
-    if (session->ufs) {
-        wtof("MVSMF99I Recovery: freeing UFS session at %p",
-             session->ufs);
-        ufsfree((void *)&session->ufs);
+    // Delegate UFS cleanup to the registered callback (set by ussapi).
+    // This keeps the router decoupled from libufs.
+    if (session->ufs_cleanup) {
+        session->ufs_cleanup(session);
     }
 }
 

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -18,6 +18,7 @@ int testHandler(Session *session)
 	fn = (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_FN");
 	if (!fn) fn = "help";
 
+	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc,
 		"Content-Type: application/json\r\n\r\n")) < 0) goto quit;
@@ -100,6 +101,7 @@ int testWildcardHandler(Session *session)
 		(const UCHAR *) "HTTP_filepath");
 	if (!filepath) filepath = "(null)";
 
+	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit2;
 	if ((rc = http_printf(session->httpc,
 		"Content-Type: application/json\r\n\r\n")) < 0) goto quit2;

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -81,6 +81,26 @@ ufsd_rc_message(int rc)
 }
 
 //
+// UFS cleanup callback for ESTAE recovery (called by session_cleanup)
+//
+
+__asm__("\n&FUNC    SETC 'uss_cleanup_cb'");
+static void
+uss_cleanup_callback(Session *session)
+{
+	if (session->ufs_file) {
+		wtof("MVSMF99I Recovery: closing UFS file at %p",
+			 session->ufs_file);
+		ufs_fclose((void *)&session->ufs_file);
+	}
+	if (session->ufs) {
+		wtof("MVSMF99I Recovery: freeing UFS session at %p",
+			 session->ufs);
+		ufsfree((void *)&session->ufs);
+	}
+}
+
+//
 // UFS session helper
 //
 
@@ -101,6 +121,7 @@ uss_open_session(Session *session)
 
 	// Track UFS session for ESTAE recovery
 	session->ufs = ufs;
+	session->ufs_cleanup = uss_cleanup_callback;
 
 	return ufs;
 }
@@ -287,6 +308,7 @@ int ussListHandler(Session *session)
 	}
 
 	// Send response headers (streaming JSON like dsapi.c)
+	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
@@ -443,6 +465,7 @@ int ussGetHandler(Session *session)
 		? "application/octet-stream"
 		: "text/plain";
 
+	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", content_type)) < 0) goto quit;

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -99,6 +99,9 @@ uss_open_session(Session *session)
 		ufs_set_acee(ufs, session->acee);
 	}
 
+	// Track UFS session for ESTAE recovery
+	session->ufs = ufs;
+
 	return ufs;
 }
 
@@ -279,6 +282,7 @@ int ussListHandler(Session *session)
 		rc = sendErrorResponse(session, 404, 6, 8, 1,
 			"Path not found or is not a directory", NULL, 0);
 		ufsfree(&ufs);
+		session->ufs = NULL;
 		return rc;
 	}
 
@@ -361,6 +365,7 @@ quit:
 	}
 	if (ufs) {
 		ufsfree(&ufs);
+		session->ufs = NULL;
 	}
 
 	return rc;
@@ -415,17 +420,21 @@ int ussGetHandler(Session *session)
 		rc = sendErrorResponse(session, 404, 6, 8, 1,
 			"File not found or is a directory", NULL, 0);
 		ufsfree(&ufs);
+		session->ufs = NULL;
 		return rc;
 	}
+	session->ufs_file = fp;
 
 	// Check for error after open (e.g. ISDIR)
 	if (fp->error != UFSD_RC_OK) {
 		int urc = fp->error;
 		ufs_fclose(&fp);
+		session->ufs_file = NULL;
 		rc = sendErrorResponse(session,
 			ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
 			ufsd_rc_message(urc), NULL, 0);
 		ufsfree(&ufs);
+		session->ufs = NULL;
 		return rc;
 	}
 
@@ -457,9 +466,11 @@ int ussGetHandler(Session *session)
 quit:
 	if (fp) {
 		ufs_fclose(&fp);
+		session->ufs_file = NULL;
 	}
 	if (ufs) {
 		ufsfree(&ufs);
+		session->ufs = NULL;
 	}
 
 	return rc;
@@ -535,11 +546,13 @@ int ussPutHandler(Session *session)
 			"Cannot open file for writing", NULL, 0);
 		goto quit;
 	}
+	session->ufs_file = fp;
 
 	// Check for error after open
 	if (fp->error != UFSD_RC_OK) {
 		int urc = fp->error;
 		ufs_fclose(&fp);
+		session->ufs_file = NULL;
 		fp = NULL;
 		rc = sendErrorResponse(session,
 			ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
@@ -552,6 +565,7 @@ int ussPutHandler(Session *session)
 	if (written != (UINT32)body_len) {
 		int urc = fp->error;
 		ufs_fclose(&fp);
+		session->ufs_file = NULL;
 		fp = NULL;
 		if (urc != UFSD_RC_OK) {
 			rc = sendErrorResponse(session,
@@ -570,10 +584,12 @@ int ussPutHandler(Session *session)
 quit:
 	if (fp) {
 		ufs_fclose(&fp);
+		session->ufs_file = NULL;
 	}
 	free(body);
 	if (ufs) {
 		ufsfree(&ufs);
+		session->ufs = NULL;
 	}
 
 	return rc;


### PR DESCRIPTION
## Summary

Addresses all findings from the ESTAE recovery code review (#98):

- **#1 (Critical)**: Add `headers_sent` flag to `Session`. If a handler abends after HTTP headers have already been written, skip `sendErrorResponse()` to avoid corrupting the HTTP stream. Flag is set in `sendDefaultHeaders()` and all direct `http_resp()` call sites.
- **#2 (High)**: Wrap individual `fclose()` calls in `session_cleanup()` with their own `try()` blocks. A corrupted FILE pointer from the original abend no longer prevents cleanup of remaining resources.
- **#3 (Medium)**: Add NULL guard for `fp->buf` before resetting `fp->upto` in the safe fclose thunk.
- **#4 (Medium)**: Verified `tryrc()` bit layout is correct — no change needed.
- **#5 (Low)**: Document that middlewares run outside ESTAE protection.
- **#6 (Low)**: Remove `libufs.h` include from `router.c`. UFS cleanup is now delegated via a `ufs_cleanup` callback on Session, set by `ussapi.c`.
- **#7 (Low)**: `session_register_file()` now returns `int` (0/-1) so callers can detect a full tracking table.
- **#8 (Low)**: Document `record_buffer` abend leak in `dsapi.c` (bounded, acceptable).
- **#9 (Cosmetic)**: Swap RTR0008/RTR0009 to match declaration order.

## Test plan

- [x] Verify normal request processing (dataset list, member read, job submit) still works
- [x] Verify USS endpoints still work (list, get, put)
- [x] Force a handler abend (e.g. access invalid dataset) and verify recovery message in WTO
- [ ] Verify no double HTTP response on mid-stream abend

Fixes #98