### PR TITLE
Fix F/FB text download: strip pad spaces before EBCDIC->ASCII translation

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -188,13 +188,18 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 
 	if (data_type == DATA_TYPE_TEXT) {
 		/* Text mode: fgets + EBCDIC->ASCII + strlen for length.
-		   F/FB records are padded with spaces to LRECL; strip them so
-		   the download matches VB-style output (newline right after text). */
+		   F/FB records are padded with EBCDIC blanks to LRECL; strip them
+		   so the download matches VB-style output (newline right after the
+		   text). The stripping must happen while the buffer is still EBCDIC,
+		   i.e. before the EBCDIC->ASCII translation: there the fgets line
+		   terminator ('\n') and the pad character (' ' = X'40') are the
+		   native character literals. Doing it after translation would compare
+		   the ASCII bytes against the compiler's EBCDIC '\n' and inject a
+		   stray control byte into the output. */
 		int is_undefined = ((fp->recfm & _FILE_RECFM_TYPE) == _FILE_RECFM_U);
 		int is_fixed = !is_undefined && !(fp->recfm & VARIABLE);
 		while (fgets(buffer, lrecl + 2, fp) > 0) {
 			size_t len = strlen(buffer);
-			http_xlate((unsigned char *)buffer, len, httpx->xlate_cp037->etoa);
 			if (is_fixed && len > 0) {
 				size_t end = len;
 				if (end > 0 && buffer[end - 1] == '\n') end--;
@@ -202,6 +207,7 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 				buffer[end] = '\n';
 				len = end + 1;
 			}
+			http_xlate((unsigned char *)buffer, len, httpx->xlate_cp037->etoa);
 			if ((rc = http_send(session->httpc,
 					(const UCHAR *)buffer, len)) < 0) {
 				break;

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -185,6 +185,20 @@ else
 	pass "FB dataset strips trailing spaces"
 fi
 
+# Regression for #138: trailing-space stripping must not leak a raw control
+# byte into the (already ASCII) output. The earlier fix re-added the newline
+# after EBCDIC->ASCII translation, writing the compiler's EBCDIC '\n' (X'15')
+# straight into the stream, which surfaced as a stray ^U (0x15) on every line
+# but the first. Download to a file and check the raw bytes.
+RAW_FILE=$(mktemp)
+curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}" > "$RAW_FILE"
+if LC_ALL=C grep -q $'\025' "$RAW_FILE"; then
+	fail "FB download has no stray control bytes" "found 0x15 (NEL/^U) in text output"
+else
+	pass "FB download has no stray control bytes"
+fi
+rm -f "$RAW_FILE"
+
 # --- List datasets (two-level prefix) ---
 echo ""
 echo "--- List Datasets (two-level prefix) ---"


### PR DESCRIPTION
Fixes #138 (regression from #136, original request #135)

## Problem
PR #136 stripped trailing space padding from F/FB datasets in **text** mode, but did the work **after** the EBCDIC→ASCII translation (`http_xlate(... etoa)`). At that point the buffer already holds ASCII bytes, yet the code compared and re-inserted the C `'\n'` literal — which the c2asm370 compiler emits as the **EBCDIC** newline (X'15'/NEL).

Two consequences, both reported in #138:
- The `buffer[end-1] == '\n'` check never matched the real ASCII LF (0x0A), so the trailing spaces were **not** removed.
- `buffer[end] = '\n'` wrote a raw X'15' into the ASCII stream, surfacing in VS Code as a stray `^U` on every line but the first (each line became `…text 0x0A 0x15`; clients split on 0x0A, so every following line starts with the orphaned 0x15).

## Fix
Move the trailing-space stripping **ahead of** `http_xlate`, so it runs while the buffer is still EBCDIC. There the fgets terminator (`'\n'`) and the pad character (`' '` = X'40') are the native character literals and match by construction. The re-added newline is then translated to ASCII LF together with the record content. This is also charset-independent — it works regardless of whether the compiler's `'\n'` is X'15' or X'25' — and avoids hardcoding ASCII codes in logic (root CLAUDE.md rule).

`read_and_send_dataset` is the shared text-read path for both sequential datasets and PDS members, and it is the only EBCDIC→ASCII read site, so this single change covers both.

## Test
Added a regression check in `tests/curl-datasets.sh` that downloads an F/FB dataset to a file and asserts the raw bytes contain no X'15' control byte — the symptom that #136's space-only assertion missed.