### PR TITLE
fix: increase member DSN buffer and validate parts separately

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -22,6 +22,9 @@
 // Constants for better readability and maintainability
 #define MAX_BUFFER_SIZE 1024
 #define MAX_DATASET_NAME 44
+#define MAX_MEMBER_NAME 8
+// Qualified form DSN(MEMBER): 44 + '(' + 8 + ')' + NUL
+#define MAX_QUALIFIED_DSN (MAX_DATASET_NAME + 1 + MAX_MEMBER_NAME + 1 + 1)
 #define HTTP_OK 200
 #define DEFAULT_JOB_CLASS 'A'
 
@@ -1238,7 +1241,7 @@ int memberGetHandler(Session *session)
     char *member = NULL;
     const char *data_type_str = NULL;
     int data_type;
-    char dataset[MAX_DATASET_NAME] = {0};
+    char dataset[MAX_QUALIFIED_DSN] = {0};
     FILE *fp = NULL;
 
     // Validate parameters
@@ -1249,8 +1252,8 @@ int memberGetHandler(Session *session)
         return handle_error(session, ERR_INVALID_PARAM, "Dataset and member names are required");
     }
 
-    // Check path length
-    if (strlen(dsname) + strlen(member) + 3 > MAX_DATASET_NAME) {
+    // Validate dsname and member individually (not combined — qualified form fits MAX_QUALIFIED_DSN)
+    if (strlen(dsname) > MAX_DATASET_NAME || strlen(member) > MAX_MEMBER_NAME) {
         return handle_error(session, ERR_INVALID_PARAM, "Dataset or member name too long");
     }
 
@@ -1284,7 +1287,7 @@ int memberPutHandler(Session *session)
     int rc = 0;
     char *dsname = NULL;
     char *member = NULL;
-    char dataset[MAX_DATASET_NAME] = {0};
+    char dataset[MAX_QUALIFIED_DSN] = {0};
     FILE *fp = NULL;
     char buffer[MAX_BUFFER_SIZE];
     const char *content_length_str = NULL;
@@ -1320,6 +1323,11 @@ int memberPutHandler(Session *session)
         if (ct && strstr(ct, "application/json") != NULL) {
             return process_rename(session, dsname, member);
         }
+    }
+
+    // Validate dsname and member individually (not combined — qualified form fits MAX_QUALIFIED_DSN)
+    if (strlen(dsname) > MAX_DATASET_NAME || strlen(member) > MAX_MEMBER_NAME) {
+        return handle_error(session, ERR_INVALID_PARAM, "Dataset or member name too long");
     }
 
     // Get headers
@@ -2001,7 +2009,7 @@ int memberDeleteHandler(Session *session)
 	int rc = 0;
 	char *dsname = NULL;
 	char *member = NULL;
-	char dataset[MAX_DATASET_NAME] = {0};
+	char dataset[MAX_QUALIFIED_DSN] = {0};
 	FILE *fp = NULL;
 
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
@@ -2013,7 +2021,8 @@ int memberDeleteHandler(Session *session)
 			"Dataset and member names are required");
 	}
 
-	if (strlen(dsname) + strlen(member) + 3 > MAX_DATASET_NAME) {
+	// Validate dsname and member individually (not combined — qualified form fits MAX_QUALIFIED_DSN)
+	if (strlen(dsname) > MAX_DATASET_NAME || strlen(member) > MAX_MEMBER_NAME) {
 		return handle_error(session, ERR_INVALID_PARAM,
 			"Dataset or member name too long");
 	}

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -565,6 +565,52 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR)")
 assert_http_status "404" "$HTTP_CODE" "delete non-existent member"
 
+# --- Long DSN(member) name validation (Issue #133) ---
+# DSN <=44 and member <=8 are individually valid even when combined they exceed 44.
+# A 36-char DSN + 8-char member = 36+1+8+1=46 chars qualified: previously false 400, now passes guard.
+echo ""
+echo "--- Long DSN(member): individually valid names, combined >44 chars ---"
+
+# GET: long qualified name — validation passes, 404 because dataset doesn't exist on this system
+LONGDSN="IBMUSER.REXX370.V1R0M0D.REF.LINKLIB"  # 36 chars — valid MVS DSN
+LONGMBR="IRXTSPRM"                               # 8 chars  — valid MVS member
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${LONGDSN}(${LONGMBR})")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+if [ "$HTTP_CODE" = "400" ] && echo "$CONTENT" | grep -q "too long"; then
+	fail "long DSN(member) GET passes validation" "server still rejects valid name with 400 'too long' — guard not fixed"
+else
+	pass "long DSN(member) GET passes validation (got HTTP $HTTP_CODE, not false 400)"
+fi
+
+# DELETE: same long name — validation passes, 404 because dataset doesn't exist
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${LONGDSN}(${LONGMBR})")
+if [ "$HTTP_CODE" = "400" ]; then
+	BODY2=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LONGDSN}(${LONGMBR})")
+	if echo "$BODY2" | grep -q "too long"; then
+		fail "long DSN(member) DELETE passes validation" "server still rejects valid name with 400 'too long'"
+	else
+		pass "long DSN(member) DELETE passes validation (got HTTP $HTTP_CODE)"
+	fi
+else
+	pass "long DSN(member) DELETE passes validation (got HTTP $HTTP_CODE, not false 400)"
+fi
+
+# GET: dsname > 44 chars — must still return 400 "too long" (dsname itself is invalid)
+# IBMUSER.REXX370.V1R0M0D.REF.LINKLIB.EXTRAS.XX = 45 chars (7+1+7+1+7+1+3+1+7+1+6+1+2)
+TOOLONG_DSN="IBMUSER.REXX370.V1R0M0D.REF.LINKLIB.EXTRAS.XX"  # 45 chars
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TOOLONG_DSN}(TESTMBR)")
+assert_http_status "400" "$HTTP_CODE" "GET with dsname >44 chars returns 400"
+
+# GET: member > 8 chars — must return 400 "too long" (member name itself is invalid)
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TOOLONGMEMBER)")
+assert_http_status "400" "$HTTP_CODE" "GET with member >8 chars returns 400"
+
 # --- Rename sequential dataset ---
 echo ""
 echo "--- Rename Sequential Dataset ---"

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -403,6 +403,24 @@ else
 	skip "delete PDS member (no member written)"
 fi
 
+# --- Long DSN(member) name validation (Issue #133) ---
+# DSN <=44 and member <=8 are individually valid even when combined they exceed 44.
+# A 36-char DSN + 8-char member (combined 46 chars) was a false 400 before the fix.
+echo ""
+echo "--- Long DSN(member): individually valid names, combined >44 chars ---"
+
+LONGDSN="IBMUSER.REXX370.V1R0M0D.REF.LINKLIB"  # 36 chars — valid MVS DSN
+LONGMBR="IRXTSPRM"                               # 8 chars  — valid MVS member
+
+# GET: validation should pass; 404 is expected since this dataset isn't on the test system
+RC=0
+OUTPUT=$(run_zowe files download ds "${LONGDSN}(${LONGMBR})" --binary --file /dev/null) || RC=$?
+if echo "$OUTPUT" | grep -q "too long"; then
+	fail "long DSN(member) GET passes validation" "server still rejects valid name with 'too long' — guard not fixed"
+else
+	pass "long DSN(member) GET passes validation (rc=$RC, no false 'too long' error)"
+fi
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"


### PR DESCRIPTION
Member GET, PUT, and DELETE handlers used a 44-byte buffer sized for a bare DSN, but stored the qualified DSN(MEMBER) form that needs up to 55 bytes. The combined length guard rejected valid names whose qualified form exceeded 44 chars.

Also adds the missing guard in memberPutHandler which silently truncated long names, risking writes to the wrong member.

Fixes #133

Generated with [Claude Code](https://claude.ai/code)