### PR TITLE
Docs: Create endpoint documentation for all USS APIs

### DIFF
--- a/doc/endpoints/README.md
+++ b/doc/endpoints/README.md
@@ -37,6 +37,16 @@ Volume-specific variants: `/zosmf/restfiles/ds/-({volser})/{name}` for GET and P
 | GET | [`/zosmf/restfiles/ds/{name}({member})`](datasets/members-get.md) | Read PDS member |
 | PUT | [`/zosmf/restfiles/ds/{name}({member})`](datasets/members-put.md) | Write PDS member |
 
+## USS Files (`/zosmf/restfiles/fs`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | [`/zosmf/restfiles/fs?path=...`](uss/list.md) | List directory |
+| GET | [`/zosmf/restfiles/fs/{filepath}`](uss/get.md) | Read file |
+| PUT | [`/zosmf/restfiles/fs/{filepath}`](uss/put.md) | Write file (or invoke utilities) |
+| POST | [`/zosmf/restfiles/fs/{filepath}`](uss/create.md) | Create file or directory |
+| DELETE | [`/zosmf/restfiles/fs/{filepath}`](uss/delete.md) | Delete file or directory |
+
 ## Common Headers
 
 | Header | Used By | Description |
@@ -45,3 +55,5 @@ Volume-specific variants: `/zosmf/restfiles/ds/-({volser})/{name}` for GET and P
 | `X-IBM-Intrdr-Mode` | Job submit | Validated but fixed to `TEXT` |
 | `X-IBM-Intrdr-Lrecl` | Job submit | Validated but fixed to `80` |
 | `X-IBM-Intrdr-Recfm` | Job submit | Validated but fixed to `F` |
+| `X-IBM-Max-Items` | Directory listing (datasets & USS) | Maximum items to return (0 = unlimited) |
+| `X-IBM-Option` | USS delete | `recursive` for non-empty directory deletion |

--- a/doc/endpoints/uss/create.md
+++ b/doc/endpoints/uss/create.md
@@ -1,0 +1,96 @@
+# POST /zosmf/restfiles/fs/{filepath} — Create File or Directory
+
+Creates a new file or directory at the specified USS path.
+
+## Request
+
+```
+POST /zosmf/restfiles/fs/{filepath}
+```
+
+### Path Parameters
+
+| Parameter  | Description |
+|------------|-------------|
+| `filepath` | Absolute path to the file or directory to create (wildcard capture, includes `/`) |
+
+### Headers
+
+| Header         | Required | Default            | Description |
+|----------------|----------|--------------------|-------------|
+| `Content-Type` | Yes      | `application/json` | Must be `application/json` |
+
+### Body (JSON)
+
+```json
+{
+  "type": "file",
+  "mode": "rwxr-xr-x"
+}
+```
+
+| Field  | Required | Default     | Description |
+|--------|----------|-------------|-------------|
+| `type` | Yes      | —           | `file`, `directory`, or `dir` |
+| `mode` | No       | `rwxr-xr-x` | Unix permission string (9 characters, e.g. `rw-r--r--`) |
+
+## Behavior
+
+- **`type: "file"`**: Creates an empty file via `ufs_fopen("w")` + `ufs_fclose()`. Returns 400 if the file already exists (does not truncate).
+- **`type: "directory"` or `"dir"`**: Creates a directory via `ufs_mkdir()`. Returns 400 if the directory already exists.
+- **`mode`**: Parsed as a Unix permission string (`rwxr-xr-x` → octal 0755). Applied via `ufs_set_create_perm()` before creation, then restored to the previous default.
+
+## Response
+
+### Success (201 Created)
+
+No response body.
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400    | Missing filepath, missing or invalid `type`, file/directory already exists, path too long, or parent directory not found |
+| 503    | UFSD subsystem not available |
+
+## Examples
+
+### Create a directory with curl
+
+```bash
+curl -X POST -u IBMUSER:sys1 \
+  -H "Content-Type: application/json" \
+  -d '{"type":"directory","mode":"rwxr-xr-x"}' \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/mydir"
+```
+
+### Create a file with curl
+
+```bash
+curl -X POST -u IBMUSER:sys1 \
+  -H "Content-Type: application/json" \
+  -d '{"type":"file","mode":"rw-r--r--"}' \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/myfile.txt"
+```
+
+### Create a directory with Zowe CLI
+
+```bash
+zowe zos-uss issue ssh "mkdir /home/ibmuser/mydir"
+```
+
+> **Note:** Zowe CLI does not have a direct `zos-files create uss-file` command.
+> The closest equivalent is `zowe zos-uss issue ssh` with a mkdir/touch command,
+> or using the API directly via `zowe zos-files invoke rest-api`.
+
+## Limitations vs Real z/OSMF
+
+- The `mode` field accepts only symbolic permission strings (`rwxr-xr-x`), not octal values
+- No support for creating symbolic links
+- Maximum path length is limited by `UFS_PATH_MAX`
+
+## Handler
+
+- Function: `ussCreateHandler`
+- Source: `src/ussapi.c`
+- ASM label: `UAPI0004`

--- a/doc/endpoints/uss/delete.md
+++ b/doc/endpoints/uss/delete.md
@@ -44,6 +44,34 @@ No response body.
 | 500    | I/O error or other server error |
 | 503    | UFSD subsystem not available |
 
+## Examples
+
+### Delete a file with curl
+
+```bash
+curl -X DELETE -u IBMUSER:sys1 \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/myfile.txt"
+```
+
+### Delete a directory recursively with curl
+
+```bash
+curl -X DELETE -u IBMUSER:sys1 \
+  -H "X-IBM-Option: recursive" \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/mydir"
+```
+
+### Delete with Zowe CLI
+
+```bash
+zowe files delete uf "/home/ibmuser/myfile.txt"
+```
+
+## Limitations vs Real z/OSMF
+
+- Only `recursive` is supported for `X-IBM-Option` (no other options)
+- No symbolic link handling (UFSD has no symlink support)
+
 ## Handler
 
 - Function: `ussDeleteHandler`

--- a/doc/endpoints/uss/get.md
+++ b/doc/endpoints/uss/get.md
@@ -46,6 +46,37 @@ GET /zosmf/restfiles/fs/{filepath}
 64 KB (UFSD Phase 1 — direct blocks only). Reads beyond this limit
 will return partial data up to the UFSD_RC_NOSPACE boundary.
 
+## Examples
+
+### Read a text file with curl
+
+```bash
+curl -u IBMUSER:sys1 \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/hello.txt"
+```
+
+### Read a binary file with curl
+
+```bash
+curl -u IBMUSER:sys1 \
+  -H "X-IBM-Data-Type: binary" \
+  -o output.bin \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/data.bin"
+```
+
+### Read with Zowe CLI
+
+```bash
+zowe files download uf "/home/ibmuser/hello.txt" -f hello.txt
+```
+
+## Limitations vs Real z/OSMF
+
+- No `Content-Length` header in response (streamed without prior size calculation)
+- No `X-IBM-Intrdr-*` headers for record-mode reading
+- No `search` query parameter for in-file searching
+- No `If-None-Match` / ETag support
+
 ## Handler
 
 - Function: `ussGetHandler`

--- a/doc/endpoints/uss/list.md
+++ b/doc/endpoints/uss/list.md
@@ -71,6 +71,36 @@ When `X-IBM-Max-Items` is set and the directory contains more entries:
 | 404    | Path not found or not a directory |
 | 503    | UFSD subsystem not available |
 
+## Examples
+
+### List a directory with curl
+
+```bash
+curl -u IBMUSER:sys1 \
+  "http://mvs:1080/zosmf/restfiles/fs?path=/home/ibmuser"
+```
+
+### List with max items
+
+```bash
+curl -u IBMUSER:sys1 \
+  -H "X-IBM-Max-Items: 10" \
+  "http://mvs:1080/zosmf/restfiles/fs?path=/home/ibmuser"
+```
+
+### List with Zowe CLI
+
+```bash
+zowe files list uf "/home/ibmuser"
+```
+
+## Limitations vs Real z/OSMF
+
+- No `depth` query parameter (lists one level only)
+- No `filesys`, `symlinks`, `group`, `mtime`, `size`, `perm`, `type` filters
+- No `lstat` mode — always follows symlinks (UFSD has no symlink support)
+- `mode` field returns UFSD `attr` string (e.g. `drwxr-xr-x`), not the numeric z/OSMF format
+
 ## Handler
 
 - Function: `ussListHandler`

--- a/doc/endpoints/uss/put.md
+++ b/doc/endpoints/uss/put.md
@@ -42,23 +42,83 @@ No response body.
 
 | Content-Type        | Behavior |
 |---------------------|----------|
-| `application/json`  | Returns 501 — USS utilities are Phase 2 |
+| `application/json`  | Dispatches to USS utilities handler (see below) |
 | Everything else     | Writes file content |
+
+## USS Utilities (Content-Type: application/json)
+
+When the request Content-Type is `application/json`, the body is parsed as a
+utility request. The `"request"` field determines which utility to invoke.
+
+### chtag — File Tag Operations
+
+```json
+{"request": "chtag", "action": "list|set|remove"}
+```
+
+| Action   | Behavior |
+|----------|----------|
+| `list`   | Returns `{"stdout":["- untagged    T=off <filepath>"]}` (UFSD has no file tagging) |
+| `set`    | Accepted as no-op (200, no body) |
+| `remove` | Accepted as no-op (200, no body) |
+
+All other utility requests return **501 Not Implemented**.
 
 ## Error Responses
 
 | Status | Condition |
 |--------|-----------|
-| 400    | Missing filepath or empty body or missing Content-Length |
+| 400    | Missing filepath, empty body, or invalid utility request |
 | 404    | Cannot open file for writing (parent directory not found) |
 | 414    | Path name too long |
-| 501    | Content-Type is application/json (Phase 2 utilities) |
+| 500    | No space left on device or I/O error (64 KB limit) |
+| 501    | Unsupported USS utility (Content-Type: application/json with unknown request) |
 | 503    | UFSD subsystem not available |
-| 507    | No space left on device (64 KB limit) |
 
 ## Max File Size
 
 64 KB (UFSD Phase 1 — direct blocks only).
+
+## Examples
+
+### Write a text file with curl
+
+```bash
+curl -X PUT -u IBMUSER:sys1 \
+  -H "Content-Length: 12" \
+  -d "Hello World!" \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/hello.txt"
+```
+
+### Write a binary file with curl
+
+```bash
+curl -X PUT -u IBMUSER:sys1 \
+  -H "X-IBM-Data-Type: binary" \
+  -H "Content-Length: 4" \
+  --data-binary $'\x00\x01\x02\x03' \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/data.bin"
+```
+
+### Write a file with Zowe CLI
+
+```bash
+echo "Hello World!" | zowe files upload stdin-to-uf "/home/ibmuser/hello.txt"
+```
+
+### Query file tag with curl (chtag utility)
+
+```bash
+curl -X PUT -u IBMUSER:sys1 \
+  -H "Content-Type: application/json" \
+  -d '{"request":"chtag","action":"list"}' \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/hello.txt"
+```
+
+## Limitations vs Real z/OSMF
+
+- No `Transfer-Encoding: chunked` on response (request chunked encoding is supported)
+- USS utilities limited to `chtag` — `chmod`, `chown`, `extattr` return 501
 
 ## Handler
 


### PR DESCRIPTION
## Summary

- Create `doc/endpoints/uss/create.md` for the POST create file/directory endpoint
- Update `doc/endpoints/uss/put.md` to document chtag utility support (was incorrectly listed as 501)
- Add curl examples, Zowe CLI equivalents, and "Limitations vs Real z/OSMF" sections to all 5 USS endpoint docs
- Add USS Files section to `doc/endpoints/README.md` with links to all 5 endpoint docs
- Add `X-IBM-Max-Items` and `X-IBM-Option` to the common headers table

Fixes #88