### PR TITLE
Support z/OSMF rename for data sets and PDS members (#125)

### DIFF
--- a/include/dsapi_err.h
+++ b/include/dsapi_err.h
@@ -16,6 +16,9 @@
 #define REASON_INVALID_ALLOC_PARAMS		3	// Invalid or missing allocation parameters
 #define REASON_DATASET_NOT_FOUND		4	// Dataset not found
 #define REASON_MEMBER_NOT_FOUND			5	// PDS member not found
+#define REASON_INVALID_RENAME_REQUEST	6	// Unsupported or malformed control request
+#define REASON_RENAME_TARGET_EXISTS		7	// Rename target already exists
+#define REASON_RENAME_FAILED			8	// Rename operation failed
 
 // Error messages for Category 6
 #define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
@@ -23,5 +26,8 @@
 #define ERR_MSG_INVALID_ALLOC_PARAMS	"Invalid or missing allocation parameters"
 #define ERR_MSG_DATASET_NOT_FOUND	"Dataset not found"
 #define ERR_MSG_MEMBER_NOT_FOUND	"PDS member not found"
+#define ERR_MSG_INVALID_RENAME_REQUEST	"Unsupported request; only 'rename' is supported"
+#define ERR_MSG_RENAME_TARGET_EXISTS	"Rename target already exists"
+#define ERR_MSG_RENAME_FAILED		"Rename operation failed"
 
 #endif // DSAPI_ERR_H

--- a/project.toml
+++ b/project.toml
@@ -45,14 +45,14 @@ naming = "fixed"
 name = "'IBMUSER.HTTPD.V3R3M1D.LOAD'"
 
 [dependencies]
-"mvslovers/crent370" = ">=1.0.7"
+"mvslovers/crent370" = ">=1.0.10"
 "mvslovers/httpd" = "=4.0.0-dev"
 "mvslovers/ufsd" = "=1.0.0-dev"
 
 [link.module]
 name = "MVSMF"
 entry = "@@CRT0"
-options = ["LIST", "MAP", "XREF", "RENT"]
+options = ["SIZE=(4000K,40K)", "LIST", "MAP", "XREF", "RENT"]
 include = [
 	"@@CRT1",
 	"CGXSTART",

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -38,6 +38,8 @@
 // Forward declarations
 static int handle_error(Session *session, int error_code, const char* message);
 static int send_standard_headers(Session *session, const char* content_type);
+static int process_rename(Session *session, const char *target_dsn,
+                          const char *target_member);
 
 // Helper functions for memory management
 static void cleanup_resources(char* buffer, FILE* fp) {
@@ -786,6 +788,16 @@ int datasetPutHandler(Session *session)
         return handle_error(session, ERR_INVALID_PARAM, "Dataset name is required");
     }
 
+    // z/OSMF control request (rename): Content-Type: application/json.
+    // Must be handled before the existence/PDS checks because the target
+    // data set (the URL name) does not exist yet.
+    {
+        const char *ct = getHeaderParam(session, "Content-Type");
+        if (ct && strstr(ct, "application/json") != NULL) {
+            return process_rename(session, dsname, NULL);
+        }
+    }
+
     // Reject PDS - this endpoint is for sequential datasets only
     if (is_pds(dsname)) {
         return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
@@ -1301,6 +1313,15 @@ int memberPutHandler(Session *session)
         return handle_error(session, ERR_INVALID_PARAM, "Dataset and member names are required");
     }
 
+    // z/OSMF control request (rename): Content-Type: application/json.
+    // Must be handled before opening the (new) member for writing.
+    {
+        const char *ct = getHeaderParam(session, "Content-Type");
+        if (ct && strstr(ct, "application/json") != NULL) {
+            return process_rename(session, dsname, member);
+        }
+    }
+
     // Get headers
     content_length_str = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_CONTENT-LENGTH");
     transfer_encoding = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_TRANSFER-ENCODING");
@@ -1643,6 +1664,114 @@ extract_json_int(const char *json, const char *key, int *out)
 	if (*pos < '0' || *pos > '9') return -1;
 	*out = atoi(pos);
 	return 0;
+}
+
+// Handle a z/OSMF rename control request (Content-Type: application/json).
+//
+//   Member rename:  PUT /ds/{dsn}({newmember})
+//                   body {"request":"rename","from-dataset":{"dsn":"{dsn}","member":"{oldmember}"}}
+//                   -> target_member = newmember (URL), oldmember from body
+//   Dataset rename: PUT /ds/{newdsn}
+//                   body {"request":"rename","from-dataset":{"dsn":"{olddsn}"}}
+//                   -> target_member = NULL, target_dsn = newdsn (URL), olddsn from body
+//
+// PDS members are renamed with __renmem() (STOW change); cataloged data sets
+// with rename() (IDCAMS ALTER). Returns 204 on success.
+__asm__("\n&FUNC    SETC 'ds_rename'");
+static int
+process_rename(Session *session, const char *target_dsn,
+               const char *target_member)
+{
+	char	*body		= NULL;
+	size_t	body_len	= 0;
+	char	request[16]	= {0};
+	char	from_dsn[MAX_DATASET_NAME] = {0};
+	char	from_member[12]	= {0};
+	int	rc;
+
+	// Read and EBCDIC-translate the JSON control body
+	if (read_request_content(session, &body, &body_len) < 0) {
+		return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+			CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
+			ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
+	}
+	http_xlate((unsigned char *)body, body_len, httpx->xlate_cp037->atoe);
+
+	// Only "rename" is supported
+	if (extract_json_string(body, "request", request, sizeof(request)) < 0 ||
+	    strcmp(request, "rename") != 0) {
+		free(body);
+		return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+			CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
+			ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
+	}
+
+	if (target_member) {
+		// Member rename: from-dataset.member is the OLD member name,
+		// the URL member is the NEW name, within the same PDS (target_dsn).
+		if (extract_json_string(body, "member", from_member,
+				sizeof(from_member)) < 0) {
+			free(body);
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
+				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
+		}
+		free(body);
+
+		rc = __renmem(target_dsn, from_member, target_member);
+		if (rc == 0) {
+			return sendDefaultHeaders(session, 204, "application/json", 0);
+		}
+		if (rc == 8 || rc == -2) {	// old member / data set not found
+			return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+				CATEGORY_SERVICE, RC_ERROR, REASON_MEMBER_NOT_FOUND,
+				ERR_MSG_MEMBER_NOT_FOUND, NULL, 0);
+		}
+		if (rc == 4) {			// new member already exists
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_RENAME_TARGET_EXISTS,
+				ERR_MSG_RENAME_TARGET_EXISTS, NULL, 0);
+		}
+		wtof("MVSMF80E Member rename failed: %s(%s) -> (%s) rc=%d",
+			target_dsn, from_member, target_member, rc);
+		return sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+			CATEGORY_SERVICE, RC_ERROR, REASON_RENAME_FAILED,
+			ERR_MSG_RENAME_FAILED, NULL, 0);
+	} else {
+		// Data set rename: from-dataset.dsn is the OLD name, the URL
+		// data set (target_dsn) is the NEW name.
+		LOCWORK	locwork;
+		char	dsn44[44];
+
+		if (extract_json_string(body, "dsn", from_dsn,
+				sizeof(from_dsn)) < 0) {
+			free(body);
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
+				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
+		}
+		free(body);
+
+		// Verify the source data set exists
+		memset(dsn44, ' ', sizeof(dsn44));
+		memcpy(dsn44, from_dsn, strlen(from_dsn));
+		memset(&locwork, 0, sizeof(locwork));
+		if (__locate(dsn44, &locwork) != 0) {
+			return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+				CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_NOT_FOUND,
+				ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
+		}
+
+		rc = rename(from_dsn, target_dsn);	// IDCAMS ALTER NEWNAME
+		if (rc == 0) {
+			return sendDefaultHeaders(session, 204, "application/json", 0);
+		}
+		wtof("MVSMF81E Dataset rename failed: %s -> %s rc=%d",
+			from_dsn, target_dsn, rc);
+		return sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+			CATEGORY_SERVICE, RC_ERROR, REASON_RENAME_FAILED,
+			ERR_MSG_RENAME_FAILED, NULL, 0);
+	}
 }
 
 __asm__("\n&FUNC    SETC 'DAPI0004'");

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -42,6 +42,7 @@ AUTH="${MVSMF_USER}:${MVSMF_PASS}"
 
 # Test dataset names
 TEST_SEQ="${MVSMF_USER}.CURL.TESTSEQ"
+TEST_SEQ2="${MVSMF_USER}.CURL.TESTSEQ2"
 TEST_PDS="${MVSMF_USER}.CURL.TESTPDS"
 
 # --- state ---
@@ -120,6 +121,7 @@ assert_json_field_exists() {
 
 cleanup_datasets() {
 	curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}" >/dev/null 2>&1 || true
+	curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ2}" >/dev/null 2>&1 || true
 	curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}" >/dev/null 2>&1 || true
 }
 
@@ -487,6 +489,51 @@ else
 	skip "write member with volume prefix (could not determine volume)"
 fi
 
+# --- Rename PDS member ---
+echo ""
+echo "--- Rename PDS Member ---"
+
+# rename TESTMBR -> TESTMBR2 (z/OSMF control request)
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${TEST_PDS}\",\"member\":\"TESTMBR\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR2)")
+assert_http_status "204" "$HTTP_CODE" "rename PDS member TESTMBR -> TESTMBR2"
+
+# new member is readable and keeps the original content
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR2)")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "200" "$HTTP_CODE" "read renamed member TESTMBR2"
+if echo "$CONTENT" | grep -q "MEMBER TEST LINE 1"; then
+	pass "renamed member content preserved"
+else
+	fail "renamed member content preserved" "expected 'MEMBER TEST LINE 1' in output"
+fi
+
+# old member no longer exists
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR)")
+assert_http_status "404" "$HTTP_CODE" "old member TESTMBR is gone after rename"
+
+# rename a non-existent member -> 404
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${TEST_PDS}\",\"member\":\"NOSUCH\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(WHATEVER)")
+assert_http_status "404" "$HTTP_CODE" "rename non-existent member returns 404"
+
+# rename back so the remaining tests operate on TESTMBR
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${TEST_PDS}\",\"member\":\"TESTMBR2\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR)")
+assert_http_status "204" "$HTTP_CODE" "rename PDS member TESTMBR2 -> TESTMBR (restore)"
+
 # --- Delete PDS member ---
 echo ""
 echo "--- Delete PDS Member ---"
@@ -518,9 +565,51 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR)")
 assert_http_status "404" "$HTTP_CODE" "delete non-existent member"
 
+# --- Rename sequential dataset ---
+echo ""
+echo "--- Rename Sequential Dataset ---"
+
+# self-contained: fresh source + clean target
+curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}"  >/dev/null 2>&1 || true
+curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ2}" >/dev/null 2>&1 || true
+
+CREATE_BODY='{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":800,"alcunit":"TRK","primary":1}'
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X POST -u "$AUTH" -H "Content-Type: application/json" \
+	-d "$CREATE_BODY" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}")
+
+if [ "$HTTP_CODE" = "201" ]; then
+	# rename TEST_SEQ -> TEST_SEQ2 (z/OSMF control request)
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" -H "Content-Type: application/json" \
+		--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${TEST_SEQ}\"}}" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ2}")
+	assert_http_status "204" "$HTTP_CODE" "rename sequential dataset TESTSEQ -> TESTSEQ2"
+
+	# the new name is cataloged
+	BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds?dslevel=${TEST_SEQ2}")
+	HTTP_CODE=$(echo "$BODY" | tail -1)
+	CONTENT=$(echo "$BODY" | sed '$d')
+	assert_http_status "200" "$HTTP_CODE" "list renamed dataset"
+	assert_json_field "$CONTENT" '.items[0].dsname' "$TEST_SEQ2" "renamed dataset present in catalog"
+
+	# rename a non-existent source -> 404
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" -H "Content-Type: application/json" \
+		--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${TEST_SEQ}.NOPE\"}}" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}.NOPE2")
+	assert_http_status "404" "$HTTP_CODE" "rename non-existent dataset returns 404"
+else
+	skip "rename sequential dataset (could not create source)"
+fi
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"
+
+curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ2}" >/dev/null 2>&1 || true
 
 HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	-X DELETE -u "$AUTH" \

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -34,6 +34,7 @@ MVS_USER=$(jq -r '.profiles.mvsmf.properties.user' "$CONFIG_FILE")
 
 # Test dataset names
 TEST_SEQ="${MVS_USER}.ZOWE.TESTSEQ"
+TEST_SEQ2="${MVS_USER}.ZOWE.TESTSEQ2"
 TEST_PDS="${MVS_USER}.ZOWE.TESTPDS"
 
 # --- state ---
@@ -129,6 +130,7 @@ assert_json_field_exists() {
 
 cleanup_datasets() {
 	zowe files delete ds "$TEST_SEQ" -f >/dev/null 2>&1 || true
+	zowe files delete ds "$TEST_SEQ2" -f >/dev/null 2>&1 || true
 	zowe files delete ds "$TEST_PDS" -f >/dev/null 2>&1 || true
 }
 
@@ -269,6 +271,23 @@ else
 	fail "moreRows=true when truncated" "expected true, got $MORE_ROWS"
 fi
 
+# --- Rename sequential dataset ---
+echo ""
+echo "--- Rename Sequential Dataset ---"
+
+RC=0
+OUTPUT=$(run_zowe files rename ds "$TEST_SEQ" "$TEST_SEQ2") || RC=$?
+assert_rc 0 "$RC" "rename sequential dataset TESTSEQ -> TESTSEQ2"
+
+RC=0
+OUTPUT=$(run_zowe_json files list ds "$TEST_SEQ2") || RC=$?
+assert_rc 0 "$RC" "list renamed dataset TESTSEQ2"
+
+# rename back so the delete test below operates on TESTSEQ
+RC=0
+OUTPUT=$(run_zowe files rename ds "$TEST_SEQ2" "$TEST_SEQ") || RC=$?
+assert_rc 0 "$RC" "rename sequential dataset TESTSEQ2 -> TESTSEQ (restore)"
+
 # --- Delete sequential dataset ---
 echo ""
 echo "--- Delete Sequential Dataset ---"
@@ -332,6 +351,32 @@ if [ "$MEMBER_WRITE_OK" -eq 1 ]; then
 	fi
 else
 	skip "read PDS member (no member written)"
+fi
+
+# --- Rename PDS member ---
+echo ""
+echo "--- Rename PDS Member ---"
+
+if [ "$MEMBER_WRITE_OK" -eq 1 ]; then
+	RC=0
+	OUTPUT=$(run_zowe files rename dsm "$TEST_PDS" TESTMBR TESTMBR2) || RC=$?
+	assert_rc 0 "$RC" "rename PDS member TESTMBR -> TESTMBR2"
+
+	RC=0
+	OUTPUT=$(run_zowe files view ds "${TEST_PDS}(TESTMBR2)") || RC=$?
+	assert_rc 0 "$RC" "read renamed member TESTMBR2"
+	if echo "$OUTPUT" | grep -q "MEMBER TEST LINE 1"; then
+		pass "renamed member content preserved"
+	else
+		fail "renamed member content preserved" "expected 'MEMBER TEST LINE 1' in output"
+	fi
+
+	# rename back so the delete test below operates on TESTMBR
+	RC=0
+	OUTPUT=$(run_zowe files rename dsm "$TEST_PDS" TESTMBR2 TESTMBR) || RC=$?
+	assert_rc 0 "$RC" "rename PDS member TESTMBR2 -> TESTMBR (restore)"
+else
+	skip "rename PDS member (no member written)"
 fi
 
 # --- Delete PDS member ---


### PR DESCRIPTION
## Summary

Implements the z/OSMF **rename** control request for data sets and PDS members,
fixing the garbage-member behaviour reported in #125.

When Zowe Explorer renames a member it sends
`PUT /zosmf/restfiles/ds/{dsn}({newmember})` with
`Content-Type: application/json` and body
`{"request":"rename","from-dataset":{"dsn":"{dsn}","member":"{oldmember}"}}`.
`memberPutHandler`/`datasetPutHandler` did not recognise the directive and wrote
the JSON body verbatim as member content — creating the `ORIGFTPD` garbage member
instead of renaming.

## Changes

- **`src/dsapi.c`** — new `process_rename()` plus a dispatch in both PUT handlers:
  when `Content-Type: application/json`, parse the control request (only `rename`
  is supported, else `400`). Dispatch is placed **before** the existence/PDS
  checks because the target name does not exist yet.
  - Member rename → `__renmem()` (crent370 STOW change): preserves the member's
    TTR and ISPF statistics, works for any RECFM incl. load modules.
  - Data set rename → `rename()` (IDCAMS `ALTER NEWNAME`), after a catalog
    `__locate()` existence check.
  - RC mapping: success → `204`; old name / data set not found → `404`; target
    already exists → `400`; other failures → `500`.
- **`include/dsapi_err.h`** — reason codes/messages for the rename paths.
- **`project.toml`**
  - bump `mvslovers/crent370` to `>=1.0.10` (provides `__renmem()`).
  - main load module link option `SIZE=(4000K,40K)`: the extra crent370 modules
    pulled in by `__renmem()` (osbdcb/osbopen/osbclose/__stow) overflowed the
    default linkage-editor tables (**IEW0374 TABLE OVERFLOW**). Same approach
    httpd already uses.
- **`tests/curl-datasets.sh`, `tests/zowe-datasets.sh`** — member and data set
  rename tests (rename, content preserved, old name gone, not-found → 404). Both
  operate on their own scratch `TEST_PDS`/`TESTSEQ` datasets.

## Verification

- ✅ `dsapi.c` cross-compiles (c2asm370, `-Wall -Werror`) and assembles on MVSCE
  (`DSAPI RC=0`).
- ✅ Full linkedit of `MVSMF` resolves `@@RENMEM`/`rename` from the crent370
  1.0.10 NCALIB (`RC=0`) with the new `SIZE=`.
- ✅ STOW `C` contract confirmed against `SYS1.MACLIB(STOW)`: the change function
  is encoded by negating R0+R1 (handled by the `STOW …,C` macro), and the area is
  old-name(8) + new-name(8) = 16 bytes — exactly what `__renmem()` builds.
- ⚠️ **Runtime rename not yet executed.** Build/link prove the module assembles
  and links; they do not prove a rename actually renames. The riskiest piece —
  STOW `C` in crent370's `__renmem()` — is hand-written assembler whose runtime
  behaviour is still unexercised.

> **Safety note for manual testing:** `__renmem()` opens a `DSORG=PO` DCB for
> OUTPUT. If the runtime `dcbdsrg1=PO` patch were wrong, OUTPUT-opening a PS-typed
> DCB against a PDS would reset the data set. The included tests use their own
> scratch PDS and are safe; **do not** hand-test against a real library (e.g.
> `SYS2.PROCLIB`) until a rename has been confirmed on a scratch PDS first.

## Related

- crent370 #35 / #36 — `__renmem()`/`__stow()` (released in crent370 1.0.10).
- The `500` on `GET …/member` in the original trace looks like an independent
  `memberListHandler` abend, not a side effect of the failed rename — should be
  tracked separately.

Fixes #125
