### PR TITLE
Fix job card buffer overflow when NOTIFY=&SYSUID precedes another parameter

### DIFF
--- a/docs/endpoints/jobs/submit.md
+++ b/docs/endpoints/jobs/submit.md
@@ -48,7 +48,7 @@ On successful completion, this request returns HTTP status code 200 (OK) and the
 
 ## Limitations
 - USER and PASSWORD are automatically injected into the job card from the authenticated user's credentials
-- The `NOTIFY` parameter in the job card is updated with the authenticated user's ID if `&SYSUID` is present
+- The `NOTIFY` parameter in the job card is updated with the authenticated user's ID if `&SYSUID` is present. `&SYSUID` may appear in any position on the job card (e.g. `NOTIFY=&SYSUID,REGION=0K`); parameters following it are preserved. Trailing blanks from fixed 80-column records are ignored during this rewrite.
 
 ## Examples
 

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -1574,6 +1574,19 @@ process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass,
                             }
                         }
 
+                        // Strip trailing blanks carried over from the fixed
+                        // 80-column input record. JCL ignores columns past the
+                        // last significant character; leaving the padding in
+                        // would overflow the 72-byte job card buffer below when
+                        // NOTIFY is not the final parameter (e.g. NOTIFY=&SYSUID
+                        // followed by REGION=).
+                        {
+                            size_t after_len = strlen(after);
+                            while (after_len > 0 && after[after_len - 1] == ' ') {
+                                after[--after_len] = '\0';
+                            }
+                        }
+
                         // Combine parts with actual user directly into lines[ii]
                         rc = snprintf(lines[ii], 72, "%sNOTIFY=%s%s",
                                     before, user, after);

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -298,6 +298,44 @@ test_submit_inline_jcl_with_intrdr_headers() {
 	fi
 }
 
+test_submit_notify_sysuid_trailing_param() {
+	echo ""
+	echo "--- Submit Job: NOTIFY=&SYSUID followed by another parameter (issue #130) ---"
+
+	# Regression for #130: VS Code submits fixed RECFM=F LRECL=80 records, so each
+	# line is padded with trailing blanks to column 80. When NOTIFY=&SYSUID was NOT
+	# the last parameter on the job card, the &SYSUID->userid rebuild carried those
+	# trailing blanks into the 72-byte job card buffer and overflowed
+	# ("MVSMF22E Buffer overflow in snprintf" -> "Failed to analyze job card" -> 400).
+	# Build 80-column-padded lines with printf to reproduce the exact condition.
+	local jcl
+	jcl=$(printf '%-80s\n%-80s\n%-80s\n' \
+		'//RGNJOB   JOB CLASS=A,MSGCLASS=H,NOTIFY=&SYSUID,REGION=8M' \
+		'//STEP1    EXEC PGM=IEFBR14' \
+		'//')
+
+	local resp
+	resp=$(do_curl PUT \
+		-H "Content-Type: text/plain" \
+		-H "X-IBM-Intrdr-Mode: TEXT" \
+		-H "X-IBM-Intrdr-Lrecl: 80" \
+		-H "X-IBM-Intrdr-Recfm: F" \
+		--data-binary "$jcl" \
+		"${BASE_URL}/zosmf/restjobs/jobs")
+	split_response "$resp"
+
+	assert_http_status "200" "$HTTP_STATUS" "submit NOTIFY=&SYSUID with trailing REGION param"
+
+	# Purge this job to avoid clutter
+	local jn ji
+	jn=$(echo "$BODY" | jq -r '.jobname')
+	ji=$(echo "$BODY" | jq -r '.jobid')
+	if [ "$jn" != "null" ] && [ "$ji" != "null" ]; then
+		wait_for_output "$jn" "$ji" || true
+		do_curl DELETE "${BASE_URL}/zosmf/restjobs/jobs/${jn}/${ji}" >/dev/null 2>&1 || true
+	fi
+}
+
 test_submit_invalid_intrdr_header() {
 	echo ""
 	echo "--- Submit Job: invalid X-IBM-Intrdr-Mode header ---"
@@ -689,6 +727,7 @@ fi
 # Submit tests
 test_submit_inline_jcl
 test_submit_inline_jcl_with_intrdr_headers
+test_submit_notify_sysuid_trailing_param
 test_submit_invalid_intrdr_header
 test_submit_invalid_content_type
 test_submit_large_jcl

--- a/tests/zowe-jobs.sh
+++ b/tests/zowe-jobs.sh
@@ -242,6 +242,40 @@ test_submit_local_file() {
 	fi
 }
 
+test_submit_notify_sysuid_trailing_param() {
+	echo ""
+	echo "--- Submit Job: NOTIFY=&SYSUID followed by another parameter (issue #130) ---"
+
+	# Regression for #130: clients that submit fixed RECFM=F LRECL=80 records pad
+	# each line with trailing blanks to column 80. When NOTIFY=&SYSUID was NOT the
+	# last parameter on the job card, the &SYSUID->userid rebuild carried those
+	# trailing blanks into the 72-byte job card buffer and overflowed -> HTTP 400.
+	# Build an 80-column-padded local file to reproduce the exact condition.
+	local tmpfile
+	tmpfile=$(mktemp /tmp/mvsmf-notify-XXXXXX.jcl)
+	printf '%-80s\n%-80s\n%-80s\n' \
+		'//RGNJOB   JOB CLASS=A,MSGCLASS=H,NOTIFY=&SYSUID,REGION=8M' \
+		'//STEP1    EXEC PGM=IEFBR14' \
+		'//' > "$tmpfile"
+
+	local output rc=0
+	output=$(run_zowe_json jobs submit local-file "$tmpfile") || rc=$?
+	rm -f "$tmpfile"
+
+	assert_rc 0 "$rc" "submit NOTIFY=&SYSUID with trailing REGION param"
+
+	if [ $rc -eq 0 ]; then
+		assert_json_field_exists "$output" '.data.jobid' "trailing-param submit has jobid"
+
+		local jn ji
+		jn=$(echo "$output" | jq -r '.data.jobname')
+		ji=$(echo "$output" | jq -r '.data.jobid')
+		echo "  Submitted: ${jn}/${ji}"
+		wait_for_output "$ji" || true
+		run_zowe jobs delete job "$ji" >/dev/null 2>&1 || true
+	fi
+}
+
 test_submit_large_jcl() {
 	echo ""
 	echo "--- Submit Job: large JCL (>2500 lines, issue #39) ---"
@@ -460,6 +494,7 @@ fi
 
 # Submit tests
 test_submit_local_file
+test_submit_notify_sysuid_trailing_param
 test_submit_large_jcl
 test_submit_from_dataset
 


### PR DESCRIPTION
## Summary

Fixes #130 — submitting a job from VS Code's right-click "Submit Job" failed with HTTP 400 ("No valid JOB card found in submitted JCL") whenever `NOTIFY=&SYSUID` was followed by another parameter (e.g. `NOTIFY=&SYSUID,REGION=0K`) on a line near column 80. The MVS console showed:

```
MVSMF22E Buffer overflow in snprintf
MVSMF22E Failed to analyze job card
MVSMF22E Emergency closing of INTRDR
```

## Root cause

VS Code submits fixed `RECFM=F LRECL=80` records, so every line is padded with trailing blanks to column 80. In `process_jobcard()` (`src/jobsapi.c`), the `&SYSUID` → userid rewrite copies the remainder of the line after `&SYSUID` into a tail buffer (`after`). When `NOTIFY=&SYSUID` was **not** the last parameter, that copy carried the trailing 80-column padding. The final `snprintf(lines[ii], 72, "%sNOTIFY=%s%s", before, user, after)` then exceeded the 72-byte job card buffer and returned the overflow error.

This matches the reporter's observations exactly:
- `&SYSUID` as the **last** parameter → works (nothing trailing copied)
- newline at column ≤ 74 → works; columns 75–80 → fails (fewer/more trailing blanks)
- literal `NOTIFY=IBMUSER` → works (no substitution)

## Fix

Trim trailing blanks from the reassembled parameter tail before rebuilding the job card line. JCL ignores columns past the last significant character, so this is safe and scoped to the NOTIFY rewrite path only. `&SYSUID` now works in any position on the job card.

## Verification

- **Host harness**: replicated `process_jobcard()`/`find_job_card_range()` logic verbatim and ran 5 cases (the `REGION=8M` repro, `&SYSUID`-last, literal `NOTIFY=IBMUSER`, the issue's continued SMP job card, and a legitimately-too-long card) — all pass, including that the genuine-overflow guard still fires (no corruption).
- **Compile**: `make compiledb` clean, no new clangd diagnostics in the changed region.
- **Behavioural verification on live MVS is pending** — the new curl/Zowe regression tests require a running mvsMF instance.

## Changes

- `src/jobsapi.c` — trim trailing blanks from the tail before the job card rebuild
- `tests/curl-jobs.sh`, `tests/zowe-jobs.sh` — regression tests submitting an 80-column-padded job card with a parameter after `NOTIFY=&SYSUID`
- `docs/endpoints/jobs/submit.md` — document that `&SYSUID` works in any position