### PR TITLE
fix: drain terminating CRLF of chunked request body (USS upload ECONNRESET)

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -297,6 +297,15 @@ read_request_content(Session *session, char **content, size_t *content_size)
 				int bytes_read = 0;
 
 				if (chunk_size == 0) {
+					// Drain the terminating CRLF of the chunked body (RFC 7230 4.1).
+					// Leaving it unread keeps 2 bytes in the socket; closing the
+					// connection with unread inbound data triggers a TCP RST that
+					// strict HTTP clients (Zowe/Node) report as ECONNRESET /
+					// "socket hang up". Best-effort: the body is already complete
+					// here, so do not fail on a short read. Trailers are not
+					// expected (Zowe sends none); mirrors dsapi.c.
+					char crlf[2];
+					(void)receive_raw_data(session->httpc, crlf, 2);
 					done = 1;
 					break;
 				}

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -663,12 +663,9 @@ int ussPutHandler(Session *session)
 			"Failed to read request body", NULL, 0);
 		return -1;
 	}
-	if (body_len == 0) {
-		free(body);
-		sendErrorResponse(session, 400, 2, 8, 1,
-			"Empty request body", NULL, 0);
-		return -1;
-	}
+	// An empty body is valid: it truncates the file to zero length (e.g. Zowe
+	// saving an emptied file, or uploading a touch'd file). The dataset PUT
+	// handler allows this too, so do not reject body_len == 0 here.
 
 	// Text mode: ASCII→EBCDIC (IBM-1047) before writing
 	if (data_type == USS_DATA_TYPE_TEXT) {
@@ -701,8 +698,9 @@ int ussPutHandler(Session *session)
 		goto quit;
 	}
 
-	// Write body to file
-	written = ufs_fwrite(body, 1, (UINT32)body_len, fp);
+	// Write body to file (an empty body just truncates: the "w" open above
+	// already set the file to zero length, so skip the zero-length write)
+	written = body_len ? ufs_fwrite(body, 1, (UINT32)body_len, fp) : 0;
 	if (written != (UINT32)body_len) {
 		int urc = fp->error;
 		ufs_fclose(&fp);


### PR DESCRIPTION
Fixes #126

## Problem

USS file uploads via Zowe (`PUT /zosmf/restfiles/fs/{path}` with
`Transfer-Encoding: chunked`) wrote the file correctly but the client reported
`socket hang up` (Zowe CLI) / `read ECONNRESET` (Zowe Explorer). The 204
response is well-formed — httpd#66 already fixed the body-less-204
chunked-response bug — so this is a TCP **RST** caused by unread request-body
bytes, not a malformed response.

## Root cause

`read_request_content()` (`src/common.c`) consumed `0\r\n` of the final chunk
but left the terminating `\r\n` of the chunked body (RFC 7230 §4.1) unread in
the socket. Closing a connection with unread inbound data makes the TCP stack
send an RST instead of a FIN; strict clients surface that as `ECONNRESET` /
`socket hang up` and discard the valid 204.

## Fix

After the zero-size chunk, drain the trailing CRLF — best-effort, since the
body is already complete, so a short read is not treated as an error —
mirroring the dataset PUT reader at `src/dsapi.c:908-922`. With nothing left in
the socket, `close()` sends a clean FIN.

## Scope

`read_request_content()` is shared by `ussPutHandler`, `ussCreateHandler`, the
USS utilities path and `jobSubmitHandler` — all chunked requests to those
endpoints are fixed. Content-Length requests were never affected.

## Verification

- `make compiledb` clean (offline). Correctness rests on **parity** with the
  proven `dsapi.c` chunked reader in the same repo: same response path, same
  close path — only the final-CRLF drain differed.
- Behaviour needs a **live** confirmation:
  `zowe files ul ftu test.txt "/U/IBMUSER/TEST.TXT"` should complete without
  `socket hang up` / `ECONNRESET`, and a server-side capture should show the
  connection closing with FIN (no RST) after the 204.
- **Open lead if this does not fully resolve it:** the httpd#65 comments noted a
  USS 204 showing only the status line and no headers in Wireshark, while a
  dataset 204 (same `sendDefaultHeaders(204, ...)`) showed full headers. The RST
  story explains client-side truncation, but if the live test still fails,
  capture the server-side wire bytes of a USS 204 vs a dataset 204 to rule out a
  second issue in the response path.
