### PR TITLE
Fix ussListHandler: support file path in ?path= parameter

### DIFF
--- a/doc/endpoints/uss/list.md
+++ b/doc/endpoints/uss/list.md
@@ -1,6 +1,8 @@
-# GET /zosmf/restfiles/fs — List Directory
+# GET /zosmf/restfiles/fs — List Directory / File Stat
 
-Lists files and directories at the specified USS path.
+Lists files and directories at the specified USS path. When the path points to
+a file instead of a directory, returns a single-item list with the file's
+attributes (stat-like query), matching z/OSMF behavior.
 
 ## Request
 
@@ -12,7 +14,7 @@ GET /zosmf/restfiles/fs?path=<filepath>
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `path`    | Yes      | Absolute path to the directory to list |
+| `path`    | Yes      | Absolute path to a directory or file |
 
 ### Headers
 
@@ -47,7 +49,7 @@ GET /zosmf/restfiles/fs?path=<filepath>
 
 | Field   | Source            | Type   | Description |
 |---------|-------------------|--------|-------------|
-| `name`  | UFSDLIST.name     | string | File or directory name |
+| `name`  | UFSDLIST.name     | string | File or directory name (full path for file stat queries) |
 | `mode`  | UFSDLIST.attr     | string | Unix permission string (e.g. `drwxr-xr-x`) |
 | `size`  | UFSDLIST.filesize | number | File size in bytes |
 | `user`  | UFSDLIST.owner    | string | Owner name |
@@ -68,7 +70,7 @@ When `X-IBM-Max-Items` is set and the directory contains more entries:
 | Status | Condition |
 |--------|-----------|
 | 400    | Missing `path` query parameter |
-| 404    | Path not found or not a directory |
+| 404    | Path not found |
 | 503    | UFSD subsystem not available |
 
 ## Examples
@@ -86,6 +88,32 @@ curl -u IBMUSER:sys1 \
 curl -u IBMUSER:sys1 \
   -H "X-IBM-Max-Items: 10" \
   "http://mvs:1080/zosmf/restfiles/fs?path=/home/ibmuser"
+```
+
+### Stat a single file (file path query)
+
+```bash
+curl -u IBMUSER:sys1 \
+  "http://mvs:1080/zosmf/restfiles/fs?path=/home/ibmuser/myfile.txt"
+```
+
+Returns a single-item list with the full path in the `name` field:
+
+```json
+{
+  "items": [
+    {
+      "name": "/home/ibmuser/myfile.txt",
+      "mode": "-rw-r--r--",
+      "size": 1234,
+      ...
+    }
+  ],
+  "returnedRows": 1,
+  "totalRows": 1,
+  "moreRows": false,
+  "JSONversion": 1
+}
 ```
 
 ### List with Zowe CLI

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -199,15 +199,114 @@ int ussListHandler(Session *session)
 		return -1;
 	}
 
-	// Open directory
+	// Open directory — if this fails, path may be a file (stat query)
 	dd = ufs_diropen(ufs, path, NULL);
 	if (!dd) {
-		rc = sendErrorResponse(session, 404, 6, 8, 1,
-			"Path not found or is not a directory", NULL, 0);
-		return rc;
+		// Try parent directory to find the file entry
+		char parent[UFS_PATH_MAX];
+		char filename[60];
+		const char *slash;
+		size_t plen;
+
+		slash = strrchr(path, '/');
+		if (!slash || slash == path + strlen(path) - 1) {
+			// No slash or trailing slash — not a valid file path
+			return sendErrorResponse(session, 404, 6, 8, 1,
+				"Path not found", NULL, 0);
+		}
+
+		// Split into parent directory and filename
+		plen = (size_t)(slash - path);
+		if (plen == 0) {
+			// File in root directory: parent = "/"
+			parent[0] = '/';
+			parent[1] = '\0';
+		} else if (plen >= sizeof(parent)) {
+			return sendErrorResponse(session, 400, 2, 8, 1,
+				"Path too long", NULL, 0);
+		} else {
+			memcpy(parent, path, plen);
+			parent[plen] = '\0';
+		}
+
+		if (strlen(slash + 1) >= sizeof(filename)) {
+			return sendErrorResponse(session, 400, 2, 8, 1,
+				"Filename too long", NULL, 0);
+		}
+		strcpy(filename, slash + 1);
+
+		dd = ufs_diropen(ufs, parent, NULL);
+		if (!dd) {
+			return sendErrorResponse(session, 404, 6, 8, 1,
+				"Path not found", NULL, 0);
+		}
+
+		// Scan parent directory for matching entry
+		while ((entry = ufs_dirread(dd)) != NULL) {
+			if (strcmp(entry->name, filename) == 0) {
+				break;
+			}
+		}
+
+		if (!entry) {
+			ufs_dirclose(&dd);
+			return sendErrorResponse(session, 404, 6, 8, 1,
+				"File not found", NULL, 0);
+		}
+
+		// Found — return single-item response with full path
+		{
+			struct tm *tm_info;
+			char mtime_buf[32];
+
+			tm_info = mgmtime64(&entry->mtime);
+			if (tm_info) {
+				snprintf(mtime_buf, sizeof(mtime_buf),
+					"%04d-%02d-%02dT%02d:%02d:%02dZ",
+					tm_info->tm_year + 1900, tm_info->tm_mon + 1,
+					tm_info->tm_mday, tm_info->tm_hour,
+					tm_info->tm_min, tm_info->tm_sec);
+			} else {
+				snprintf(mtime_buf, sizeof(mtime_buf), "1970-01-01T00:00:00Z");
+			}
+
+			session->headers_sent = 1;
+			if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
+			if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+			if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
+			if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
+			if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
+			if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
+
+			rc = http_printf(session->httpc,
+				"{\n"
+				"  \"items\": [\n"
+				"    {\n"
+				"      \"name\": \"%s\",\n"
+				"      \"mode\": \"%s\",\n"
+				"      \"size\": %u,\n"
+				"      \"user\": \"%s\",\n"
+				"      \"group\": \"%s\",\n"
+				"      \"links\": %u,\n"
+				"      \"mtime\": \"%s\",\n"
+				"      \"inode\": %u\n"
+				"    }\n"
+				"  ],\n"
+				"  \"returnedRows\": 1,\n"
+				"  \"totalRows\": 1,\n"
+				"  \"moreRows\": false,\n"
+				"  \"JSONversion\": 1\n"
+				"}\n",
+				path, entry->attr, entry->filesize,
+				entry->owner, entry->group,
+				(unsigned) entry->nlink,
+				mtime_buf, entry->inode_number);
+
+			goto quit;
+		}
 	}
 
-	// Send response headers (streaming JSON like dsapi.c)
+	// Directory listing — send response headers (streaming JSON)
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -161,10 +161,129 @@ uss_build_path(char *buf, size_t bufsz, const char *captured)
 #define USS_LIST_DEFAULT_MAX_ITEMS 1000
 
 //
+// uss_stat_file — stat a single file via parent directory scan
+//
+// When path points to a file, opens the parent directory, finds the
+// matching entry, and returns a single-item JSON list with the full
+// path in the name field.  Returns 0 on success, -1 on error (with
+// HTTP error response already sent).
+//
+
+__asm__("\n&FUNC    SETC 'uss_stat_file'");
+static int
+uss_stat_file(Session *session, UFS *ufs, const char *path)
+{
+	char parent[UFS_PATH_MAX];
+	char filename[60];
+	const char *slash;
+	size_t plen;
+	UFSDDESC *dd;
+	UFSDLIST *entry;
+	struct tm *tm_info;
+	char mtime_buf[32];
+	int rc;
+
+	slash = strrchr(path, '/');
+	if (!slash || slash == path + strlen(path) - 1) {
+		return sendErrorResponse(session, 404, 6, 8, 1,
+			"Path not found", NULL, 0);
+	}
+
+	// Split into parent directory and filename
+	plen = (size_t)(slash - path);
+	if (plen == 0) {
+		parent[0] = '/';
+		parent[1] = '\0';
+	} else if (plen >= sizeof(parent)) {
+		return sendErrorResponse(session, 400, 2, 8, 1,
+			"Path too long", NULL, 0);
+	} else {
+		memcpy(parent, path, plen);
+		parent[plen] = '\0';
+	}
+
+	if (strlen(slash + 1) >= sizeof(filename)) {
+		return sendErrorResponse(session, 400, 2, 8, 1,
+			"Filename too long", NULL, 0);
+	}
+	strcpy(filename, slash + 1);
+
+	dd = ufs_diropen(ufs, parent, NULL);
+	if (!dd) {
+		return sendErrorResponse(session, 404, 6, 8, 1,
+			"Path not found", NULL, 0);
+	}
+
+	// Scan parent directory for matching entry
+	while ((entry = ufs_dirread(dd)) != NULL) {
+		if (strcmp(entry->name, filename) == 0) {
+			break;
+		}
+	}
+
+	if (!entry) {
+		ufs_dirclose(&dd);
+		return sendErrorResponse(session, 404, 6, 8, 1,
+			"File not found", NULL, 0);
+	}
+
+	// Format mtime
+	tm_info = mgmtime64(&entry->mtime);
+	if (tm_info) {
+		snprintf(mtime_buf, sizeof(mtime_buf),
+			"%04d-%02d-%02dT%02d:%02d:%02dZ",
+			tm_info->tm_year + 1900, tm_info->tm_mon + 1,
+			tm_info->tm_mday, tm_info->tm_hour,
+			tm_info->tm_min, tm_info->tm_sec);
+	} else {
+		snprintf(mtime_buf, sizeof(mtime_buf), "1970-01-01T00:00:00Z");
+	}
+
+	// Send single-item response with full path in name
+	session->headers_sent = 1;
+	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
+
+	rc = http_printf(session->httpc,
+		"{\n"
+		"  \"items\": [\n"
+		"    {\n"
+		"      \"name\": \"%s\",\n"
+		"      \"mode\": \"%s\",\n"
+		"      \"size\": %u,\n"
+		"      \"user\": \"%s\",\n"
+		"      \"group\": \"%s\",\n"
+		"      \"links\": %u,\n"
+		"      \"mtime\": \"%s\",\n"
+		"      \"inode\": %u\n"
+		"    }\n"
+		"  ],\n"
+		"  \"returnedRows\": 1,\n"
+		"  \"totalRows\": 1,\n"
+		"  \"moreRows\": false,\n"
+		"  \"JSONversion\": 1\n"
+		"}\n",
+		path, entry->attr, entry->filesize,
+		entry->owner, entry->group,
+		(unsigned) entry->nlink,
+		mtime_buf, entry->inode_number);
+
+quit:
+	ufs_dirclose(&dd);
+	return rc;
+}
+
+//
 // ussListHandler — GET /zosmf/restfiles/fs?path=<filepath>
 //
 // Lists files and directories at the given path, returning
 // z/OSMF-compatible JSON with file metadata from UFSDLIST entries.
+// When path points to a file, delegates to uss_stat_file() for a
+// single-item stat response.
 //
 
 int ussListHandler(Session *session)
@@ -202,108 +321,7 @@ int ussListHandler(Session *session)
 	// Open directory — if this fails, path may be a file (stat query)
 	dd = ufs_diropen(ufs, path, NULL);
 	if (!dd) {
-		// Try parent directory to find the file entry
-		char parent[UFS_PATH_MAX];
-		char filename[60];
-		const char *slash;
-		size_t plen;
-
-		slash = strrchr(path, '/');
-		if (!slash || slash == path + strlen(path) - 1) {
-			// No slash or trailing slash — not a valid file path
-			return sendErrorResponse(session, 404, 6, 8, 1,
-				"Path not found", NULL, 0);
-		}
-
-		// Split into parent directory and filename
-		plen = (size_t)(slash - path);
-		if (plen == 0) {
-			// File in root directory: parent = "/"
-			parent[0] = '/';
-			parent[1] = '\0';
-		} else if (plen >= sizeof(parent)) {
-			return sendErrorResponse(session, 400, 2, 8, 1,
-				"Path too long", NULL, 0);
-		} else {
-			memcpy(parent, path, plen);
-			parent[plen] = '\0';
-		}
-
-		if (strlen(slash + 1) >= sizeof(filename)) {
-			return sendErrorResponse(session, 400, 2, 8, 1,
-				"Filename too long", NULL, 0);
-		}
-		strcpy(filename, slash + 1);
-
-		dd = ufs_diropen(ufs, parent, NULL);
-		if (!dd) {
-			return sendErrorResponse(session, 404, 6, 8, 1,
-				"Path not found", NULL, 0);
-		}
-
-		// Scan parent directory for matching entry
-		while ((entry = ufs_dirread(dd)) != NULL) {
-			if (strcmp(entry->name, filename) == 0) {
-				break;
-			}
-		}
-
-		if (!entry) {
-			ufs_dirclose(&dd);
-			return sendErrorResponse(session, 404, 6, 8, 1,
-				"File not found", NULL, 0);
-		}
-
-		// Found — return single-item response with full path
-		{
-			struct tm *tm_info;
-			char mtime_buf[32];
-
-			tm_info = mgmtime64(&entry->mtime);
-			if (tm_info) {
-				snprintf(mtime_buf, sizeof(mtime_buf),
-					"%04d-%02d-%02dT%02d:%02d:%02dZ",
-					tm_info->tm_year + 1900, tm_info->tm_mon + 1,
-					tm_info->tm_mday, tm_info->tm_hour,
-					tm_info->tm_min, tm_info->tm_sec);
-			} else {
-				snprintf(mtime_buf, sizeof(mtime_buf), "1970-01-01T00:00:00Z");
-			}
-
-			session->headers_sent = 1;
-			if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
-			if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
-			if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
-			if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
-			if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
-			if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
-
-			rc = http_printf(session->httpc,
-				"{\n"
-				"  \"items\": [\n"
-				"    {\n"
-				"      \"name\": \"%s\",\n"
-				"      \"mode\": \"%s\",\n"
-				"      \"size\": %u,\n"
-				"      \"user\": \"%s\",\n"
-				"      \"group\": \"%s\",\n"
-				"      \"links\": %u,\n"
-				"      \"mtime\": \"%s\",\n"
-				"      \"inode\": %u\n"
-				"    }\n"
-				"  ],\n"
-				"  \"returnedRows\": 1,\n"
-				"  \"totalRows\": 1,\n"
-				"  \"moreRows\": false,\n"
-				"  \"JSONversion\": 1\n"
-				"}\n",
-				path, entry->attr, entry->filesize,
-				entry->owner, entry->group,
-				(unsigned) entry->nlink,
-				mtime_buf, entry->inode_number);
-
-			goto quit;
-		}
+		return uss_stat_file(session, ufs, path);
 	}
 
 	// Directory listing — send response headers (streaming JSON)

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -241,12 +241,29 @@ HTTP_CODE=$(echo "$RESP" | tail -1)
 assert_http_status "404" "$HTTP_CODE" "non-existent path returns 404"
 
 if [ -n "$TEST_FILE" ]; then
+	echo ""
+	echo "--- List file path (stat-like query) ---"
+
 	RESP=$(curl -s -w '\n%{http_code}' \
 		-u "$AUTH" \
 		"${BASE_URL}/zosmf/restfiles/fs?path=${TEST_FILE}")
 	HTTP_CODE=$(echo "$RESP" | tail -1)
+	BODY=$(echo "$RESP" | sed '$d')
 
-	assert_http_status "404" "$HTTP_CODE" "list file path (not a directory) returns 404"
+	assert_http_status "200" "$HTTP_CODE" "list file path returns 200 (stat query)"
+
+	RETURNED=$(echo "$BODY" | grep -o '"returnedRows": *[0-9]*' | grep -o '[0-9]*')
+	if [ "$RETURNED" = "1" ]; then
+		pass "stat query: returnedRows is 1"
+	else
+		fail "stat query: returnedRows expected 1, got ${RETURNED}"
+	fi
+
+	if echo "$BODY" | grep -q "\"name\": \"${TEST_FILE}\""; then
+		pass "stat query: name contains full path"
+	else
+		fail "stat query: name does not contain full path ${TEST_FILE}"
+	fi
 fi
 
 # =========================================================================


### PR DESCRIPTION
## Summary

- When `?path=` points to a file, open the parent directory, find the matching entry, and return a single-item list with the full path in `name` (stat-like query)
- Matches z/OSMF spec behavior where `path` can be a fully qualified filename
- Fixes Zowe Explorer file attribute lookups that returned 404 for file paths

## Test plan

- [ ] `curl "$BASE/zosmf/restfiles/fs?path=/tmp/test.txt"` → 200, single item with full path in name
- [ ] `curl "$BASE/zosmf/restfiles/fs?path=/tmp"` → 200, directory listing (unchanged)
- [ ] `curl "$BASE/zosmf/restfiles/fs?path=/nonexistent.txt"` → 404
- [ ] Verify Zowe Explorer can open USS files without 404 errors

Fixes #122