### PR TITLE
Use CP037 for Dataset/Jobs, IBM-1047 for USS translation

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -185,7 +185,7 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 		/* Text mode: fgets + EBCDIC->ASCII + strlen for length */
 		while (fgets(buffer, lrecl + 2, fp) > 0) {
 			size_t len = strlen(buffer);
-			http_etoa((unsigned char *)buffer, len);
+			http_xlate((unsigned char *)buffer, len, httpx->xlate_cp037->etoa);
 			if ((rc = http_send(session->httpc,
 					(const UCHAR *)buffer, len)) < 0) {
 				break;
@@ -375,7 +375,7 @@ static int write_record(Session *session, FILE *fp, char *record_buffer, size_t 
             
             // Copy to temporary buffer and convert to EBCDIC
             memcpy(ebcdic_buffer, record_buffer, record_length);
-            http_atoe((unsigned char *)ebcdic_buffer, record_length);
+            http_xlate((unsigned char *)ebcdic_buffer, record_length, httpx->xlate_cp037->atoe);
   
             // Write the converted record
             if (fwrite(ebcdic_buffer, 1, record_length, fp) != record_length) return -1;
@@ -884,7 +884,7 @@ int datasetPutHandler(Session *session)
             }
             
             // Convert chunk size from ASCII hex to EBCDIC hex
-            http_atoe((unsigned char *)chunk_size_str, strlen(chunk_size_str));
+            http_xlate((unsigned char *)chunk_size_str, strlen(chunk_size_str), httpx->xlate_cp037->atoe);
 
             // Convert chunk size from string to integer
             chunk_size = strtoul(chunk_size_str, NULL, 16);
@@ -1364,7 +1364,7 @@ int memberPutHandler(Session *session)
             }
             
             // Convert chunk size from ASCII hex to EBCDIC hex
-            http_atoe((unsigned char *)chunk_size_str, strlen(chunk_size_str));
+            http_xlate((unsigned char *)chunk_size_str, strlen(chunk_size_str), httpx->xlate_cp037->atoe);
 
             // Convert chunk size from string to integer
             chunk_size = strtoul(chunk_size_str, NULL, 16);
@@ -1716,7 +1716,7 @@ int datasetCreateHandler(Session *session)
 				chunk_hdr[i] = '\0';
 
 				/* Convert ASCII hex to EBCDIC for strtoul */
-				http_atoe((unsigned char *)chunk_hdr, strlen(chunk_hdr));
+				http_xlate((unsigned char *)chunk_hdr, strlen(chunk_hdr), httpx->xlate_cp037->atoe);
 				chunk_size = strtoul(chunk_hdr, NULL, 16);
 
 				if (chunk_size == 0) {
@@ -1765,8 +1765,8 @@ int datasetCreateHandler(Session *session)
 
 		local_body[body_size] = '\0';
 
-		/* Convert from ASCII to EBCDIC */
-		http_atoe((unsigned char *)local_body, body_size);
+		/* Convert from ASCII to EBCDIC (CP037 for dataset API) */
+		http_xlate((unsigned char *)local_body, body_size, httpx->xlate_cp037->atoe);
 		body = local_body;
 	} else {
 		body_size = strlen(body);

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -427,8 +427,8 @@ int jobSubmitHandler(Session *session)
 		}
 
 		if (is_json) {
-			/* convert ASCII request body to EBCDIC so strstr/strchr work */
-			http_atoe((unsigned char *)data, data_size);
+			/* convert ASCII request body to EBCDIC (CP037) so strstr/strchr work */
+			http_xlate((unsigned char *)data, data_size, httpx->xlate_cp037->atoe);
 
 			/* JSON body: extract file reference and submit from dataset */
 			{
@@ -1655,7 +1655,7 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
     memcpy(ebcdic_content, content, content_length);
     ebcdic_content[content_length] = '\0';
 
-    http_atoe((unsigned char *)ebcdic_content, content_length);
+    http_xlate((unsigned char *)ebcdic_content, content_length, httpx->xlate_cp037->atoe);
 
     /* Allocate lines array + contiguous buffer */
     lines = (char **)calloc(capacity, sizeof(char *));

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -368,7 +368,7 @@ int ussGetHandler(Session *session)
 	// Stream file content in chunks
 	while ((n = ufs_fread(buf, 1, sizeof(buf), fp)) > 0) {
 		if (data_type == USS_DATA_TYPE_TEXT) {
-			http_etoa((unsigned char *)buf, n);
+			http_xlate((unsigned char *)buf, n, httpx->xlate_1047->etoa);
 		}
 		rc = http_send(session->httpc, (const UCHAR *)buf, n);
 		if (rc < 0) {
@@ -473,8 +473,8 @@ uss_handle_utilities(Session *session, const char *filepath)
 		}
 		free_body = 1;
 
-		// Convert from ASCII to EBCDIC for JSON parsing
-		http_atoe((unsigned char *)body, (int)body_len);
+		// Convert from ASCII to EBCDIC (IBM-1047) for JSON parsing
+		http_xlate((unsigned char *)body, (int)body_len, httpx->xlate_1047->atoe);
 	}
 
 	// Extract "request" field to determine which utility
@@ -553,9 +553,9 @@ int ussPutHandler(Session *session)
 		return -1;
 	}
 
-	// Text mode: ASCII→EBCDIC before writing
+	// Text mode: ASCII→EBCDIC (IBM-1047) before writing
 	if (data_type == USS_DATA_TYPE_TEXT) {
-		http_atoe((unsigned char *)body, (int)body_len);
+		http_xlate((unsigned char *)body, (int)body_len, httpx->xlate_1047->atoe);
 	}
 
 	// Open UFS session
@@ -738,8 +738,8 @@ int ussCreateHandler(Session *session)
 		}
 		free_body = 1;
 
-		// Convert from ASCII to EBCDIC for JSON parsing
-		http_atoe((unsigned char *)body, (int)body_len);
+		// Convert from ASCII to EBCDIC (IBM-1047) for JSON parsing
+		http_xlate((unsigned char *)body, (int)body_len, httpx->xlate_1047->atoe);
 	}
 
 	// Parse required "type" field


### PR DESCRIPTION
## Summary

- Switch all Dataset/Member/Job API handlers to explicit **CP037** codepage via `http_xlate()` with `httpx->xlate_cp037`
- Switch all USS/UFS handlers to explicit **IBM-1047** codepage via `http_xlate()` with `httpx->xlate_1047`
- Infrastructure translation (URL decode, chunk parsing, auth, JSON envelope) remains on server-default

Previously all handlers used `http_etoa()`/`http_atoe()` which use the server-default codepage, causing characters like `^`, `¬`, `[`, `]`, `|` to be mistranslated when the codepage didn't match the data source (CP037 for MVS-native, IBM-1047 for USS).

**12 call sites changed** across 3 files (dsapi.c: 6, jobsapi.c: 2, ussapi.c: 4).

## Test plan

- [ ] Read a dataset containing `^` and `¬` — verify correct display (CP037)
- [ ] Submit JCL with special characters (`[`, `]`, `|`) — verify CP037
- [ ] Read/write USS files — verify IBM-1047 still works
- [ ] Run existing curl/Zowe test suites (`tests/curl-datasets.sh`, `tests/curl-uss.sh`)

Fixes #118