### PR TITLE
Strip trailing space padding when downloading F/FB datasets in text mode

### DIFF
--- a/docs/endpoints/datasets/get.md
+++ b/docs/endpoints/datasets/get.md
@@ -25,7 +25,7 @@ or with explicit volume:
 ## Response
 On successful completion, this request returns HTTP status code 200 (OK) with the dataset content.
 
-- **Text mode**: Each record is sent as-is after EBCDIC-to-ASCII conversion
+- **Text mode**: Each record is sent after EBCDIC-to-ASCII conversion. For F/FB datasets, trailing space padding (added by MVS to fill each record to LRECL) is stripped so the output matches VB-style line endings.
 - **Binary mode**: Raw record data without conversion. For FB datasets, the exact record count is calculated from VTOC (DSCB1/DSCB4) to avoid reading past logical end-of-data.
 - **Record mode**: Each record is preceded by a 4-byte big-endian length prefix
 

--- a/docs/endpoints/datasets/members-get.md
+++ b/docs/endpoints/datasets/members-get.md
@@ -24,7 +24,7 @@ or with explicit volume:
     - `record`: Like binary, but each record prefixed with 4-byte big-endian length, Content-Type: `application/octet-stream`
 
 ## Response
-On successful completion, this request returns HTTP status code 200 (OK) with the member content.
+On successful completion, this request returns HTTP status code 200 (OK) with the member content. In text mode, trailing space padding on F/FB records is stripped so the output matches VB-style line endings.
 
 ## Error Responses
 - HTTP 500 (Internal Server Error)

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -187,10 +187,21 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 	}
 
 	if (data_type == DATA_TYPE_TEXT) {
-		/* Text mode: fgets + EBCDIC->ASCII + strlen for length */
+		/* Text mode: fgets + EBCDIC->ASCII + strlen for length.
+		   F/FB records are padded with spaces to LRECL; strip them so
+		   the download matches VB-style output (newline right after text). */
+		int is_undefined = ((fp->recfm & _FILE_RECFM_TYPE) == _FILE_RECFM_U);
+		int is_fixed = !is_undefined && !(fp->recfm & VARIABLE);
 		while (fgets(buffer, lrecl + 2, fp) > 0) {
 			size_t len = strlen(buffer);
 			http_xlate((unsigned char *)buffer, len, httpx->xlate_cp037->etoa);
+			if (is_fixed && len > 0) {
+				size_t end = len;
+				if (end > 0 && buffer[end - 1] == '\n') end--;
+				while (end > 0 && buffer[end - 1] == ' ') end--;
+				buffer[end] = '\n';
+				len = end + 1;
+			}
 			if ((rc = http_send(session->httpc,
 					(const UCHAR *)buffer, len)) < 0) {
 				break;

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -178,6 +178,13 @@ else
 	fail "read content matches" "expected 'LINE 1 TEST DATA' in output"
 fi
 
+# FB datasets pad records to LRECL with spaces; verify they are stripped on download
+if echo "$CONTENT" | grep -q "LINE 1 TEST DATA  "; then
+	fail "FB dataset strips trailing spaces" "trailing space padding found in text output"
+else
+	pass "FB dataset strips trailing spaces"
+fi
+
 # --- List datasets (two-level prefix) ---
 echo ""
 echo "--- List Datasets (two-level prefix) ---"


### PR DESCRIPTION
Fixes #135

MVS pads fixed-format (F/FB) records to LRECL with EBCDIC spaces, which appeared as trailing ASCII spaces in the downloaded content. After EBCDIC-to-ASCII translation, trailing spaces are stripped and the newline re-added, so F/FB downloads match VB-style output.

Generated with [Claude Code](https://claude.ai/code)