### PR TITLE
fix: use EBCDIC NEL as JCL tokenizer delimiter

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -31,6 +31,9 @@
 /** @brief EBCDIC line feed */
 #define EBCDIC_LF 0x25
 
+/** @brief EBCDIC newline (NEL) - used by CP037 A2E for ASCII LF (0x0A) */
+#define EBCDIC_NEL 0x15
+
 /** @brief HTTP status codes */
 #define HTTP_STATUS_OK 200                    /**< Success */
 #define HTTP_STATUS_CREATED 201               /**< Resource created */

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -1672,7 +1672,7 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
         }
     }
 
-    char delimiter[2] = {EBCDIC_LF, '\0'}; // EBCDIC Line Feed
+    char delimiter[2] = {EBCDIC_NEL, '\0'}; // CP037 A2E maps ASCII LF to NEL (0x15)
     char *saveptr = NULL;
     char *line = tokenize(ebcdic_content, delimiter, &saveptr);
 


### PR DESCRIPTION
## Summary

- CP037 A2E maps ASCII LF (0x0A) → EBCDIC NEL (0x15), not EBCDIC LF (0x25)
- JCL tokenizer in `submit_jcl_content()` was splitting on 0x25 (no match after conversion)
- Entire JCL treated as single line → "No space for comma" → "No valid JOB card"
- Fix: define `EBCDIC_NEL` (0x15) in `common.h`, use it as tokenizer delimiter

## Test plan

- [ ] Submit JCL from local file via `zowe jobs submit local-file`
- [ ] Submit JCL inline via curl PUT with text/plain
- [ ] Verify job card parsing, USER/PASSWORD injection, and job completion

Fixes #120