### PR TITLE
Desktop Phase 1: modular static/ shell + deploy-desktop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,18 @@ stop-mvs:
 		echo "$(MVS_CONTAINER) does not exist"; \
 	fi
 .PHONY: stop-mvs
+
+# --- Desktop frontend deploy (project-specific) ---
+# Upload static/ (the mvsMF Desktop) to the HTTPD UFS via our own USS REST
+# API, dogfooding it. Default matches the HTTPD's default DOCROOT (/www),
+# so the desktop is served at /mvsmf/. Override for a custom DOCROOT,
+# e.g.  make deploy-desktop DESKTOP_UFS_DIR=/wwwroot/mvsmf
+DESKTOP_UFS_DIR ?= /www/mvsmf
+
+deploy-desktop:
+	@DESKTOP_UFS_DIR='$(DESKTOP_UFS_DIR)' tools/deploy-desktop.sh
+.PHONY: deploy-desktop
+
+deploy-desktop-dry:
+	@DESKTOP_UFS_DIR='$(DESKTOP_UFS_DIR)' tools/deploy-desktop.sh --dry-run
+.PHONY: deploy-desktop-dry

--- a/docs/desktop-poc.html
+++ b/docs/desktop-poc.html
@@ -1,0 +1,1396 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>mvsMF Desktop</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+/* ============================================================
+   mvsMF Desktop — OS/2 Workplace Shell theme
+   All theme colors as CSS custom properties so a future
+   theme switcher can swap them.
+   ============================================================ */
+:root {
+  --wps-desktop-bg: linear-gradient(145deg, #1a3a5c 0%, #0d2137 60%, #1a2a3c 100%);
+  --wps-title-active: linear-gradient(90deg, #00007b 0%, #1084d0 100%);
+  --wps-title-inactive: linear-gradient(90deg, #555 0%, #888 100%);
+  --wps-title-text: #ffffff;
+  --wps-title-system: #aac8ff;
+  --wps-chrome: #d4d4d4;
+  --wps-chrome-dark: #c8c8c8;
+  --wps-chrome-darker: #b0b0b0;
+  --wps-border-light: #e8e8e8;
+  --wps-border-mid: #aaaaaa;
+  --wps-border-dark: #999999;
+  --wps-text: #1a1a1a;
+  --wps-text-dim: #555555;
+  --wps-accent: #00007b;
+  --wps-led-green: #33cc33;
+  --wps-led-red: #cc3333;
+  --wps-led-yellow: #cccc33;
+  --wps-console-bg: #1a1a1a;
+  --wps-console-fg: #33ff33;
+  --wps-shadow: 3px 3px 8px rgba(0,0,0,0.4);
+  --wps-font-ui: "Segoe UI", system-ui, sans-serif;
+  --wps-font-mono: "Cascadia Mono", "Consolas", "Menlo", monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--wps-font-ui);
+  font-size: 12px;
+  color: var(--wps-text);
+  user-select: none;
+}
+
+/* ---------- Desktop ---------- */
+#desktop {
+  position: fixed;
+  inset: 0 0 28px 0;   /* leave room for taskbar */
+  background: var(--wps-desktop-bg);
+  overflow: hidden;
+}
+#desktop::before {
+  /* subtle grid overlay */
+  content: "";
+  position: absolute; inset: 0;
+  opacity: 0.03;
+  background-image:
+    repeating-linear-gradient(0deg, #fff 0 1px, transparent 1px 40px),
+    repeating-linear-gradient(90deg, #fff 0 1px, transparent 1px 40px);
+  pointer-events: none;
+}
+
+/* ---------- Desktop icons ---------- */
+#desktop-icons {
+  position: absolute;
+  top: 16px; right: 16px;
+  display: flex; flex-direction: column; gap: 16px;
+  z-index: 1;
+}
+.desk-icon {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  width: 74px; cursor: pointer; padding: 4px; border-radius: 3px;
+}
+.desk-icon:hover { background: rgba(255,255,255,0.08); }
+.desk-icon.selected { background: rgba(16,132,208,0.35); outline: 1px dotted #fff8; }
+.desk-icon .box {
+  width: 38px; height: 38px; border-radius: 3px;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 1px 1px 0 rgba(0,0,0,0.25);
+  font-size: 20px;
+}
+.desk-icon .label {
+  font-size: 10.5px; color: #fff; text-align: center; line-height: 1.2;
+  text-shadow: 1px 1px 2px #000;
+}
+
+/* ---------- Windows ---------- */
+.wps-window {
+  position: absolute;
+  background: var(--wps-chrome);
+  border: 2px outset var(--wps-border-light);
+  box-shadow: var(--wps-shadow);
+  display: flex; flex-direction: column;
+  min-width: 200px; min-height: 120px;
+}
+.wps-window.maximized { border-width: 0; box-shadow: none; }
+.wps-window.minimized { display: none; }
+
+.wps-titlebar {
+  display: flex; align-items: center; justify-content: space-between;
+  background: var(--wps-title-inactive);
+  height: 22px; padding: 0 3px; flex: 0 0 auto;
+  cursor: default;
+}
+.wps-window.focused .wps-titlebar { background: var(--wps-title-active); }
+.wps-titlebar .tleft { display: flex; align-items: center; gap: 6px; overflow: hidden; }
+.wps-titlebar .ticon {
+  width: 14px; height: 14px; flex: 0 0 auto;
+  background: var(--wps-chrome); border: 1px outset #fff;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; color: var(--wps-accent);
+}
+.wps-titlebar .ttext {
+  font-size: 12px; font-weight: 500; color: var(--wps-title-text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.wps-titlebar .tsys { font-size: 10px; color: var(--wps-title-system); margin-left: 4px; }
+.wps-titlebar .tbtns { display: flex; gap: 2px; flex: 0 0 auto; }
+.wps-titlebar .tbtn {
+  width: 15px; height: 15px;
+  background: var(--wps-chrome); border: 1px outset #fff;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 10px; line-height: 1; color: #333; cursor: pointer;
+  font-family: var(--wps-font-ui);
+}
+.wps-titlebar .tbtn:active { border-style: inset; }
+
+.wps-toolbar {
+  display: flex; align-items: center; gap: 2px;
+  padding: 3px 4px; background: var(--wps-chrome-dark);
+  border-bottom: 1px solid var(--wps-border-mid); flex: 0 0 auto;
+}
+.wps-toolbar .tb-btn {
+  font-size: 11px; color: #333; padding: 2px 8px;
+  border: 1px outset #ddd; background: var(--wps-chrome); cursor: pointer;
+  display: flex; align-items: center; gap: 4px;
+}
+.wps-toolbar .tb-btn:active { border-style: inset; background: var(--wps-chrome-darker); }
+.wps-toolbar .tb-spacer { flex: 1; }
+
+.wps-content {
+  flex: 1; overflow: auto; background: #fff; position: relative;
+}
+
+.wps-statusbar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 2px 6px; background: var(--wps-chrome-dark);
+  border-top: 1px solid var(--wps-border-mid); flex: 0 0 auto;
+  font-size: 10px; color: var(--wps-text-dim);
+}
+
+/* Resize handles — invisible strips around the window edge */
+.rs { position: absolute; z-index: 5; }
+.rs-n  { top: -3px; left: 8px; right: 8px; height: 6px; cursor: n-resize; }
+.rs-s  { bottom: -3px; left: 8px; right: 8px; height: 6px; cursor: s-resize; }
+.rs-e  { right: -3px; top: 8px; bottom: 8px; width: 6px; cursor: e-resize; }
+.rs-w  { left: -3px; top: 8px; bottom: 8px; width: 6px; cursor: w-resize; }
+.rs-ne { top: -3px; right: -3px; width: 10px; height: 10px; cursor: ne-resize; }
+.rs-nw { top: -3px; left: -3px; width: 10px; height: 10px; cursor: nw-resize; }
+.rs-se { bottom: -3px; right: -3px; width: 10px; height: 10px; cursor: se-resize; }
+.rs-sw { bottom: -3px; left: -3px; width: 10px; height: 10px; cursor: sw-resize; }
+
+/* ---------- Taskbar ---------- */
+#taskbar {
+  position: fixed; left: 0; right: 0; bottom: 0; height: 28px;
+  background: var(--wps-chrome-dark);
+  border-top: 2px outset var(--wps-border-light);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 4px; z-index: 9000;
+}
+#taskbar .tb-left { display: flex; align-items: center; gap: 3px; overflow: hidden; }
+#start-btn {
+  display: flex; align-items: center; gap: 5px;
+  padding: 2px 10px 2px 6px; font-size: 11px; font-weight: 500;
+  color: var(--wps-accent); cursor: pointer;
+  border: 1px outset var(--wps-border-light); background: var(--wps-chrome);
+}
+#start-btn.open, #start-btn:active { border-style: inset; background: var(--wps-chrome-darker); }
+#start-btn .logo {
+  width: 14px; height: 14px; border-radius: 2px;
+  background: linear-gradient(135deg, #1084d0, #00007b);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; font-weight: 500; color: #fff;
+}
+.tb-sep { width: 1px; height: 20px; background: var(--wps-border-mid); margin: 0 3px; flex: 0 0 auto; }
+.task-btn {
+  display: flex; align-items: center; gap: 5px;
+  padding: 2px 10px; font-size: 11px; color: #333; cursor: pointer;
+  border: 1px outset var(--wps-border-light); background: var(--wps-chrome);
+  max-width: 160px; white-space: nowrap; overflow: hidden;
+}
+.task-btn span { overflow: hidden; text-overflow: ellipsis; }
+.task-btn.active {
+  border-style: inset; background: var(--wps-chrome-darker);
+  color: var(--wps-accent); font-weight: 500;
+}
+#tray {
+  display: flex; align-items: center; gap: 6px;
+  border: 1px inset var(--wps-border-mid); background: #c0c0c0;
+  padding: 1px 8px; height: 22px; flex: 0 0 auto;
+}
+#tray .led { width: 7px; height: 7px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.35); }
+#tray .sysname {
+  font-family: var(--wps-font-mono); font-size: 11px; font-weight: 500;
+  color: var(--wps-accent); cursor: pointer; border-bottom: 1px dotted var(--wps-accent);
+}
+#tray .dim { color: #999; font-size: 10px; }
+#tray .user, #tray .clock { font-family: var(--wps-font-mono); font-size: 10px; color: #444; }
+#tray .clock { color: #222; }
+
+/* ---------- Start menu ---------- */
+#startmenu {
+  position: fixed; left: 2px; bottom: 30px; width: 224px;
+  background: var(--wps-chrome); border: 2px outset var(--wps-border-light);
+  box-shadow: var(--wps-shadow); z-index: 9999; display: none;
+}
+#startmenu.open { display: block; }
+#startmenu .sm-head {
+  background: var(--wps-title-active); padding: 7px 10px;
+  display: flex; align-items: center; gap: 8px;
+}
+#startmenu .sm-head .logo {
+  width: 28px; height: 28px; border-radius: 3px; background: rgba(255,255,255,0.15);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px; font-weight: 500; color: #fff;
+}
+#startmenu .sm-head .t1 { font-size: 12px; font-weight: 500; color: #fff; }
+#startmenu .sm-head .t2 { font-size: 10px; color: var(--wps-title-system); }
+.sm-section { padding: 4px 0; }
+.sm-section + .sm-section { border-top: 1px solid var(--wps-border-mid); }
+.sm-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 12px; cursor: pointer; font-size: 12px; color: #333;
+}
+.sm-item:hover { background: var(--wps-accent); color: #fff; }
+.sm-item .pico {
+  width: 20px; height: 20px; border-radius: 2px; flex: 0 0 auto;
+  display: flex; align-items: center; justify-content: center; font-size: 13px;
+}
+.sm-item .gico { width: 20px; text-align: center; font-size: 15px; color: #555; }
+.sm-item:hover .gico { color: #fff; }
+.sm-item .chev { margin-left: auto; font-size: 12px; color: #999; }
+.sm-item:hover .chev { color: #fff; }
+
+/* Systems submenu */
+#sys-submenu {
+  position: fixed; width: 220px;
+  background: var(--wps-chrome); border: 2px outset var(--wps-border-light);
+  box-shadow: var(--wps-shadow); z-index: 10001; display: none;
+}
+#sys-submenu.open { display: block; }
+#sys-submenu .sm-item { padding: 4px 10px; }
+#sys-submenu .led { width: 7px; height: 7px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.35); flex: 0 0 auto; }
+#sys-submenu .mono { font-family: var(--wps-font-mono); font-size: 11px; }
+#sys-submenu .hostinfo { margin-left: auto; font-size: 9px; color: #888; }
+#sys-submenu .sm-item:hover .hostinfo { color: #cdf; }
+
+/* ---------- Login ---------- */
+#login-layer {
+  position: fixed; inset: 0; z-index: 10000;
+  background: var(--wps-desktop-bg);
+  display: flex; align-items: center; justify-content: center;
+}
+#login-layer::before {
+  content: ""; position: absolute; inset: 0; opacity: 0.03;
+  background-image:
+    repeating-linear-gradient(0deg, #fff 0 1px, transparent 1px 40px),
+    repeating-linear-gradient(90deg, #fff 0 1px, transparent 1px 40px);
+}
+#login-box {
+  width: 330px; background: var(--wps-chrome);
+  border: 2px outset var(--wps-border-light);
+  box-shadow: 4px 4px 12px rgba(0,0,0,0.5); position: relative;
+}
+#login-box .lb-title {
+  display: flex; align-items: center; gap: 6px;
+  background: var(--wps-title-active); height: 22px; padding: 0 4px;
+}
+#login-box .lb-title .ticon {
+  width: 14px; height: 14px; background: var(--wps-chrome); border: 1px outset #fff;
+  display: flex; align-items: center; justify-content: center; font-size: 9px; color: var(--wps-accent);
+}
+#login-box .lb-title .t { font-size: 12px; font-weight: 500; color: #fff; }
+#login-box .lb-body { padding: 18px 24px 16px; }
+.lb-logo { display: flex; justify-content: center; margin-bottom: 16px; }
+.lb-logo .inner { display: flex; align-items: center; gap: 8px; }
+.lb-logo .sq {
+  width: 36px; height: 36px; border-radius: 4px;
+  background: linear-gradient(135deg, #1084d0, #00007b);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 16px; font-weight: 500; color: #fff;
+  box-shadow: 1px 1px 0 rgba(0,0,0,0.2);
+}
+.lb-logo .t1 { font-size: 16px; font-weight: 500; letter-spacing: -0.3px; }
+.lb-logo .t2 { font-size: 10px; color: #777; }
+.lb-field { margin-bottom: 10px; }
+.lb-field label { display: block; font-size: 11px; color: var(--wps-text-dim); margin-bottom: 3px; }
+.lb-field input, .lb-field select {
+  width: 100%; padding: 5px 6px; font-size: 12px;
+  font-family: var(--wps-font-mono); color: #333;
+  border: 1px inset var(--wps-border-mid); background: #fff; outline: none;
+}
+.lb-field input:focus, .lb-field select:focus { background: #fffef0; }
+#login-status {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 8px; margin-bottom: 12px; font-size: 11px;
+  border: 1px solid transparent;
+}
+#login-status .led { width: 7px; height: 7px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.3); flex: 0 0 auto; }
+#login-status.ok    { background: #c8e6c8; border-color: #8aba8a; color: #2a5a2a; }
+#login-status.bad   { background: #e6c8c8; border-color: #ba8a8a; color: #5a2a2a; }
+#login-status.warn  { background: #e6e0c0; border-color: #bab08a; color: #5a512a; }
+#login-status.wait  { background: #d8d8d8; border-color: #aaa; color: #555; }
+.lb-buttons { display: flex; justify-content: flex-end; gap: 6px; margin-top: 14px; }
+.lb-btn {
+  padding: 4px 16px; font-size: 12px; cursor: pointer;
+  border: 1px outset #ddd; background: var(--wps-chrome); color: #333;
+  font-family: var(--wps-font-ui);
+}
+.lb-btn:active { border-style: inset; }
+.lb-btn.primary { background: var(--wps-accent); color: #fff; border-color: #3333aa; font-weight: 500; }
+.lb-links { text-align: center; margin-top: 12px; display: flex; justify-content: center; gap: 16px; }
+.lb-link { font-size: 10px; color: var(--wps-accent); cursor: pointer; border-bottom: 1px dotted var(--wps-accent); }
+#login-version {
+  position: absolute; bottom: 8px; right: 12px;
+  font-size: 10px; color: rgba(255,255,255,0.25); font-family: var(--wps-font-mono);
+}
+
+/* ---------- Program content helpers ---------- */
+.prog-pad { padding: 14px 16px; font-size: 12px; line-height: 1.6; user-select: text; }
+.prog-pad h1 { font-size: 15px; font-weight: 500; margin-bottom: 8px; }
+.prog-pad p { margin-bottom: 8px; }
+.prog-pad code {
+  font-family: var(--wps-font-mono); font-size: 11px;
+  background: #f0f0f0; padding: 0 3px; border: 1px solid #ddd;
+}
+.prog-mono {
+  font-family: var(--wps-font-mono); font-size: 11px; line-height: 1.6;
+  white-space: pre-wrap; user-select: text; padding: 10px 12px;
+}
+.sys-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px; border-bottom: 1px solid #e4e4e4; font-size: 12px;
+}
+.sys-row .led { width: 8px; height: 8px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.3); flex: 0 0 auto; }
+.sys-row .name { font-family: var(--wps-font-mono); font-weight: 500; width: 90px; }
+.sys-row .host { font-family: var(--wps-font-mono); color: #666; flex: 1; font-size: 11px; }
+.sys-row .stat { font-size: 10px; color: #888; width: 90px; }
+.sys-row .rm { color: #a33; cursor: pointer; font-size: 13px; }
+.sys-add { display: flex; gap: 6px; padding: 10px; background: #f4f4f4; border-top: 1px solid #ddd; }
+.sys-add input {
+  border: 1px inset var(--wps-border-mid); padding: 3px 6px;
+  font-family: var(--wps-font-mono); font-size: 11px; outline: none;
+}
+.sys-add .in-name { width: 80px; } .sys-add .in-host { flex: 1; } .sys-add .in-port { width: 56px; }
+</style>
+</head>
+<body>
+
+<!-- ================= Login layer ================= -->
+<div id="login-layer">
+  <div id="login-box">
+    <div class="lb-title">
+      <div class="ticon"><i class="ti ti-lock"></i></div>
+      <span class="t">mvsMF Desktop — Login</span>
+    </div>
+    <div class="lb-body">
+      <div class="lb-logo">
+        <div class="inner">
+          <div class="sq">M</div>
+          <div><div class="t1">mvs<span style="color:#1084d0;">MF</span> Desktop</div>
+               <div class="t2">MVS management facility</div></div>
+        </div>
+      </div>
+      <div class="lb-field">
+        <label for="login-system">System</label>
+        <select id="login-system"></select>
+      </div>
+      <div id="login-status" class="wait">
+        <span class="led" style="background:#999;"></span>
+        <span id="login-status-text">Checking connection…</span>
+      </div>
+      <div class="lb-field">
+        <label for="login-user">Username</label>
+        <input id="login-user" autocomplete="username" spellcheck="false">
+      </div>
+      <div class="lb-field">
+        <label for="login-pass">Password</label>
+        <input id="login-pass" type="password" autocomplete="current-password">
+      </div>
+      <div class="lb-buttons">
+        <button class="lb-btn" id="login-cancel">Cancel</button>
+        <button class="lb-btn primary" id="login-submit">Login</button>
+      </div>
+      <div class="lb-links">
+        <span class="lb-link" id="login-manage">Manage systems…</span>
+        <span class="lb-link" id="login-demo">Demo mode</span>
+      </div>
+    </div>
+  </div>
+  <div id="login-version">mvsMF Desktop v2.0.0-alpha1</div>
+</div>
+
+<!-- ================= Desktop ================= -->
+<div id="desktop" style="display:none;">
+  <div id="desktop-icons"></div>
+</div>
+
+<!-- ================= Taskbar ================= -->
+<div id="taskbar" style="display:none;">
+  <div class="tb-left">
+    <div id="start-btn"><span class="logo">M</span>Start</div>
+    <div class="tb-sep"></div>
+    <div id="task-buttons" style="display:flex;gap:3px;overflow:hidden;"></div>
+  </div>
+  <div id="tray">
+    <span class="led" id="tray-led" style="background:var(--wps-led-green);"></span>
+    <span class="sysname" id="tray-sys">—</span>
+    <span class="dim">|</span>
+    <span class="user" id="tray-user">—</span>
+    <span class="dim">|</span>
+    <span class="clock" id="tray-clock">--:--:--</span>
+  </div>
+</div>
+
+<!-- ================= Start menu ================= -->
+<div id="startmenu">
+  <div class="sm-head">
+    <div class="logo">M</div>
+    <div><div class="t1">mvsMF Desktop</div><div class="t2">v2.0.0-alpha1</div></div>
+  </div>
+  <div class="sm-section" id="sm-programs"></div>
+  <div class="sm-section">
+    <div class="sm-item" id="sm-systems">
+      <span class="gico"><i class="ti ti-server"></i></span>Systems
+      <span class="chev"><i class="ti ti-chevron-right"></i></span>
+    </div>
+    <div class="sm-item" id="sm-settings">
+      <span class="gico"><i class="ti ti-settings"></i></span>Settings
+    </div>
+    <div class="sm-item" id="sm-about">
+      <span class="gico"><i class="ti ti-info-circle"></i></span>About
+    </div>
+    <div class="sm-item" id="sm-logout">
+      <span class="gico"><i class="ti ti-logout"></i></span>Logout
+    </div>
+  </div>
+</div>
+<div id="sys-submenu"></div>
+
+<script>
+"use strict";
+/* ============================================================
+   mvsMF Desktop — Phase 1 prototype (single file)
+   Sections: SafeStore, SystemRegistry, Session, WindowManager,
+   Taskbar, StartMenu, ProgramRegistry, demo programs, Login.
+   ============================================================ */
+
+/* ---------- SafeStore: localStorage with in-memory fallback ----------
+   Sandboxed previews may block localStorage; a real deployment
+   on the HTTPD UFS uses it normally. */
+const SafeStore = (() => {
+  let mem = {};
+  let ok = false;
+  try { localStorage.setItem("__t", "1"); localStorage.removeItem("__t"); ok = true; } catch (e) { ok = false; }
+  return {
+    get(key, fallback) {
+      try {
+        const raw = ok ? localStorage.getItem(key) : mem[key];
+        return raw ? JSON.parse(raw) : fallback;
+      } catch (e) { return fallback; }
+    },
+    set(key, value) {
+      const raw = JSON.stringify(value);
+      if (ok) { try { localStorage.setItem(key, raw); } catch (e) {} }
+      mem[key] = raw;
+    }
+  };
+})();
+
+/* ---------- System registry ---------- */
+const SystemRegistry = {
+  KEY: "mvsmf.systems",
+  defaults: { systems: [], defaultSystem: null },
+  load() { return SafeStore.get(this.KEY, this.defaults); },
+  save(data) { SafeStore.set(this.KEY, data); },
+  list() { return this.load().systems; },
+  get(name) { return this.list().find(s => s.name === name); },
+  add(sys) {
+    const d = this.load();
+    d.systems = d.systems.filter(s => s.name !== sys.name);
+    d.systems.push(sys);
+    this.save(d);
+  },
+  remove(name) {
+    const d = this.load();
+    d.systems = d.systems.filter(s => s.name !== name);
+    this.save(d);
+  },
+  baseUrl(sys) {
+    // local system follows the page protocol (works behind a TLS proxy);
+    // remote MVS 3.8j systems are plain http
+    const proto = sys.local ? location.protocol : "http:";
+    return `${proto}//${sys.host}:${sys.port}`;
+  },
+  /* Derive the "local" system from the URL this page was served from.
+     When the desktop is deployed on the HTTPD UFS, that host IS the
+     default mvsMF system — no manual configuration needed. */
+  ensureLocal() {
+    if (!/^https?:$/.test(location.protocol) || !location.hostname) return null;
+    const host = location.hostname;
+    const port = location.port ? parseInt(location.port, 10)
+                               : (location.protocol === "https:" ? 443 : 80);
+    const d = this.load();
+    let sys = d.systems.find(s => s.host === host && s.port === port);
+    if (!sys) {
+      // derive a system name from the first hostname label,
+      // e.g. MVSDEV from mvsdev.lan (max 8 chars, mainframe style)
+      let name = host.split(".")[0].toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 8) || "LOCAL";
+      if (d.systems.some(s => s.name === name)) name = "LOCAL";
+      sys = { name, host, port, local: true };
+      d.systems.unshift(sys);
+    } else {
+      sys.local = true;
+    }
+    d.systems.forEach(s => { if (s !== sys) delete s.local; });
+    d.defaultSystem = sys.name;
+    this.save(d);
+    return sys;
+  }
+};
+
+/* ---------- Connection check via /zosmf/info ---------- */
+async function checkSystem(sys, auth) {
+  // auth: optional {user, pass} to verify credentials
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 4000);
+  try {
+    // Anonymous probe stays a "simple request" (no custom headers) so it
+    // avoids a CORS preflight; authenticated checks send the full headers.
+    const headers = {};
+    if (auth) {
+      headers["Authorization"] = "Basic " + btoa(auth.user + ":" + auth.pass);
+      headers["X-CSRF-ZOSMF-HEADER"] = "true";
+    }
+    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { headers, signal: ctl.signal });
+    clearTimeout(timer);
+    if (resp.ok) {
+      let info = null;
+      try { info = await resp.json(); } catch (e) {}
+      return { status: "connected", info };
+    }
+    if (resp.status === 401 || resp.status === 403) return { status: "auth_failed" };
+    return { status: "error", code: resp.status };
+  } catch (e) {
+    clearTimeout(timer);
+    // Fetch failed — either the host is down or the browser blocked the
+    // response (missing CORS headers on a cross-origin request). An
+    // opaque no-cors probe still resolves when the host is reachable.
+    try {
+      const ctl2 = new AbortController();
+      const t2 = setTimeout(() => ctl2.abort(), 4000);
+      await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { mode: "no-cors", signal: ctl2.signal });
+      clearTimeout(t2);
+      return { status: "cors_blocked" };
+    } catch (e2) {
+      return { status: "unreachable" };
+    }
+  }
+}
+
+/* ---------- Session (current login) ---------- */
+const Session = {
+  system: null,     // system object from registry
+  user: null,
+  pass: null,
+  demo: false,
+  /* Build a system context handed to every program window. */
+  contextFor(systemName) {
+    const sys = systemName ? SystemRegistry.get(systemName) : this.system;
+    const self = this;
+    return {
+      name: sys ? sys.name : (self.demo ? "DEMO" : "?"),
+      host: sys ? sys.host : "demo.local",
+      port: sys ? sys.port : 0,
+      baseUrl: sys ? SystemRegistry.baseUrl(sys) : "",
+      user: self.user,
+      demo: self.demo,
+      async apiFetch(path, options = {}) {
+        if (self.demo) throw new Error("demo mode: no backend");
+        options.headers = Object.assign({
+          "Authorization": "Basic " + btoa(self.user + ":" + self.pass),
+          "X-CSRF-ZOSMF-HEADER": "true"
+        }, options.headers || {});
+        return fetch(this.baseUrl + path, options);
+      }
+    };
+  }
+};
+
+/* ---------- Window manager ---------- */
+const WM = (() => {
+  const windows = new Map();   // id -> win record
+  let zTop = 10;
+  let seq = 0;
+  let cascade = 0;
+  const desktop = () => document.getElementById("desktop");
+
+  function focus(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    zTop += 1;
+    w.el.style.zIndex = zTop;
+    windows.forEach(x => x.el.classList.toggle("focused", x.id === id));
+    Taskbar.setActive(id);
+  }
+
+  function focusTopmost() {
+    let best = null;
+    windows.forEach(w => {
+      if (w.state === "minimized") return;
+      const z = parseInt(w.el.style.zIndex || "0", 10);
+      if (!best || z > best.z) best = { id: w.id, z };
+    });
+    if (best) focus(best.id); else Taskbar.setActive(null);
+  }
+
+  function open(program, systemName) {
+    const id = "win_" + (++seq);
+    const ctx = Session.contextFor(systemName);
+    const dsk = desktop().getBoundingClientRect();
+
+    const width = Math.min(program.defaultWidth || 500, dsk.width - 40);
+    const height = Math.min(program.defaultHeight || 380, dsk.height - 40);
+    cascade = (cascade + 1) % 8;
+    const x = 60 + cascade * 26;
+    const y = 30 + cascade * 24;
+
+    const el = document.createElement("div");
+    el.className = "wps-window focused";
+    el.style.cssText = `left:${x}px; top:${y}px; width:${width}px; height:${height}px; z-index:${++zTop};`;
+
+    // Title bar
+    const tb = document.createElement("div");
+    tb.className = "wps-titlebar";
+    tb.innerHTML = `
+      <div class="tleft">
+        <div class="ticon"><i class="ti ${program.icon}"></i></div>
+        <span class="ttext">${program.name}<span class="tsys">— ${ctx.name}</span></span>
+      </div>
+      <div class="tbtns">
+        <div class="tbtn" data-act="min">_</div>
+        <div class="tbtn" data-act="max">□</div>
+        <div class="tbtn" data-act="close" style="font-weight:500;">×</div>
+      </div>`;
+    el.appendChild(tb);
+
+    // Optional toolbar
+    if (program.toolbar && program.toolbar.length) {
+      const bar = document.createElement("div");
+      bar.className = "wps-toolbar";
+      program.toolbar.forEach(item => {
+        const b = document.createElement("div");
+        b.className = "tb-btn";
+        b.innerHTML = (item.icon ? `<i class="ti ${item.icon}" style="font-size:13px;"></i>` : "") + item.label;
+        b.addEventListener("click", () => item.onClick && item.onClick(winCtx));
+        bar.appendChild(b);
+      });
+      el.appendChild(bar);
+    }
+
+    // Content
+    const content = document.createElement("div");
+    content.className = "wps-content";
+    el.appendChild(content);
+
+    // Optional status bar
+    let statusEl = null;
+    if (program.statusBar) {
+      statusEl = document.createElement("div");
+      statusEl.className = "wps-statusbar";
+      statusEl.innerHTML = `<span class="sb-l"></span><span class="sb-r">${ctx.name} — ${ctx.user || ""}</span>`;
+      el.appendChild(statusEl);
+    }
+
+    // Resize handles
+    ["n","s","e","w","ne","nw","se","sw"].forEach(dir => {
+      const h = document.createElement("div");
+      h.className = "rs rs-" + dir;
+      h.dataset.dir = dir;
+      el.appendChild(h);
+    });
+
+    desktop().appendChild(el);
+
+    const win = {
+      id, program, el, content, statusEl,
+      state: "normal",
+      prevRect: null,
+      title: program.name,
+      systemName: ctx.name
+    };
+    windows.set(id, win);
+
+    // Context object handed to the program instance
+    const winCtx = {
+      windowId: id,
+      system: ctx,
+      contentEl: content,
+      setTitle(t) {
+        win.title = t;
+        tb.querySelector(".ttext").innerHTML = `${t}<span class="tsys">— ${ctx.name}</span>`;
+        Taskbar.rename(id, t);
+      },
+      setStatus(text) { if (statusEl) statusEl.querySelector(".sb-l").textContent = text; },
+      close() { close(id); }
+    };
+    win.ctx = winCtx;
+
+    // Mount program content
+    try {
+      const node = program.create(winCtx);
+      if (node) content.appendChild(node);
+    } catch (e) {
+      content.innerHTML = `<div class="prog-pad" style="color:#a33;">Program error: ${e.message}</div>`;
+    }
+
+    // --- events ---
+    el.addEventListener("pointerdown", () => focus(id));
+
+    tb.addEventListener("pointerdown", ev => {
+      if (ev.target.closest(".tbtn")) return;
+      startDrag(win, ev);
+    });
+    tb.addEventListener("dblclick", ev => {
+      if (ev.target.closest(".tbtn")) return;
+      toggleMax(id);
+    });
+    tb.querySelectorAll(".tbtn").forEach(btn => {
+      btn.addEventListener("click", ev => {
+        ev.stopPropagation();
+        const act = btn.dataset.act;
+        if (act === "close") close(id);
+        else if (act === "min") minimize(id);
+        else if (act === "max") toggleMax(id);
+      });
+    });
+
+    el.querySelectorAll(".rs").forEach(h => {
+      h.addEventListener("pointerdown", ev => startResize(win, ev, h.dataset.dir));
+    });
+
+    Taskbar.add(id, program, win.title);
+    focus(id);
+    return id;
+  }
+
+  function close(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    try { w.program.destroy && w.program.destroy(w.ctx); } catch (e) {}
+    w.el.remove();
+    windows.delete(id);
+    Taskbar.remove(id);
+    focusTopmost();
+  }
+
+  function minimize(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    w.state = "minimized";
+    w.el.classList.add("minimized");
+    Taskbar.setActive(null);
+    focusTopmost();
+  }
+
+  function restore(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    w.state = w.prevRect ? "maximized" : "normal";
+    w.el.classList.remove("minimized");
+    focus(id);
+  }
+
+  function toggleMax(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    const dsk = desktop().getBoundingClientRect();
+    if (w.state !== "maximized") {
+      w.prevRect = {
+        left: w.el.style.left, top: w.el.style.top,
+        width: w.el.style.width, height: w.el.style.height
+      };
+      w.el.style.left = "0px"; w.el.style.top = "0px";
+      w.el.style.width = dsk.width + "px"; w.el.style.height = dsk.height + "px";
+      w.el.classList.add("maximized");
+      w.state = "maximized";
+    } else {
+      const p = w.prevRect || { left: "60px", top: "40px", width: "500px", height: "380px" };
+      w.el.style.left = p.left; w.el.style.top = p.top;
+      w.el.style.width = p.width; w.el.style.height = p.height;
+      w.el.classList.remove("maximized");
+      w.state = "normal";
+      w.prevRect = null;
+    }
+  }
+
+  /* Dragging via pointer events; keeps the title bar reachable. */
+  function startDrag(win, ev) {
+    if (win.state === "maximized") return;
+    ev.preventDefault();
+    focus(win.id);
+    const startX = ev.clientX, startY = ev.clientY;
+    const rect = win.el.getBoundingClientRect();
+    const dsk = desktop().getBoundingClientRect();
+    const offX = startX - rect.left, offY = startY - rect.top;
+
+    function move(e) {
+      let nx = e.clientX - offX;
+      let ny = e.clientY - offY;
+      // constraints: keep >= 60px of window on screen, titlebar never above top
+      nx = Math.max(-(rect.width - 60), Math.min(nx, dsk.width - 60));
+      ny = Math.max(0, Math.min(ny, dsk.height - 24));
+      win.el.style.left = nx + "px";
+      win.el.style.top = ny + "px";
+    }
+    function up() {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+    }
+    document.addEventListener("pointermove", move);
+    document.addEventListener("pointerup", up);
+  }
+
+  /* Resizing from any edge/corner; respects program min sizes. */
+  function startResize(win, ev, dir) {
+    if (win.state === "maximized") return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    focus(win.id);
+    const rect = win.el.getBoundingClientRect();
+    const dskRect = desktop().getBoundingClientRect();
+    const startX = ev.clientX, startY = ev.clientY;
+    const minW = win.program.minWidth || 240;
+    const minH = win.program.minHeight || 140;
+    const orig = { left: rect.left - dskRect.left, top: rect.top - dskRect.top, w: rect.width, h: rect.height };
+
+    function move(e) {
+      const dx = e.clientX - startX, dy = e.clientY - startY;
+      let { left, top, w, h } = orig;
+      if (dir.includes("e")) w = Math.max(minW, orig.w + dx);
+      if (dir.includes("s")) h = Math.max(minH, orig.h + dy);
+      if (dir.includes("w")) { w = Math.max(minW, orig.w - dx); left = orig.left + (orig.w - w); }
+      if (dir.includes("n")) { h = Math.max(minH, orig.h - dy); top = Math.max(0, orig.top + (orig.h - h)); h = orig.h + (orig.top - top); }
+      win.el.style.left = left + "px";
+      win.el.style.top = top + "px";
+      win.el.style.width = w + "px";
+      win.el.style.height = h + "px";
+    }
+    function up() {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+    }
+    document.addEventListener("pointermove", move);
+    document.addEventListener("pointerup", up);
+  }
+
+  function isMinimized(id) {
+    const w = windows.get(id);
+    return w ? w.state === "minimized" : false;
+  }
+  function isFocused(id) {
+    const w = windows.get(id);
+    return w ? w.el.classList.contains("focused") : false;
+  }
+
+  return { open, close, minimize, restore, focus, isMinimized, isFocused };
+})();
+
+/* ---------- Taskbar ---------- */
+const Taskbar = (() => {
+  const container = () => document.getElementById("task-buttons");
+  const buttons = new Map();
+
+  function add(id, program, title) {
+    const b = document.createElement("div");
+    b.className = "task-btn active";
+    b.innerHTML = `<i class="ti ${program.icon}" style="font-size:12px;flex:0 0 auto;"></i><span>${title}</span>`;
+    b.addEventListener("click", () => {
+      if (WM.isMinimized(id)) WM.restore(id);
+      else if (WM.isFocused(id)) WM.minimize(id);
+      else WM.focus(id);
+    });
+    container().appendChild(b);
+    buttons.set(id, b);
+  }
+  function remove(id) {
+    const b = buttons.get(id);
+    if (b) b.remove();
+    buttons.delete(id);
+  }
+  function rename(id, title) {
+    const b = buttons.get(id);
+    if (b) b.querySelector("span").textContent = title;
+  }
+  function setActive(id) {
+    buttons.forEach((b, key) => b.classList.toggle("active", key === id));
+  }
+  return { add, remove, rename, setActive };
+})();
+
+/* ---------- Clock ---------- */
+setInterval(() => {
+  const el = document.getElementById("tray-clock");
+  if (el) el.textContent = new Date().toTimeString().slice(0, 8);
+}, 1000);
+
+/* ---------- Program registry ---------- */
+const Programs = (() => {
+  const list = [];
+  function register(p) { list.push(p); }
+  function get(id) { return list.find(p => p.id === id); }
+  function all() { return list.slice(); }
+  return { register, get, all };
+})();
+
+/* ============================================================
+   Demo programs — prove the window manager & plugin API work.
+   Real programs (Dataset browser, Spool browser, …) follow in
+   Phase 2 and use exactly this interface.
+   ============================================================ */
+
+/* Welcome */
+Programs.register({
+  id: "welcome",
+  name: "Welcome",
+  icon: "ti-home",
+  iconBg: "#1084d0", iconColor: "#fff",
+  defaultWidth: 460, defaultHeight: 330,
+  desktopIcon: true,
+  create(ctx) {
+    const d = document.createElement("div");
+    d.className = "prog-pad";
+    d.innerHTML = `
+      <h1>Welcome to mvsMF Desktop</h1>
+      <p>This is the <b>Phase 1 shell prototype</b>: window manager,
+      taskbar, start menu, login and the program plugin API.</p>
+      <p>Try it out:</p>
+      <p>• Drag windows by their title bar<br>
+         • Resize from any edge or corner<br>
+         • Double-click the title bar to maximize<br>
+         • Minimize to the taskbar and bring windows back<br>
+         • Open several windows and watch the z-order</p>
+      <p>Programs are plugins — each one registers with
+      <code>Programs.register({...})</code> and receives a system context
+      with an authenticated <code>apiFetch()</code>.</p>
+      <p style="color:#777;">Connected to <code>${ctx.system.name}</code>
+      as <code>${ctx.system.user || "demo"}</code>.</p>`;
+    return d;
+  }
+});
+
+/* System info — first program that actually talks to mvsMF */
+Programs.register({
+  id: "sysinfo",
+  name: "System info",
+  icon: "ti-info-circle",
+  iconBg: "#4db84d", iconColor: "#fff",
+  defaultWidth: 480, defaultHeight: 340,
+  desktopIcon: true,
+  statusBar: true,
+  toolbar: [
+    { label: "Refresh", icon: "ti-refresh", onClick(ctx) { ctx._load && ctx._load(); } }
+  ],
+  create(ctx) {
+    const d = document.createElement("div");
+    d.className = "prog-mono";
+    d.textContent = "Loading /zosmf/info …";
+
+    ctx._load = async () => {
+      ctx.setStatus("GET /zosmf/info …");
+      if (ctx.system.demo) {
+        // canned response so the shell can be explored without a backend
+        d.textContent = JSON.stringify({
+          zosmf_saf_realm: "SAFRealm",
+          zosmf_port: "1080",
+          zosmf_full_version: "2.0.0",
+          api_version: "1",
+          zos_version: "MVS 3.8j",
+          zosmf_hostname: "demo.local",
+          note: "demo mode — canned data, no backend call"
+        }, null, 2);
+        ctx.setStatus("Demo mode — canned data");
+        return;
+      }
+      try {
+        const resp = await ctx.system.apiFetch("/zosmf/info");
+        const body = await resp.text();
+        try { d.textContent = JSON.stringify(JSON.parse(body), null, 2); }
+        catch (e) { d.textContent = body; }
+        ctx.setStatus(`HTTP ${resp.status} — ${ctx.system.baseUrl}/zosmf/info`);
+      } catch (e) {
+        d.textContent = "Request failed: " + e.message;
+        ctx.setStatus("Request failed");
+      }
+    };
+    ctx._load();
+    return d;
+  }
+});
+
+/* Systems manager */
+Programs.register({
+  id: "systems",
+  name: "Systems",
+  icon: "ti-server",
+  iconBg: "#888880", iconColor: "#fff",
+  defaultWidth: 460, defaultHeight: 320,
+  desktopIcon: false,
+  statusBar: true,
+  create(ctx) {
+    const wrap = document.createElement("div");
+    wrap.style.cssText = "display:flex;flex-direction:column;height:100%;";
+    const listEl = document.createElement("div");
+    listEl.style.cssText = "flex:1;overflow:auto;";
+    wrap.appendChild(listEl);
+
+    const addBar = document.createElement("div");
+    addBar.className = "sys-add";
+    addBar.innerHTML = `
+      <input class="in-name" placeholder="NAME" maxlength="8">
+      <input class="in-host" placeholder="host / IP">
+      <input class="in-port" placeholder="1080" maxlength="5">
+      <button class="lb-btn" style="padding:2px 10px;">Add</button>`;
+    wrap.appendChild(addBar);
+
+    async function render() {
+      const systems = SystemRegistry.list();
+      listEl.innerHTML = "";
+      ctx.setStatus(`${systems.length} system(s) configured`);
+      for (const s of systems) {
+        const row = document.createElement("div");
+        row.className = "sys-row";
+        row.innerHTML = `
+          <span class="led" style="background:#999;"></span>
+          <span class="name">${s.name}${s.local ? ' <span style="color:#888;font-size:9px;">(local)</span>' : ""}</span>
+          <span class="host">${s.host}:${s.port}</span>
+          <span class="stat">checking…</span>
+          ${s.local ? "" : '<span class="rm" title="Remove"><i class="ti ti-trash"></i></span>'}`;
+        const rm = row.querySelector(".rm");
+        if (rm) rm.addEventListener("click", () => {
+          SystemRegistry.remove(s.name);
+          render();
+        });
+        listEl.appendChild(row);
+        // async status check per system
+        checkSystem(s).then(res => {
+          const led = row.querySelector(".led");
+          const stat = row.querySelector(".stat");
+          if (res.status === "connected") { led.style.background = "var(--wps-led-green)"; stat.textContent = "connected"; }
+          else if (res.status === "auth_failed") { led.style.background = "var(--wps-led-yellow)"; stat.textContent = "auth required"; }
+          else if (res.status === "cors_blocked") { led.style.background = "var(--wps-led-yellow)"; stat.textContent = "cors blocked"; }
+          else { led.style.background = "var(--wps-led-red)"; stat.textContent = res.status; }
+        });
+      }
+    }
+
+    addBar.querySelector("button").addEventListener("click", () => {
+      const name = addBar.querySelector(".in-name").value.trim().toUpperCase();
+      const host = addBar.querySelector(".in-host").value.trim();
+      const port = parseInt(addBar.querySelector(".in-port").value.trim() || "1080", 10);
+      if (!name || !host) return;
+      SystemRegistry.add({ name, host, port });
+      addBar.querySelectorAll("input").forEach(i => i.value = "");
+      render();
+      Login.refreshSystems();   // keep login dropdown in sync
+      StartMenu.refreshSystems();
+    });
+
+    render();
+    return wrap;
+  }
+});
+
+/* About */
+Programs.register({
+  id: "about",
+  name: "About",
+  icon: "ti-info-circle",
+  iconBg: "#666", iconColor: "#fff",
+  defaultWidth: 380, defaultHeight: 260,
+  desktopIcon: false,
+  create() {
+    const d = document.createElement("div");
+    d.className = "prog-pad";
+    d.innerHTML = `
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
+        <div style="width:40px;height:40px;border-radius:4px;background:linear-gradient(135deg,#1084d0,#00007b);display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:500;color:#fff;">M</div>
+        <div><div style="font-size:15px;font-weight:500;">mvsMF Desktop</div>
+        <div style="color:#777;font-size:11px;">Version 2.0.0-alpha1 — Phase 1 shell</div></div>
+      </div>
+      <p>A browser desktop for MVS 3.8j, inspired by the OS/2 Workplace Shell.</p>
+      <p>Backend: <code>mvsMF</code> (z/OSMF-compatible REST API),
+      <code>httprexx</code>, <code>httpjes</code> on <code>HTTPD</code>.</p>
+      <p style="color:#777;">mvslovers — running modern APIs on 1981 iron.</p>`;
+    return d;
+  }
+});
+
+/* Stub for the Phase 2 programs — proves multiple instances & cascade */
+function registerStub(id, name, icon, iconBg, iconColor) {
+  Programs.register({
+    id, name, icon, iconBg, iconColor,
+    defaultWidth: 400, defaultHeight: 220,
+    desktopIcon: true,
+    stub: true,
+    create() {
+      const d = document.createElement("div");
+      d.className = "prog-pad";
+      d.innerHTML = `
+        <h1>${name}</h1>
+        <p>This program arrives in <b>Phase 2</b>.</p>
+        <p>The window you are looking at is served by the plugin API —
+        the real implementation will use the same interface and the
+        system context's <code>apiFetch()</code>.</p>`;
+      return d;
+    }
+  });
+}
+registerStub("datasets",  "Dataset browser",  "ti-database",   "#e8d44d", "#5a4e00");
+registerStub("ussfiles",  "USS file manager", "ti-folder",     "#4d8de8", "#fff");
+registerStub("spool",     "JES spool browser","ti-list",       "#4db84d", "#fff");
+registerStub("console",   "MVS console",      "ti-terminal-2", "#1a1a1a", "#33ff33");
+registerStub("rexx",      "REXX workbench",   "ti-code",       "#b84d4d", "#fff");
+registerStub("jobsubmit", "Job submit",       "ti-upload",     "#8855bb", "#fff");
+registerStub("localfiles","Local files",      "ti-files",      "#dd8833", "#fff");
+
+/* ---------- Desktop icons ---------- */
+function buildDesktopIcons() {
+  const host = document.getElementById("desktop-icons");
+  host.innerHTML = "";
+  Programs.all().filter(p => p.desktopIcon).forEach(p => {
+    const ic = document.createElement("div");
+    ic.className = "desk-icon";
+    ic.innerHTML = `
+      <div class="box" style="background:${p.iconBg};">
+        <i class="ti ${p.icon}" style="color:${p.iconColor};"></i>
+      </div>
+      <span class="label">${p.name}</span>`;
+    ic.addEventListener("click", () => {
+      document.querySelectorAll(".desk-icon.selected").forEach(x => x.classList.remove("selected"));
+      ic.classList.add("selected");
+    });
+    ic.addEventListener("dblclick", () => WM.open(p));
+    host.appendChild(ic);
+  });
+  // click on empty desktop clears selection
+  document.getElementById("desktop").addEventListener("pointerdown", ev => {
+    if (ev.target.id === "desktop")
+      document.querySelectorAll(".desk-icon.selected").forEach(x => x.classList.remove("selected"));
+  });
+}
+
+/* ---------- Start menu ---------- */
+const StartMenu = (() => {
+  const menu = () => document.getElementById("startmenu");
+  const btn = () => document.getElementById("start-btn");
+  const submenu = () => document.getElementById("sys-submenu");
+
+  function build() {
+    const host = document.getElementById("sm-programs");
+    host.innerHTML = "";
+    Programs.all().filter(p => p.id !== "about").forEach(p => {
+      const item = document.createElement("div");
+      item.className = "sm-item";
+      item.innerHTML = `
+        <span class="pico" style="background:${p.iconBg};">
+          <i class="ti ${p.icon}" style="color:${p.iconColor};"></i>
+        </span>${p.name}`;
+      item.addEventListener("click", () => { hide(); WM.open(p); });
+      host.appendChild(item);
+    });
+
+    document.getElementById("sm-systems").addEventListener("click", ev => {
+      ev.stopPropagation();
+      toggleSubmenu();
+    });
+    document.getElementById("sm-settings").addEventListener("click", () => {
+      hide();
+      WM.open(Programs.get("systems"));   // settings = systems manager for now
+    });
+    document.getElementById("sm-about").addEventListener("click", () => {
+      hide(); WM.open(Programs.get("about"));
+    });
+    document.getElementById("sm-logout").addEventListener("click", () => {
+      hide(); Login.logout();
+    });
+
+    btn().addEventListener("click", ev => { ev.stopPropagation(); toggle(); });
+    document.addEventListener("pointerdown", ev => {
+      if (!menu().contains(ev.target) && !btn().contains(ev.target) && !submenu().contains(ev.target)) hide();
+    });
+  }
+
+  function refreshSystems() {
+    const sm = submenu();
+    sm.innerHTML = "";
+    SystemRegistry.list().forEach(s => {
+      const item = document.createElement("div");
+      item.className = "sm-item";
+      item.innerHTML = `
+        <span class="led" style="background:#999;"></span>
+        <span class="mono">${s.name}</span>
+        <span class="hostinfo">${s.host}:${s.port}</span>`;
+      item.addEventListener("click", () => {
+        hideSubmenu(); hide();
+        // Phase 1: open the systems manager focused on that system
+        WM.open(Programs.get("systems"));
+      });
+      sm.appendChild(item);
+      checkSystem(s).then(res => {
+        item.querySelector(".led").style.background =
+          res.status === "connected" ? "var(--wps-led-green)" :
+          (res.status === "auth_failed" || res.status === "cors_blocked") ? "var(--wps-led-yellow)" : "var(--wps-led-red)";
+      });
+    });
+    const manage = document.createElement("div");
+    manage.className = "sm-item";
+    manage.innerHTML = `<span class="gico"><i class="ti ti-settings"></i></span>Manage systems…`;
+    manage.addEventListener("click", () => { hideSubmenu(); hide(); WM.open(Programs.get("systems")); });
+    sm.appendChild(manage);
+  }
+
+  function toggleSubmenu() {
+    const sm = submenu();
+    if (sm.classList.contains("open")) { hideSubmenu(); return; }
+    refreshSystems();
+    const anchor = document.getElementById("sm-systems").getBoundingClientRect();
+    sm.style.left = (anchor.right + 2) + "px";
+    sm.style.top = Math.max(4, anchor.top - 4) + "px";
+    sm.style.bottom = "auto";
+    sm.classList.add("open");
+  }
+  function hideSubmenu() { submenu().classList.remove("open"); }
+  function show() { menu().classList.add("open"); btn().classList.add("open"); }
+  function hide() { menu().classList.remove("open"); btn().classList.remove("open"); hideSubmenu(); }
+  function toggle() { menu().classList.contains("open") ? hide() : show(); }
+
+  return { build, refreshSystems, hide };
+})();
+
+/* ---------- Login ---------- */
+const Login = (() => {
+  const layer = () => document.getElementById("login-layer");
+  const sel = () => document.getElementById("login-system");
+  let checkSeq = 0;
+
+  function refreshSystems() {
+    const s = sel();
+    const current = s.value;
+    s.innerHTML = "";
+    SystemRegistry.list().forEach(sys => {
+      const o = document.createElement("option");
+      o.value = sys.name;
+      o.textContent = `${sys.name} — ${sys.host}:${sys.port}` + (sys.local ? " (local)" : "");
+      s.appendChild(o);
+    });
+    const def = SystemRegistry.load().defaultSystem;
+    s.value = current && [...s.options].some(o => o.value === current) ? current : def;
+  }
+
+  function setStatus(cls, ledColor, text) {
+    const st = document.getElementById("login-status");
+    st.className = cls;
+    st.querySelector(".led").style.background = ledColor;
+    document.getElementById("login-status-text").textContent = text;
+  }
+
+  async function checkSelected() {
+    const mySeq = ++checkSeq;
+    const sys = SystemRegistry.get(sel().value);
+    if (!sys) { setStatus("warn", "var(--wps-led-yellow)", "No systems configured — use Manage systems…"); return; }
+    setStatus("wait", "#999", `Checking ${sys.name} …`);
+    const res = await checkSystem(sys);
+    if (mySeq !== checkSeq) return;   // stale response, selection changed
+    if (res.status === "connected") {
+      const ver = res.info && (res.info.zos_version || res.info.zosmf_full_version);
+      setStatus("ok", "var(--wps-led-green)", `Connected${ver ? " — " + ver : ""}`);
+    } else if (res.status === "auth_failed") {
+      setStatus("warn", "var(--wps-led-yellow)", "Reachable — authentication required");
+    } else if (res.status === "cors_blocked") {
+      setStatus("warn", "var(--wps-led-yellow)", "Reachable — response blocked by CORS (serve this page from the HTTPD)");
+    } else {
+      setStatus("bad", "var(--wps-led-red)", "Unreachable — check host and port");
+    }
+  }
+
+  async function submit() {
+    const sys = SystemRegistry.get(sel().value);
+    const user = document.getElementById("login-user").value.trim();
+    const pass = document.getElementById("login-pass").value;
+    if (!sys) return;
+    if (!user) { setStatus("warn", "var(--wps-led-yellow)", "Enter a username"); return; }
+
+    setStatus("wait", "#999", "Authenticating …");
+    const res = await checkSystem(sys, { user, pass });
+    if (res.status === "connected") {
+      Session.system = sys;
+      Session.user = user.toUpperCase();
+      Session.pass = pass;
+      Session.demo = false;
+      const d = SystemRegistry.load();
+      d.defaultSystem = sys.name;
+      SystemRegistry.save(d);
+      enterDesktop();
+    } else if (res.status === "auth_failed") {
+      setStatus("bad", "var(--wps-led-red)", "Login failed — check credentials");
+    } else if (res.status === "cors_blocked") {
+      setStatus("warn", "var(--wps-led-yellow)", "Blocked by CORS — serve this page from the HTTPD or use demo mode");
+    } else {
+      setStatus("bad", "var(--wps-led-red)", "System unreachable");
+    }
+  }
+
+  function demoLogin() {
+    Session.system = null;
+    Session.user = "DEMO";
+    Session.pass = "";
+    Session.demo = true;
+    enterDesktop();
+  }
+
+  function enterDesktop() {
+    layer().style.display = "none";
+    document.getElementById("desktop").style.display = "block";
+    document.getElementById("taskbar").style.display = "flex";
+    document.getElementById("tray-sys").textContent = Session.demo ? "DEMO" : Session.system.name;
+    document.getElementById("tray-user").textContent = Session.user;
+    document.getElementById("tray-led").style.background =
+      Session.demo ? "var(--wps-led-yellow)" : "var(--wps-led-green)";
+    // greet with the welcome window on first entry
+    WM.open(Programs.get("welcome"));
+  }
+
+  function logout() {
+    // close everything by reloading state — simplest clean slate
+    location.reload();
+  }
+
+  function init() {
+    refreshSystems();
+    checkSelected();
+    sel().addEventListener("change", checkSelected);
+    document.getElementById("login-submit").addEventListener("click", submit);
+    document.getElementById("login-pass").addEventListener("keydown", e => { if (e.key === "Enter") submit(); });
+    document.getElementById("login-user").addEventListener("keydown", e => { if (e.key === "Enter") document.getElementById("login-pass").focus(); });
+    document.getElementById("login-cancel").addEventListener("click", () => {
+      document.getElementById("login-user").value = "";
+      document.getElementById("login-pass").value = "";
+    });
+    document.getElementById("login-demo").addEventListener("click", demoLogin);
+    document.getElementById("login-manage").addEventListener("click", () => {
+      // Phase 1: quick inline prompt-based add; the Systems program
+      // offers full management once logged in.
+      const name = prompt("System name (e.g. MVSD):");
+      if (!name) return;
+      const host = prompt("Host or IP:");
+      if (!host) return;
+      const port = parseInt(prompt("Port:", "1080") || "1080", 10);
+      SystemRegistry.add({ name: name.toUpperCase(), host, port });
+      refreshSystems();
+      checkSelected();
+    });
+  }
+
+  return { init, refreshSystems, logout };
+})();
+
+/* ---------- Tray system name → open systems manager ---------- */
+document.getElementById("tray-sys").addEventListener("click", () => {
+  WM.open(Programs.get("systems"));
+});
+
+/* ---------- Boot ---------- */
+SystemRegistry.ensureLocal();   // page origin = default system when served from the HTTPD
+buildDesktopIcons();
+StartMenu.build();
+Login.init();
+</script>
+</body>
+</html>

--- a/docs/desktop-spec.md
+++ b/docs/desktop-spec.md
@@ -1,0 +1,247 @@
+# mvsMF Desktop — Specification
+
+Browser-based management frontend for mvsMF, inspired by the OS/2 Workplace
+Shell: overlapping windows, taskbar, start menu, desktop icons. Served as
+static files from the HTTPD UFS — pure vanilla HTML/JS/CSS, no frameworks,
+no build step.
+
+Concept & tracking: Notion Concepts DB → "mvsMF Desktop — OS/2 Workplace
+Shell inspired web frontend" (Status: Approved), task TSK-281.
+
+## Current state
+
+A feature-complete Phase 1 PoC exists as a single file. It is the
+**behavioral reference** for the production implementation: every feature,
+interaction and visual detail of the shell has been validated in it
+(deployed on a real HTTPD/UFS, login against a live mvsMF).
+
+Phase 1 task: port the PoC into the module structure below with feature
+parity, plus the theme-hardening pass. Phase 2+ adds real programs
+(Dataset browser, JES spool browser, Console, REXX workbench, …) one task
+at a time — the plugin API is final and must not change shape.
+
+## Repo layout
+
+```
+static/
+├── index.html              # entry point, loads shell as ES modules
+├── css/
+│   └── desktop.css         # all styles, OS/2 theme via --wps-* variables
+├── js/
+│   ├── shell.js            # boot, desktop icons, glue
+│   ├── wm.js               # window manager
+│   ├── taskbar.js          # taskbar component
+│   ├── startmenu.js        # start menu + systems submenu
+│   ├── login.js            # login screen + auth flow
+│   ├── systems.js          # SystemRegistry, checkSystem, SafeStore
+│   └── programs/
+│       ├── _template.js    # documented program template
+│       ├── welcome.js
+│       ├── sysinfo.js      # fetches /zosmf/info via ctx.system.apiFetch
+│       └── systems.js      # systems manager program
+└── (img/ optional — Tabler icons come from CDN)
+```
+
+ES modules via `<script type="module">`. English code comments.
+The PoC file is preserved as `docs/desktop-poc.html` for reference and
+removed once feature parity is confirmed.
+
+## Deployment
+
+Target on the UFS: `<DOCROOT>/mvsmf/` → `http://<host>:<port>/mvsmf/`.
+The HTTPD prepends its configured `DOCROOT` (default `/www`) to every
+request path, so with the stock docroot the desktop lives at
+`/www/mvsmf/`. Set `DESKTOP_UFS_DIR` to override for a custom docroot.
+
+Add a make target (e.g. `make deploy-desktop`) that uploads `static/`
+recursively via the mvsMF USS API (`PUT /zosmf/restfiles/fs/www/mvsmf/...`)
+— dogfooding our own API. Text files go through the normal IBM-1047 USS
+conversion; no binary assets exist yet. HTTPD serves character files
+(`.html`/`.css`/`.js`) with EBCDIC→ASCII translation and the right MIME
+type (`.js` → `application/x-javascript`, valid for `type="module"`).
+
+Same-origin note: served from the HTTPD itself, all API calls are
+same-origin — no CORS needed for the local system. Cross-origin
+(multi-system) is blocked until HTTPD has CORS support (TSK-283).
+
+## Visual design — OS/2 Workplace Shell
+
+All chrome colors live in `--wps-*` CSS custom properties on `:root`.
+
+### Theme tokens (validated in the PoC)
+```css
+:root {
+  --wps-desktop-bg: linear-gradient(145deg, #1a3a5c 0%, #0d2137 60%, #1a2a3c 100%);
+  --wps-title-active: linear-gradient(90deg, #00007b 0%, #1084d0 100%);
+  --wps-title-inactive: linear-gradient(90deg, #555 0%, #888 100%);
+  --wps-title-text: #ffffff;
+  --wps-title-system: #aac8ff;
+  --wps-chrome: #d4d4d4;
+  --wps-chrome-dark: #c8c8c8;
+  --wps-chrome-darker: #b0b0b0;
+  --wps-border-light: #e8e8e8;
+  --wps-border-mid: #aaaaaa;
+  --wps-border-dark: #999999;
+  --wps-text: #1a1a1a;
+  --wps-text-dim: #555555;
+  --wps-accent: #00007b;
+  --wps-led-green: #33cc33;
+  --wps-led-red: #cc3333;
+  --wps-led-yellow: #cccc33;
+  --wps-console-bg: #1a1a1a;
+  --wps-console-fg: #33ff33;
+  --wps-shadow: 3px 3px 8px rgba(0,0,0,0.4);
+  --wps-font-ui: "Segoe UI", system-ui, sans-serif;
+  --wps-font-mono: "Cascadia Mono", "Consolas", "Menlo", monospace;
+}
+```
+
+### Theme-hardening pass (part of Phase 1)
+The PoC still has stray inline hex values. For the production port:
+- Move ALL remaining colors into `--wps-*` variables: logo gradient
+  (`#1084d0 → #00007b`, used in login, start menu, start button, about),
+  login status tints (ok/bad/warn/wait), window content background,
+  program-content grays.
+- Bezel style as a variable: `--wps-bezel-out: 2px outset var(--wps-border-light)`
+  and `--wps-bezel-in: 1px inset var(--wps-border-mid)` (plus the 1px
+  variants) so a flat theme can override the *style*, not just colors.
+- `data-theme` attribute on `<html>`, persisted via SafeStore. Only the
+  default theme ships in Phase 1 — the mechanism must work, a second
+  theme is future work.
+
+### Window chrome
+- Title bar: `--wps-title-active` gradient, 22px, small icon (14×14 gray
+  raised), title 12px/500 white, "— SYSTEMNAME" in `--wps-title-system`
+- Controls right: three 15×15 raised buttons `_` `□` `×`, inset on :active
+- Chrome: `--wps-chrome` with outset bezel, drop shadow `--wps-shadow`
+- Optional toolbar (raised 3D buttons) and status bar (sunken text) per program
+- Content area: white by default
+
+### Taskbar (28px, bottom)
+Start button (logo square + "Start", inset when menu open) · separator ·
+window buttons (inset+accent = focused; click toggles minimize/restore) ·
+system tray in sunken container: LED · system name (mono, accent,
+dotted underline, click → systems manager) · username · clock (updates 1/s)
+
+### Start menu
+Blue-gradient header (logo, name, version) · program list (20×20 colored
+icon squares) · separator · Systems (chevron → submenu with live LEDs per
+system + "Manage systems…") · Settings · About · Logout. Closes on
+outside click.
+
+### Login screen
+Fullscreen desktop background, centered OS/2 dialog. System dropdown
+(`NAME — host:port (local)`), live connection status bar, username,
+password, Cancel/Login, "Manage systems…" and "Demo mode" links,
+version string bottom-right.
+
+### Program icon colors
+| Program          | iconBg    | icon (Tabler)   | iconColor |
+|------------------|-----------|-----------------|-----------|
+| Dataset browser  | `#e8d44d` | `ti-database`   | `#5a4e00` |
+| USS file manager | `#4d8de8` | `ti-folder`     | `#fff`    |
+| JES spool browser| `#4db84d` | `ti-list`       | `#fff`    |
+| MVS console      | `#1a1a1a` | `ti-terminal-2` | `#33ff33` |
+| REXX workbench   | `#b84d4d` | `ti-code`       | `#fff`    |
+| Job submit       | `#8855bb` | `ti-upload`     | `#fff`    |
+| Local files      | `#dd8833` | `ti-files`      | `#fff`    |
+
+Icon colors belong to the program definition, not the theme.
+
+Tabler icons via CDN (outline only, no `-filled`):
+`https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css`
+
+All UI text is sentence case, never Title Case.
+
+## Window manager
+
+Validated behaviors (all present in the PoC):
+- Open with cascade offset; close (calls program `destroy`); minimize to
+  taskbar; maximize fills desktop area (not the taskbar); restore;
+  double-click on title bar toggles maximize
+- Drag via title bar (pointer events); constraints: ≥60px of the window
+  stays on screen horizontally, title bar never above y=0
+- Resize from all 8 edges/corners via invisible handle strips; respects
+  program `minWidth`/`minHeight`; north/west resizing moves the origin
+- Focus on pointerdown anywhere in the window → z-index bump, titlebar
+  active gradient, taskbar button pressed
+- Multiple instances of the same program allowed
+- z-layers: desktop 0 · icons 1 · windows 10+ · start menu 9999 · login 10000
+
+## Program plugin API (final — do not change shape)
+
+```javascript
+Programs.register({
+  id: "my-program",
+  name: "My program",
+  icon: "ti-star",
+  iconBg: "#4d8de8",
+  iconColor: "#fff",
+  defaultWidth: 500, defaultHeight: 400,
+  minWidth: 300, minHeight: 200,
+  desktopIcon: true,          // show on the desktop
+  statusBar: true,            // optional status bar
+  toolbar: [                  // optional toolbar buttons
+    { label: "Refresh", icon: "ti-refresh", onClick(ctx) { /* ... */ } }
+  ],
+  create(ctx) {               // return the content DOM node
+    // ctx: { windowId, system, contentEl, setTitle(t), setStatus(t), close() }
+    // ctx.system: { name, host, port, baseUrl, user, demo, apiFetch(path, opts) }
+    const el = document.createElement("div");
+    return el;
+  },
+  destroy(ctx) { /* cleanup timers, listeners */ }
+});
+```
+
+`apiFetch()` injects `Authorization: Basic` and `X-CSRF-ZOSMF-HEADER`
+and prefixes `baseUrl`. In demo mode it throws — programs provide canned
+data instead (see sysinfo).
+
+## Systems & login
+
+### SystemRegistry
+Persisted via SafeStore (localStorage with in-memory fallback) under
+`mvsmf.systems`: `{ systems: [{name, host, port, local?}], defaultSystem }`.
+
+### ensureLocal() — origin-derived default system
+On boot, if the page is served over http(s): host+port from
+`window.location` become the local system. Name = first hostname label,
+uppercase, max 8 chars (`MVSDEV` from `mvsdev.lan`), fallback `LOCAL` on
+collision. Existing host+port entries are reused (marked `local`), never
+duplicated. The local system is the default, shown as `(local)`, and
+cannot be removed. `baseUrl()` follows the page protocol for the local
+system (TLS-proxy safe), plain `http:` for remotes.
+
+### Connection check — checkSystem(sys, auth?)
+`GET {base}/zosmf/info`, 4s timeout via AbortController.
+- 200 → `connected` (+parsed info)
+- 401/403 → `auth_failed` — **counts as reachable** (yellow LED); works
+  today while `/zosmf/info` still requires auth (TSK-282 will open it up)
+- fetch TypeError → retry with `mode: "no-cors"`: resolves → `cors_blocked`
+  (yellow, "serve this page from the HTTPD"), rejects → `unreachable` (red)
+- Anonymous probe sends NO custom headers (CORS simple request, no
+  preflight); authenticated check sends Authorization + CSRF header
+
+### Login flow
+System select → live check → username/password → authenticated
+`/zosmf/info` → success stores session (system becomes `defaultSystem`),
+enter desktop, open Welcome. Demo mode link enters the desktop without a
+backend (`Session.demo`, canned data). Logout = clean reload.
+
+## Phase 1 acceptance
+
+- Feature parity with `docs/desktop-poc.html` (side-by-side check)
+- 4-5 overlapping windows behave correctly (drag, resize, focus, taskbar)
+- Login against the local system works when served from the HTTPD
+- Demo mode works from `file://`
+- Theme-hardening pass complete (no stray hex values, bezel variables,
+  data-theme mechanism)
+- `make deploy-desktop` uploads static/ to `<DOCROOT>/mvsmf/` (default
+  `/www/mvsmf/`) via mvsMF
+
+## Out of scope (Phase 2+)
+
+Real programs (dataset/USS/spool/console/REXX/job-submit/local-files),
+cross-system operations, drag & drop between windows, keyboard shortcuts,
+additional themes, notifications.

--- a/static/css/desktop.css
+++ b/static/css/desktop.css
@@ -1,0 +1,419 @@
+/* ============================================================
+   mvsMF Desktop — OS/2 Workplace Shell theme
+   All chrome colours and bezel styles live in --wps-* custom
+   properties so a future theme (data-theme on <html>) can swap
+   both the colours AND the 3D bezel style. Only the default
+   "os2" theme ships in Phase 1.
+   Program icon colours (iconBg / iconColor) belong to the
+   program definition, NOT the theme, so they stay in JS.
+   ============================================================ */
+:root,
+:root[data-theme="os2"] {
+  /* --- desktop / chrome --- */
+  --wps-desktop-bg: linear-gradient(145deg, #1a3a5c 0%, #0d2137 60%, #1a2a3c 100%);
+  --wps-title-active: linear-gradient(90deg, #00007b 0%, #1084d0 100%);
+  --wps-title-inactive: linear-gradient(90deg, #555 0%, #888 100%);
+  --wps-title-text: #ffffff;
+  --wps-title-system: #aac8ff;
+  --wps-chrome: #d4d4d4;
+  --wps-chrome-dark: #c8c8c8;
+  --wps-chrome-darker: #b0b0b0;
+  --wps-border-light: #e8e8e8;
+  --wps-border-mid: #aaaaaa;
+  --wps-border-dark: #999999;
+
+  /* --- text --- */
+  --wps-text: #1a1a1a;
+  --wps-text-dim: #555555;
+  --wps-text-mid: #333333;
+  --wps-text-soft: #666666;
+  --wps-text-faint: #777777;
+  --wps-text-muted: #888888;
+  --wps-text-disabled: #999999;
+  --wps-text-user: #444444;
+  --wps-text-strong: #222222;
+
+  /* --- accents / LEDs --- */
+  --wps-accent: #00007b;
+  --wps-accent-border: #3333aa;
+  --wps-led-green: #33cc33;
+  --wps-led-red: #cc3333;
+  --wps-led-yellow: #cccc33;
+  --wps-led-off: #999999;
+  --wps-led-ring: rgba(0,0,0,0.35);
+  --wps-led-ring-soft: rgba(0,0,0,0.30);
+  --wps-remove: #aa3333;
+  --wps-hostinfo-hover: #ccddff;
+
+  /* --- console (used by Phase 2 programs) --- */
+  --wps-console-bg: #1a1a1a;
+  --wps-console-fg: #33ff33;
+
+  /* --- surfaces / hairlines --- */
+  --wps-content-bg: #ffffff;
+  --wps-input-bg: #ffffff;
+  --wps-input-focus-bg: #fffef0;
+  --wps-tray-bg: #c0c0c0;
+  --wps-code-bg: #f0f0f0;
+  --wps-panel-bg: #f4f4f4;
+  --wps-hairline: #dddddd;
+  --wps-hairline-soft: #e4e4e4;
+
+  /* --- logo (blue square, used in login / start menu / about) --- */
+  --wps-logo-gradient: linear-gradient(135deg, #1084d0, #00007b);
+  --wps-logo-accent: #1084d0;
+  --wps-logo-ghost: rgba(255,255,255,0.15);
+
+  /* --- shadows / overlays --- */
+  --wps-shadow: 3px 3px 8px rgba(0,0,0,0.4);
+  --wps-shadow-strong: 4px 4px 12px rgba(0,0,0,0.5);
+  --wps-emboss: 1px 1px 0 rgba(0,0,0,0.2);
+  --wps-emboss-strong: 1px 1px 0 rgba(0,0,0,0.25);
+  --wps-grid-line: #ffffff;
+  --wps-icon-hover: rgba(255,255,255,0.08);
+  --wps-icon-selected: rgba(16,132,208,0.35);
+  --wps-icon-outline: rgba(255,255,255,0.5);
+  --wps-label-shadow: #000000;
+  --wps-version-fg: rgba(255,255,255,0.25);
+
+  /* --- login status tints --- */
+  --wps-status-ok-bg: #c8e6c8;   --wps-status-ok-border: #8aba8a;   --wps-status-ok-fg: #2a5a2a;
+  --wps-status-bad-bg: #e6c8c8;  --wps-status-bad-border: #ba8a8a;  --wps-status-bad-fg: #5a2a2a;
+  --wps-status-warn-bg: #e6e0c0; --wps-status-warn-border: #bab08a; --wps-status-warn-fg: #5a512a;
+  --wps-status-wait-bg: #d8d8d8; --wps-status-wait-border: #aaaaaa; --wps-status-wait-fg: #555555;
+
+  /* --- bezels (style + colour) so a flat theme can override the *style* --- */
+  --wps-bezel-out: 2px outset var(--wps-border-light);
+  --wps-bezel-out-1: 1px outset var(--wps-border-light);
+  --wps-bezel-in: 1px inset var(--wps-border-mid);
+  --wps-bezel-in-2: 2px inset var(--wps-border-mid);
+
+  /* --- fonts --- */
+  --wps-font-ui: "Segoe UI", system-ui, sans-serif;
+  --wps-font-mono: "Cascadia Mono", "Consolas", "Menlo", monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--wps-font-ui);
+  font-size: 12px;
+  color: var(--wps-text);
+  user-select: none;
+}
+
+/* ---------- Desktop ---------- */
+#desktop {
+  position: fixed;
+  inset: 0 0 28px 0;   /* leave room for taskbar */
+  background: var(--wps-desktop-bg);
+  overflow: hidden;
+}
+#desktop::before {
+  /* subtle grid overlay */
+  content: "";
+  position: absolute; inset: 0;
+  opacity: 0.03;
+  background-image:
+    repeating-linear-gradient(0deg, var(--wps-grid-line) 0 1px, transparent 1px 40px),
+    repeating-linear-gradient(90deg, var(--wps-grid-line) 0 1px, transparent 1px 40px);
+  pointer-events: none;
+}
+
+/* ---------- Desktop icons ---------- */
+#desktop-icons {
+  position: absolute;
+  top: 16px; right: 16px;
+  display: flex; flex-direction: column; gap: 16px;
+  z-index: 1;
+}
+.desk-icon {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  width: 74px; cursor: pointer; padding: 4px; border-radius: 3px;
+}
+.desk-icon:hover { background: var(--wps-icon-hover); }
+.desk-icon.selected { background: var(--wps-icon-selected); outline: 1px dotted var(--wps-icon-outline); }
+.desk-icon .box {
+  width: 38px; height: 38px; border-radius: 3px;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: var(--wps-emboss-strong);
+  font-size: 20px;
+}
+.desk-icon .label {
+  font-size: 10.5px; color: var(--wps-title-text); text-align: center; line-height: 1.2;
+  text-shadow: 1px 1px 2px var(--wps-label-shadow);
+}
+
+/* ---------- Windows ---------- */
+.wps-window {
+  position: absolute;
+  background: var(--wps-chrome);
+  border: var(--wps-bezel-out);
+  box-shadow: var(--wps-shadow);
+  display: flex; flex-direction: column;
+  min-width: 200px; min-height: 120px;
+}
+.wps-window.maximized { border-width: 0; box-shadow: none; }
+.wps-window.minimized { display: none; }
+
+.wps-titlebar {
+  display: flex; align-items: center; justify-content: space-between;
+  background: var(--wps-title-inactive);
+  height: 22px; padding: 0 3px; flex: 0 0 auto;
+  cursor: default;
+}
+.wps-window.focused .wps-titlebar { background: var(--wps-title-active); }
+.wps-titlebar .tleft { display: flex; align-items: center; gap: 6px; overflow: hidden; }
+.wps-titlebar .ticon {
+  width: 14px; height: 14px; flex: 0 0 auto;
+  background: var(--wps-chrome); border: var(--wps-bezel-out-1);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; color: var(--wps-accent);
+}
+.wps-titlebar .ttext {
+  font-size: 12px; font-weight: 500; color: var(--wps-title-text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.wps-titlebar .tsys { font-size: 10px; color: var(--wps-title-system); margin-left: 4px; }
+.wps-titlebar .tbtns { display: flex; gap: 2px; flex: 0 0 auto; }
+.wps-titlebar .tbtn {
+  width: 15px; height: 15px;
+  background: var(--wps-chrome); border: var(--wps-bezel-out-1);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 10px; line-height: 1; color: var(--wps-text-mid); cursor: pointer;
+  font-family: var(--wps-font-ui);
+}
+.wps-titlebar .tbtn:active { border-style: inset; }
+
+.wps-toolbar {
+  display: flex; align-items: center; gap: 2px;
+  padding: 3px 4px; background: var(--wps-chrome-dark);
+  border-bottom: 1px solid var(--wps-border-mid); flex: 0 0 auto;
+}
+.wps-toolbar .tb-btn {
+  font-size: 11px; color: var(--wps-text-mid); padding: 2px 8px;
+  border: var(--wps-bezel-out-1); background: var(--wps-chrome); cursor: pointer;
+  display: flex; align-items: center; gap: 4px;
+}
+.wps-toolbar .tb-btn:active { border-style: inset; background: var(--wps-chrome-darker); }
+.wps-toolbar .tb-spacer { flex: 1; }
+
+.wps-content {
+  flex: 1; overflow: auto; background: var(--wps-content-bg); position: relative;
+}
+
+.wps-statusbar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 2px 6px; background: var(--wps-chrome-dark);
+  border-top: 1px solid var(--wps-border-mid); flex: 0 0 auto;
+  font-size: 10px; color: var(--wps-text-dim);
+}
+
+/* Resize handles — invisible strips around the window edge */
+.rs { position: absolute; z-index: 5; }
+.rs-n  { top: -3px; left: 8px; right: 8px; height: 6px; cursor: n-resize; }
+.rs-s  { bottom: -3px; left: 8px; right: 8px; height: 6px; cursor: s-resize; }
+.rs-e  { right: -3px; top: 8px; bottom: 8px; width: 6px; cursor: e-resize; }
+.rs-w  { left: -3px; top: 8px; bottom: 8px; width: 6px; cursor: w-resize; }
+.rs-ne { top: -3px; right: -3px; width: 10px; height: 10px; cursor: ne-resize; }
+.rs-nw { top: -3px; left: -3px; width: 10px; height: 10px; cursor: nw-resize; }
+.rs-se { bottom: -3px; right: -3px; width: 10px; height: 10px; cursor: se-resize; }
+.rs-sw { bottom: -3px; left: -3px; width: 10px; height: 10px; cursor: sw-resize; }
+
+/* ---------- Taskbar ---------- */
+#taskbar {
+  position: fixed; left: 0; right: 0; bottom: 0; height: 28px;
+  background: var(--wps-chrome-dark);
+  border-top: var(--wps-bezel-out);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 4px; z-index: 9000;
+}
+#taskbar .tb-left { display: flex; align-items: center; gap: 3px; overflow: hidden; }
+#start-btn {
+  display: flex; align-items: center; gap: 5px;
+  padding: 2px 10px 2px 6px; font-size: 11px; font-weight: 500;
+  color: var(--wps-accent); cursor: pointer;
+  border: var(--wps-bezel-out-1); background: var(--wps-chrome);
+}
+#start-btn.open, #start-btn:active { border-style: inset; background: var(--wps-chrome-darker); }
+#start-btn .logo {
+  width: 14px; height: 14px; border-radius: 2px;
+  background: var(--wps-logo-gradient);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; font-weight: 500; color: var(--wps-title-text);
+}
+.tb-sep { width: 1px; height: 20px; background: var(--wps-border-mid); margin: 0 3px; flex: 0 0 auto; }
+.task-btn {
+  display: flex; align-items: center; gap: 5px;
+  padding: 2px 10px; font-size: 11px; color: var(--wps-text-mid); cursor: pointer;
+  border: var(--wps-bezel-out-1); background: var(--wps-chrome);
+  max-width: 160px; white-space: nowrap; overflow: hidden;
+}
+.task-btn span { overflow: hidden; text-overflow: ellipsis; }
+.task-btn.active {
+  border-style: inset; background: var(--wps-chrome-darker);
+  color: var(--wps-accent); font-weight: 500;
+}
+#tray {
+  display: flex; align-items: center; gap: 6px;
+  border: var(--wps-bezel-in); background: var(--wps-tray-bg);
+  padding: 1px 8px; height: 22px; flex: 0 0 auto;
+}
+#tray .led { width: 7px; height: 7px; border-radius: 50%; border: 1px solid var(--wps-led-ring); }
+#tray .sysname {
+  font-family: var(--wps-font-mono); font-size: 11px; font-weight: 500;
+  color: var(--wps-accent); cursor: pointer; border-bottom: 1px dotted var(--wps-accent);
+}
+#tray .dim { color: var(--wps-text-disabled); font-size: 10px; }
+#tray .user, #tray .clock { font-family: var(--wps-font-mono); font-size: 10px; color: var(--wps-text-user); }
+#tray .clock { color: var(--wps-text-strong); }
+
+/* ---------- Start menu ---------- */
+#startmenu {
+  position: fixed; left: 2px; bottom: 30px; width: 224px;
+  background: var(--wps-chrome); border: var(--wps-bezel-out);
+  box-shadow: var(--wps-shadow); z-index: 9999; display: none;
+}
+#startmenu.open { display: block; }
+#startmenu .sm-head {
+  background: var(--wps-title-active); padding: 7px 10px;
+  display: flex; align-items: center; gap: 8px;
+}
+#startmenu .sm-head .logo {
+  width: 28px; height: 28px; border-radius: 3px; background: var(--wps-logo-ghost);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px; font-weight: 500; color: var(--wps-title-text);
+}
+#startmenu .sm-head .t1 { font-size: 12px; font-weight: 500; color: var(--wps-title-text); }
+#startmenu .sm-head .t2 { font-size: 10px; color: var(--wps-title-system); }
+.sm-section { padding: 4px 0; }
+.sm-section + .sm-section { border-top: 1px solid var(--wps-border-mid); }
+.sm-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 12px; cursor: pointer; font-size: 12px; color: var(--wps-text-mid);
+}
+.sm-item:hover { background: var(--wps-accent); color: var(--wps-title-text); }
+.sm-item .pico {
+  width: 20px; height: 20px; border-radius: 2px; flex: 0 0 auto;
+  display: flex; align-items: center; justify-content: center; font-size: 13px;
+}
+.sm-item .gico { width: 20px; text-align: center; font-size: 15px; color: var(--wps-text-dim); }
+.sm-item:hover .gico { color: var(--wps-title-text); }
+.sm-item .chev { margin-left: auto; font-size: 12px; color: var(--wps-text-disabled); }
+.sm-item:hover .chev { color: var(--wps-title-text); }
+
+/* Systems submenu */
+#sys-submenu {
+  position: fixed; width: 220px;
+  background: var(--wps-chrome); border: var(--wps-bezel-out);
+  box-shadow: var(--wps-shadow); z-index: 10001; display: none;
+}
+#sys-submenu.open { display: block; }
+#sys-submenu .sm-item { padding: 4px 10px; }
+#sys-submenu .led { width: 7px; height: 7px; border-radius: 50%; border: 1px solid var(--wps-led-ring); flex: 0 0 auto; }
+#sys-submenu .mono { font-family: var(--wps-font-mono); font-size: 11px; }
+#sys-submenu .hostinfo { margin-left: auto; font-size: 9px; color: var(--wps-text-muted); }
+#sys-submenu .sm-item:hover .hostinfo { color: var(--wps-hostinfo-hover); }
+
+/* ---------- Login ---------- */
+#login-layer {
+  position: fixed; inset: 0; z-index: 10000;
+  background: var(--wps-desktop-bg);
+  display: flex; align-items: center; justify-content: center;
+}
+#login-layer::before {
+  content: ""; position: absolute; inset: 0; opacity: 0.03;
+  background-image:
+    repeating-linear-gradient(0deg, var(--wps-grid-line) 0 1px, transparent 1px 40px),
+    repeating-linear-gradient(90deg, var(--wps-grid-line) 0 1px, transparent 1px 40px);
+}
+#login-box {
+  width: 330px; background: var(--wps-chrome);
+  border: var(--wps-bezel-out);
+  box-shadow: var(--wps-shadow-strong); position: relative;
+}
+#login-box .lb-title {
+  display: flex; align-items: center; gap: 6px;
+  background: var(--wps-title-active); height: 22px; padding: 0 4px;
+}
+#login-box .lb-title .ticon {
+  width: 14px; height: 14px; background: var(--wps-chrome); border: var(--wps-bezel-out-1);
+  display: flex; align-items: center; justify-content: center; font-size: 9px; color: var(--wps-accent);
+}
+#login-box .lb-title .t { font-size: 12px; font-weight: 500; color: var(--wps-title-text); }
+#login-box .lb-body { padding: 18px 24px 16px; }
+.lb-logo { display: flex; justify-content: center; margin-bottom: 16px; }
+.lb-logo .inner { display: flex; align-items: center; gap: 8px; }
+.lb-logo .sq {
+  width: 36px; height: 36px; border-radius: 4px;
+  background: var(--wps-logo-gradient);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 16px; font-weight: 500; color: var(--wps-title-text);
+  box-shadow: var(--wps-emboss);
+}
+.lb-logo .t1 { font-size: 16px; font-weight: 500; letter-spacing: -0.3px; }
+.lb-logo .t2 { font-size: 10px; color: var(--wps-text-faint); }
+.lb-field { margin-bottom: 10px; }
+.lb-field label { display: block; font-size: 11px; color: var(--wps-text-dim); margin-bottom: 3px; }
+.lb-field input, .lb-field select {
+  width: 100%; padding: 5px 6px; font-size: 12px;
+  font-family: var(--wps-font-mono); color: var(--wps-text-mid);
+  border: var(--wps-bezel-in); background: var(--wps-input-bg); outline: none;
+}
+.lb-field input:focus, .lb-field select:focus { background: var(--wps-input-focus-bg); }
+#login-status {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 8px; margin-bottom: 12px; font-size: 11px;
+  border: 1px solid transparent;
+}
+#login-status .led { width: 7px; height: 7px; border-radius: 50%; border: 1px solid var(--wps-led-ring-soft); flex: 0 0 auto; }
+#login-status.ok    { background: var(--wps-status-ok-bg);   border-color: var(--wps-status-ok-border);   color: var(--wps-status-ok-fg); }
+#login-status.bad   { background: var(--wps-status-bad-bg);  border-color: var(--wps-status-bad-border);  color: var(--wps-status-bad-fg); }
+#login-status.warn  { background: var(--wps-status-warn-bg); border-color: var(--wps-status-warn-border); color: var(--wps-status-warn-fg); }
+#login-status.wait  { background: var(--wps-status-wait-bg); border-color: var(--wps-status-wait-border); color: var(--wps-status-wait-fg); }
+.lb-buttons { display: flex; justify-content: flex-end; gap: 6px; margin-top: 14px; }
+.lb-btn {
+  padding: 4px 16px; font-size: 12px; cursor: pointer;
+  border: var(--wps-bezel-out-1); background: var(--wps-chrome); color: var(--wps-text-mid);
+  font-family: var(--wps-font-ui);
+}
+.lb-btn:active { border-style: inset; }
+.lb-btn.primary { background: var(--wps-accent); color: var(--wps-title-text); border-color: var(--wps-accent-border); font-weight: 500; }
+.lb-links { text-align: center; margin-top: 12px; display: flex; justify-content: center; gap: 16px; }
+.lb-link { font-size: 10px; color: var(--wps-accent); cursor: pointer; border-bottom: 1px dotted var(--wps-accent); }
+#login-version {
+  position: absolute; bottom: 8px; right: 12px;
+  font-size: 10px; color: var(--wps-version-fg); font-family: var(--wps-font-mono);
+}
+
+/* ---------- Program content helpers ---------- */
+.prog-pad { padding: 14px 16px; font-size: 12px; line-height: 1.6; user-select: text; }
+.prog-pad h1 { font-size: 15px; font-weight: 500; margin-bottom: 8px; }
+.prog-pad p { margin-bottom: 8px; }
+.prog-pad code {
+  font-family: var(--wps-font-mono); font-size: 11px;
+  background: var(--wps-code-bg); padding: 0 3px; border: 1px solid var(--wps-hairline);
+}
+.prog-err { color: var(--wps-remove); }
+.prog-mono {
+  font-family: var(--wps-font-mono); font-size: 11px; line-height: 1.6;
+  white-space: pre-wrap; user-select: text; padding: 10px 12px;
+}
+.sys-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px; border-bottom: 1px solid var(--wps-hairline-soft); font-size: 12px;
+}
+.sys-row .led { width: 8px; height: 8px; border-radius: 50%; border: 1px solid var(--wps-led-ring-soft); flex: 0 0 auto; }
+.sys-row .name { font-family: var(--wps-font-mono); font-weight: 500; width: 90px; }
+.sys-row .name .tag { color: var(--wps-text-muted); font-size: 9px; }
+.sys-row .host { font-family: var(--wps-font-mono); color: var(--wps-text-soft); flex: 1; font-size: 11px; }
+.sys-row .stat { font-size: 10px; color: var(--wps-text-muted); width: 90px; }
+.sys-row .rm { color: var(--wps-remove); cursor: pointer; font-size: 13px; }
+.sys-add { display: flex; gap: 6px; padding: 10px; background: var(--wps-panel-bg); border-top: 1px solid var(--wps-hairline); }
+.sys-add input {
+  border: var(--wps-bezel-in); padding: 3px 6px;
+  font-family: var(--wps-font-mono); font-size: 11px; outline: none;
+}
+.sys-add .in-name { width: 80px; } .sys-add .in-host { flex: 1; } .sys-add .in-port { width: 56px; }

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="os2">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>mvsMF Desktop</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<link rel="stylesheet" href="css/desktop.css">
+</head>
+<body>
+
+<!-- ================= Login layer ================= -->
+<div id="login-layer">
+  <div id="login-box">
+    <div class="lb-title">
+      <div class="ticon"><i class="ti ti-lock"></i></div>
+      <span class="t">mvsMF Desktop — Login</span>
+    </div>
+    <div class="lb-body">
+      <div class="lb-logo">
+        <div class="inner">
+          <div class="sq">M</div>
+          <div><div class="t1">mvs<span style="color:var(--wps-logo-accent);">MF</span> Desktop</div>
+               <div class="t2">MVS management facility</div></div>
+        </div>
+      </div>
+      <div class="lb-field">
+        <label for="login-system">System</label>
+        <select id="login-system"></select>
+      </div>
+      <div id="login-status" class="wait">
+        <span class="led" style="background:var(--wps-led-off);"></span>
+        <span id="login-status-text">Checking connection…</span>
+      </div>
+      <div class="lb-field">
+        <label for="login-user">Username</label>
+        <input id="login-user" autocomplete="username" spellcheck="false">
+      </div>
+      <div class="lb-field">
+        <label for="login-pass">Password</label>
+        <input id="login-pass" type="password" autocomplete="current-password">
+      </div>
+      <div class="lb-buttons">
+        <button class="lb-btn" id="login-cancel">Cancel</button>
+        <button class="lb-btn primary" id="login-submit">Login</button>
+      </div>
+      <div class="lb-links">
+        <span class="lb-link" id="login-manage">Manage systems…</span>
+        <span class="lb-link" id="login-demo">Demo mode</span>
+      </div>
+    </div>
+  </div>
+  <div id="login-version">mvsMF Desktop v2.0.0-alpha1</div>
+</div>
+
+<!-- ================= Desktop ================= -->
+<div id="desktop" style="display:none;">
+  <div id="desktop-icons"></div>
+</div>
+
+<!-- ================= Taskbar ================= -->
+<div id="taskbar" style="display:none;">
+  <div class="tb-left">
+    <div id="start-btn"><span class="logo">M</span>Start</div>
+    <div class="tb-sep"></div>
+    <div id="task-buttons" style="display:flex;gap:3px;overflow:hidden;"></div>
+  </div>
+  <div id="tray">
+    <span class="led" id="tray-led" style="background:var(--wps-led-green);"></span>
+    <span class="sysname" id="tray-sys">—</span>
+    <span class="dim">|</span>
+    <span class="user" id="tray-user">—</span>
+    <span class="dim">|</span>
+    <span class="clock" id="tray-clock">--:--:--</span>
+  </div>
+</div>
+
+<!-- ================= Start menu ================= -->
+<div id="startmenu">
+  <div class="sm-head">
+    <div class="logo">M</div>
+    <div><div class="t1">mvsMF Desktop</div><div class="t2">v2.0.0-alpha1</div></div>
+  </div>
+  <div class="sm-section" id="sm-programs"></div>
+  <div class="sm-section">
+    <div class="sm-item" id="sm-systems">
+      <span class="gico"><i class="ti ti-server"></i></span>Systems
+      <span class="chev"><i class="ti ti-chevron-right"></i></span>
+    </div>
+    <div class="sm-item" id="sm-settings">
+      <span class="gico"><i class="ti ti-settings"></i></span>Settings
+    </div>
+    <div class="sm-item" id="sm-about">
+      <span class="gico"><i class="ti ti-info-circle"></i></span>About
+    </div>
+    <div class="sm-item" id="sm-logout">
+      <span class="gico"><i class="ti ti-logout"></i></span>Logout
+    </div>
+  </div>
+</div>
+<div id="sys-submenu"></div>
+
+<!-- ES modules: the whole shell boots from shell.js -->
+<script type="module" src="js/shell.js"></script>
+</body>
+</html>

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,0 +1,136 @@
+/* ============================================================
+   login.js — login screen + auth flow
+   System selector, live /zosmf/info connection check (401 = still
+   reachable, no-cors fallback), authenticated login, demo mode,
+   inline "Manage systems…" add, logout. On success it enters the
+   desktop and opens the Welcome window.
+   ============================================================ */
+import { Session, SystemRegistry, checkSystem } from "./systems.js";
+import { WM } from "./wm.js";
+import { Programs } from "./programs/registry.js";
+
+export const Login = (() => {
+  const layer = () => document.getElementById("login-layer");
+  const sel = () => document.getElementById("login-system");
+  let checkSeq = 0;
+
+  function refreshSystems() {
+    const s = sel();
+    const current = s.value;
+    s.innerHTML = "";
+    SystemRegistry.list().forEach(sys => {
+      const o = document.createElement("option");
+      o.value = sys.name;
+      o.textContent = `${sys.name} — ${sys.host}:${sys.port}` + (sys.local ? " (local)" : "");
+      s.appendChild(o);
+    });
+    const def = SystemRegistry.load().defaultSystem;
+    s.value = current && [...s.options].some(o => o.value === current) ? current : def;
+  }
+
+  function setStatus(cls, ledColor, text) {
+    const st = document.getElementById("login-status");
+    st.className = cls;
+    st.querySelector(".led").style.background = ledColor;
+    document.getElementById("login-status-text").textContent = text;
+  }
+
+  async function checkSelected() {
+    const mySeq = ++checkSeq;
+    const sys = SystemRegistry.get(sel().value);
+    if (!sys) { setStatus("warn", "var(--wps-led-yellow)", "No systems configured — use Manage systems…"); return; }
+    setStatus("wait", "var(--wps-led-off)", `Checking ${sys.name} …`);
+    const res = await checkSystem(sys);
+    if (mySeq !== checkSeq) return;   // stale response, selection changed
+    if (res.status === "connected") {
+      const ver = res.info && (res.info.zos_version || res.info.zosmf_full_version);
+      setStatus("ok", "var(--wps-led-green)", `Connected${ver ? " — " + ver : ""}`);
+    } else if (res.status === "auth_failed") {
+      setStatus("warn", "var(--wps-led-yellow)", "Reachable — authentication required");
+    } else if (res.status === "cors_blocked") {
+      setStatus("warn", "var(--wps-led-yellow)", "Reachable — response blocked by CORS (serve this page from the HTTPD)");
+    } else {
+      setStatus("bad", "var(--wps-led-red)", "Unreachable — check host and port");
+    }
+  }
+
+  async function submit() {
+    const sys = SystemRegistry.get(sel().value);
+    const user = document.getElementById("login-user").value.trim();
+    const pass = document.getElementById("login-pass").value;
+    if (!sys) return;
+    if (!user) { setStatus("warn", "var(--wps-led-yellow)", "Enter a username"); return; }
+
+    setStatus("wait", "var(--wps-led-off)", "Authenticating …");
+    const res = await checkSystem(sys, { user, pass });
+    if (res.status === "connected") {
+      Session.system = sys;
+      Session.user = user.toUpperCase();
+      Session.pass = pass;
+      Session.demo = false;
+      const d = SystemRegistry.load();
+      d.defaultSystem = sys.name;
+      SystemRegistry.save(d);
+      enterDesktop();
+    } else if (res.status === "auth_failed") {
+      setStatus("bad", "var(--wps-led-red)", "Login failed — check credentials");
+    } else if (res.status === "cors_blocked") {
+      setStatus("warn", "var(--wps-led-yellow)", "Blocked by CORS — serve this page from the HTTPD or use demo mode");
+    } else {
+      setStatus("bad", "var(--wps-led-red)", "System unreachable");
+    }
+  }
+
+  function demoLogin() {
+    Session.system = null;
+    Session.user = "DEMO";
+    Session.pass = "";
+    Session.demo = true;
+    enterDesktop();
+  }
+
+  function enterDesktop() {
+    layer().style.display = "none";
+    document.getElementById("desktop").style.display = "block";
+    document.getElementById("taskbar").style.display = "flex";
+    document.getElementById("tray-sys").textContent = Session.demo ? "DEMO" : Session.system.name;
+    document.getElementById("tray-user").textContent = Session.user;
+    document.getElementById("tray-led").style.background =
+      Session.demo ? "var(--wps-led-yellow)" : "var(--wps-led-green)";
+    // greet with the welcome window on first entry
+    WM.open(Programs.get("welcome"));
+  }
+
+  function logout() {
+    // close everything by reloading state — simplest clean slate
+    location.reload();
+  }
+
+  function init() {
+    refreshSystems();
+    checkSelected();
+    sel().addEventListener("change", checkSelected);
+    document.getElementById("login-submit").addEventListener("click", submit);
+    document.getElementById("login-pass").addEventListener("keydown", e => { if (e.key === "Enter") submit(); });
+    document.getElementById("login-user").addEventListener("keydown", e => { if (e.key === "Enter") document.getElementById("login-pass").focus(); });
+    document.getElementById("login-cancel").addEventListener("click", () => {
+      document.getElementById("login-user").value = "";
+      document.getElementById("login-pass").value = "";
+    });
+    document.getElementById("login-demo").addEventListener("click", demoLogin);
+    document.getElementById("login-manage").addEventListener("click", () => {
+      // Phase 1: quick inline prompt-based add; the Systems program
+      // offers full management once logged in.
+      const name = prompt("System name (e.g. MVSD):");
+      if (!name) return;
+      const host = prompt("Host or IP:");
+      if (!host) return;
+      const port = parseInt(prompt("Port:", "1080") || "1080", 10);
+      SystemRegistry.add({ name: name.toUpperCase(), host, port });
+      refreshSystems();
+      checkSelected();
+    });
+  }
+
+  return { init, refreshSystems, logout };
+})();

--- a/static/js/programs/_template.js
+++ b/static/js/programs/_template.js
@@ -1,0 +1,58 @@
+/* ============================================================
+   _template.js — documented program template (Phase 2 authors).
+
+   This file is NOT imported by shell.js, so it registers nothing
+   at runtime. To add a real program:
+     1. Copy this file to js/programs/<your-id>.js
+     2. Fill in the definition below
+     3. Add `import "./programs/<your-id>.js";` to js/shell.js
+
+   The plugin API is FINAL — keep the shape exactly as documented
+   here; the shell and Phase 2 programs depend on it.
+   ============================================================ */
+import { Programs } from "./registry.js";
+
+Programs.register({
+  /* --- identity --- */
+  id: "my-program",          // unique, kebab-case
+  name: "My program",        // sentence case (never Title Case)
+  icon: "ti-star",           // Tabler icon class (outline, no -filled)
+
+  /* --- icon square colours (belong to the program, NOT the theme) --- */
+  iconBg: "#4d8de8",
+  iconColor: "#fff",
+
+  /* --- default + minimum window size --- */
+  defaultWidth: 500, defaultHeight: 400,
+  minWidth: 300, minHeight: 200,
+
+  /* --- shell integration --- */
+  desktopIcon: true,         // show an icon on the desktop
+  statusBar: true,           // render a status bar (ctx.setStatus writes to it)
+
+  /* --- optional toolbar of raised 3D buttons --- */
+  toolbar: [
+    { label: "Refresh", icon: "ti-refresh", onClick(ctx) { /* ctx is the window context */ } }
+  ],
+
+  /* --- create: build and return the content DOM node ---
+     ctx = {
+       windowId,                       // this window's id
+       system,                         // { name, host, port, baseUrl, user, demo, apiFetch(path, opts) }
+       contentEl,                      // the .wps-content element
+       setTitle(t),                    // update title bar + taskbar label
+       setStatus(t),                   // write to the status bar (if statusBar)
+       close()                         // close this window
+     }
+     system.apiFetch() injects Authorization: Basic + X-CSRF-ZOSMF-HEADER
+     and prefixes baseUrl. In demo mode it throws — provide canned data. */
+  create(ctx) {
+    const el = document.createElement("div");
+    el.className = "prog-pad";
+    el.textContent = "Hello from " + ctx.system.name;
+    return el;
+  },
+
+  /* --- destroy: clean up timers / listeners (optional) --- */
+  destroy(ctx) { /* ... */ }
+});

--- a/static/js/programs/about.js
+++ b/static/js/programs/about.js
@@ -1,0 +1,30 @@
+/* ============================================================
+   about.js — the About window (opened from the start menu).
+   Not shown as a desktop icon and excluded from the start-menu
+   program list (it has its own menu entry).
+   ============================================================ */
+import { Programs } from "./registry.js";
+
+Programs.register({
+  id: "about",
+  name: "About",
+  icon: "ti-info-circle",
+  iconBg: "#666", iconColor: "#fff",
+  defaultWidth: 380, defaultHeight: 260,
+  desktopIcon: false,
+  create() {
+    const d = document.createElement("div");
+    d.className = "prog-pad";
+    d.innerHTML = `
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
+        <div style="width:40px;height:40px;border-radius:4px;background:var(--wps-logo-gradient);display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:500;color:var(--wps-title-text);">M</div>
+        <div><div style="font-size:15px;font-weight:500;">mvsMF Desktop</div>
+        <div style="color:var(--wps-text-faint);font-size:11px;">Version 2.0.0-alpha1 — Phase 1 shell</div></div>
+      </div>
+      <p>A browser desktop for MVS 3.8j, inspired by the OS/2 Workplace Shell.</p>
+      <p>Backend: <code>mvsMF</code> (z/OSMF-compatible REST API),
+      <code>httprexx</code>, <code>httpjes</code> on <code>HTTPD</code>.</p>
+      <p style="color:var(--wps-text-faint);">mvslovers — running modern APIs on 1981 iron.</p>`;
+    return d;
+  }
+});

--- a/static/js/programs/registry.js
+++ b/static/js/programs/registry.js
@@ -1,0 +1,26 @@
+/* ============================================================
+   registry.js — the program plugin registry
+   Leaf module (imports nothing from the shell) so every program
+   file can `import { Programs }` and self-register at load time
+   without a temporal-dead-zone problem.
+
+   Plugin API (final — do not change shape; Phase 2 builds on it):
+
+     Programs.register({
+       id, name, icon, iconBg, iconColor,
+       defaultWidth, defaultHeight, minWidth, minHeight,
+       desktopIcon, statusBar, toolbar,
+       create(ctx) { return <DOM node>; },
+       destroy(ctx) { ... }
+     });
+
+   ctx: { windowId, system, contentEl, setTitle(t), setStatus(t), close() }
+   ctx.system: { name, host, port, baseUrl, user, demo, apiFetch(path, opts) }
+   ============================================================ */
+export const Programs = (() => {
+  const list = [];
+  function register(p) { list.push(p); }
+  function get(id) { return list.find(p => p.id === id); }
+  function all() { return list.slice(); }
+  return { register, get, all };
+})();

--- a/static/js/programs/stubs.js
+++ b/static/js/programs/stubs.js
@@ -1,0 +1,38 @@
+/* ============================================================
+   stubs.js — Phase 2 placeholder programs.
+   Each real program (Dataset browser, JES spool browser, MVS
+   console, REXX workbench, …) arrives in its own Phase 2 task
+   and uses exactly this plugin interface. Registering the stubs
+   now proves the desktop icons, start menu, cascade and multiple
+   instances all work. Icon colours come from the spec's table
+   and belong to the program definition, not the theme.
+   ============================================================ */
+import { Programs } from "./registry.js";
+
+function registerStub(id, name, icon, iconBg, iconColor) {
+  Programs.register({
+    id, name, icon, iconBg, iconColor,
+    defaultWidth: 400, defaultHeight: 220,
+    desktopIcon: true,
+    stub: true,
+    create() {
+      const d = document.createElement("div");
+      d.className = "prog-pad";
+      d.innerHTML = `
+        <h1>${name}</h1>
+        <p>This program arrives in <b>Phase 2</b>.</p>
+        <p>The window you are looking at is served by the plugin API —
+        the real implementation will use the same interface and the
+        system context's <code>apiFetch()</code>.</p>`;
+      return d;
+    }
+  });
+}
+
+registerStub("datasets",  "Dataset browser",  "ti-database",   "#e8d44d", "#5a4e00");
+registerStub("ussfiles",  "USS file manager", "ti-folder",     "#4d8de8", "#fff");
+registerStub("spool",     "JES spool browser","ti-list",       "#4db84d", "#fff");
+registerStub("console",   "MVS console",      "ti-terminal-2", "#1a1a1a", "#33ff33");
+registerStub("rexx",      "REXX workbench",   "ti-code",       "#b84d4d", "#fff");
+registerStub("jobsubmit", "Job submit",       "ti-upload",     "#8855bb", "#fff");
+registerStub("localfiles","Local files",      "ti-files",      "#dd8833", "#fff");

--- a/static/js/programs/sysinfo.js
+++ b/static/js/programs/sysinfo.js
@@ -1,0 +1,55 @@
+/* ============================================================
+   sysinfo.js — first program that actually talks to mvsMF.
+   Fetches /zosmf/info via ctx.system.apiFetch and pretty-prints
+   it. In demo mode apiFetch throws, so it shows canned data —
+   the pattern every real Phase 2 program follows.
+   ============================================================ */
+import { Programs } from "./registry.js";
+
+Programs.register({
+  id: "sysinfo",
+  name: "System info",
+  icon: "ti-info-circle",
+  iconBg: "#4db84d", iconColor: "#fff",
+  defaultWidth: 480, defaultHeight: 340,
+  desktopIcon: true,
+  statusBar: true,
+  toolbar: [
+    { label: "Refresh", icon: "ti-refresh", onClick(ctx) { ctx._load && ctx._load(); } }
+  ],
+  create(ctx) {
+    const d = document.createElement("div");
+    d.className = "prog-mono";
+    d.textContent = "Loading /zosmf/info …";
+
+    ctx._load = async () => {
+      ctx.setStatus("GET /zosmf/info …");
+      if (ctx.system.demo) {
+        // canned response so the shell can be explored without a backend
+        d.textContent = JSON.stringify({
+          zosmf_saf_realm: "SAFRealm",
+          zosmf_port: "1080",
+          zosmf_full_version: "2.0.0",
+          api_version: "1",
+          zos_version: "MVS 3.8j",
+          zosmf_hostname: "demo.local",
+          note: "demo mode — canned data, no backend call"
+        }, null, 2);
+        ctx.setStatus("Demo mode — canned data");
+        return;
+      }
+      try {
+        const resp = await ctx.system.apiFetch("/zosmf/info");
+        const body = await resp.text();
+        try { d.textContent = JSON.stringify(JSON.parse(body), null, 2); }
+        catch (e) { d.textContent = body; }
+        ctx.setStatus(`HTTP ${resp.status} — ${ctx.system.baseUrl}/zosmf/info`);
+      } catch (e) {
+        d.textContent = "Request failed: " + e.message;
+        ctx.setStatus("Request failed");
+      }
+    };
+    ctx._load();
+    return d;
+  }
+});

--- a/static/js/programs/systems.js
+++ b/static/js/programs/systems.js
@@ -1,0 +1,82 @@
+/* ============================================================
+   systems.js (program) — systems manager window.
+   Lists configured systems with a live connection LED, lets you
+   add/remove remotes, and keeps the login dropdown + start-menu
+   submenu in sync. The origin-derived local system is read-only.
+   ============================================================ */
+import { Programs } from "./registry.js";
+import { SystemRegistry, checkSystem } from "../systems.js";
+import { Login } from "../login.js";
+import { StartMenu } from "../startmenu.js";
+
+Programs.register({
+  id: "systems",
+  name: "Systems",
+  icon: "ti-server",
+  iconBg: "#888880", iconColor: "#fff",
+  defaultWidth: 460, defaultHeight: 320,
+  desktopIcon: false,
+  statusBar: true,
+  create(ctx) {
+    const wrap = document.createElement("div");
+    wrap.style.cssText = "display:flex;flex-direction:column;height:100%;";
+    const listEl = document.createElement("div");
+    listEl.style.cssText = "flex:1;overflow:auto;";
+    wrap.appendChild(listEl);
+
+    const addBar = document.createElement("div");
+    addBar.className = "sys-add";
+    addBar.innerHTML = `
+      <input class="in-name" placeholder="NAME" maxlength="8">
+      <input class="in-host" placeholder="host / IP">
+      <input class="in-port" placeholder="1080" maxlength="5">
+      <button class="lb-btn" style="padding:2px 10px;">Add</button>`;
+    wrap.appendChild(addBar);
+
+    async function render() {
+      const systems = SystemRegistry.list();
+      listEl.innerHTML = "";
+      ctx.setStatus(`${systems.length} system(s) configured`);
+      for (const s of systems) {
+        const row = document.createElement("div");
+        row.className = "sys-row";
+        row.innerHTML = `
+          <span class="led" style="background:var(--wps-led-off);"></span>
+          <span class="name">${s.name}${s.local ? ' <span class="tag">(local)</span>' : ""}</span>
+          <span class="host">${s.host}:${s.port}</span>
+          <span class="stat">checking…</span>
+          ${s.local ? "" : '<span class="rm" title="Remove"><i class="ti ti-trash"></i></span>'}`;
+        const rm = row.querySelector(".rm");
+        if (rm) rm.addEventListener("click", () => {
+          SystemRegistry.remove(s.name);
+          render();
+        });
+        listEl.appendChild(row);
+        // async status check per system
+        checkSystem(s).then(res => {
+          const led = row.querySelector(".led");
+          const stat = row.querySelector(".stat");
+          if (res.status === "connected") { led.style.background = "var(--wps-led-green)"; stat.textContent = "connected"; }
+          else if (res.status === "auth_failed") { led.style.background = "var(--wps-led-yellow)"; stat.textContent = "auth required"; }
+          else if (res.status === "cors_blocked") { led.style.background = "var(--wps-led-yellow)"; stat.textContent = "cors blocked"; }
+          else { led.style.background = "var(--wps-led-red)"; stat.textContent = res.status; }
+        });
+      }
+    }
+
+    addBar.querySelector("button").addEventListener("click", () => {
+      const name = addBar.querySelector(".in-name").value.trim().toUpperCase();
+      const host = addBar.querySelector(".in-host").value.trim();
+      const port = parseInt(addBar.querySelector(".in-port").value.trim() || "1080", 10);
+      if (!name || !host) return;
+      SystemRegistry.add({ name, host, port });
+      addBar.querySelectorAll("input").forEach(i => i.value = "");
+      render();
+      Login.refreshSystems();   // keep login dropdown in sync
+      StartMenu.refreshSystems();
+    });
+
+    render();
+    return wrap;
+  }
+});

--- a/static/js/programs/welcome.js
+++ b/static/js/programs/welcome.js
@@ -1,0 +1,34 @@
+/* ============================================================
+   welcome.js — greeting window opened on first desktop entry.
+   Pure presentation; a good minimal example of the plugin API.
+   ============================================================ */
+import { Programs } from "./registry.js";
+
+Programs.register({
+  id: "welcome",
+  name: "Welcome",
+  icon: "ti-home",
+  iconBg: "#1084d0", iconColor: "#fff",
+  defaultWidth: 460, defaultHeight: 330,
+  desktopIcon: true,
+  create(ctx) {
+    const d = document.createElement("div");
+    d.className = "prog-pad";
+    d.innerHTML = `
+      <h1>Welcome to mvsMF Desktop</h1>
+      <p>This is the <b>Phase 1 shell prototype</b>: window manager,
+      taskbar, start menu, login and the program plugin API.</p>
+      <p>Try it out:</p>
+      <p>• Drag windows by their title bar<br>
+         • Resize from any edge or corner<br>
+         • Double-click the title bar to maximize<br>
+         • Minimize to the taskbar and bring windows back<br>
+         • Open several windows and watch the z-order</p>
+      <p>Programs are plugins — each one registers with
+      <code>Programs.register({...})</code> and receives a system context
+      with an authenticated <code>apiFetch()</code>.</p>
+      <p style="color:var(--wps-text-faint);">Connected to <code>${ctx.system.name}</code>
+      as <code>${ctx.system.user || "demo"}</code>.</p>`;
+    return d;
+  }
+});

--- a/static/js/shell.js
+++ b/static/js/shell.js
@@ -1,0 +1,70 @@
+/* ============================================================
+   shell.js — boot + glue
+   Entry point loaded by index.html as an ES module (implicitly
+   deferred, so the DOM is ready when this runs). It:
+     - imports every program module for its self-registration
+     - applies the persisted theme
+     - derives the local system from the page origin
+     - builds the desktop icons + start menu
+     - starts the tray clock and initialises the login screen
+
+   To add a Phase 2 program, drop js/programs/<id>.js next to the
+   others (copy _template.js) and add one import line below.
+   ============================================================ */
+import { Theme, SystemRegistry } from "./systems.js";
+import { Programs } from "./programs/registry.js";
+import { WM } from "./wm.js";
+import { StartMenu } from "./startmenu.js";
+import { Login } from "./login.js";
+
+/* Program modules — imported for their Programs.register() side effect.
+   Order here is the registration order (desktop icons + start menu). */
+import "./programs/welcome.js";
+import "./programs/sysinfo.js";
+import "./programs/systems.js";
+import "./programs/about.js";
+import "./programs/stubs.js";
+
+/* ---------- Desktop icons ---------- */
+function buildDesktopIcons() {
+  const host = document.getElementById("desktop-icons");
+  host.innerHTML = "";
+  Programs.all().filter(p => p.desktopIcon).forEach(p => {
+    const ic = document.createElement("div");
+    ic.className = "desk-icon";
+    ic.innerHTML = `
+      <div class="box" style="background:${p.iconBg};">
+        <i class="ti ${p.icon}" style="color:${p.iconColor};"></i>
+      </div>
+      <span class="label">${p.name}</span>`;
+    ic.addEventListener("click", () => {
+      document.querySelectorAll(".desk-icon.selected").forEach(x => x.classList.remove("selected"));
+      ic.classList.add("selected");
+    });
+    ic.addEventListener("dblclick", () => WM.open(p));
+    host.appendChild(ic);
+  });
+  // click on empty desktop clears selection
+  document.getElementById("desktop").addEventListener("pointerdown", ev => {
+    if (ev.target.id === "desktop")
+      document.querySelectorAll(".desk-icon.selected").forEach(x => x.classList.remove("selected"));
+  });
+}
+
+/* ---------- Tray clock (updates once a second) ---------- */
+setInterval(() => {
+  const el = document.getElementById("tray-clock");
+  if (el) el.textContent = new Date().toTimeString().slice(0, 8);
+}, 1000);
+
+/* ---------- Tray system name → open systems manager ---------- */
+document.getElementById("tray-sys").addEventListener("click", () => {
+  WM.open(Programs.get("systems"));
+});
+
+/* ---------- Boot ---------- */
+Theme.apply();                  // data-theme on <html> from SafeStore (default "os2")
+SystemRegistry.ensureLocal();   // page origin = default system when served from the HTTPD
+buildDesktopIcons();
+StartMenu.build();
+Login.init();

--- a/static/js/startmenu.js
+++ b/static/js/startmenu.js
@@ -1,0 +1,97 @@
+/* ============================================================
+   startmenu.js — Start menu + systems submenu
+   Program list (opens windows), Systems submenu with a live LED
+   per configured system, Settings / About / Logout. Closes on
+   outside click.
+   ============================================================ */
+import { Programs } from "./programs/registry.js";
+import { WM } from "./wm.js";
+import { SystemRegistry, checkSystem } from "./systems.js";
+import { Login } from "./login.js";
+
+export const StartMenu = (() => {
+  const menu = () => document.getElementById("startmenu");
+  const btn = () => document.getElementById("start-btn");
+  const submenu = () => document.getElementById("sys-submenu");
+
+  function build() {
+    const host = document.getElementById("sm-programs");
+    host.innerHTML = "";
+    Programs.all().filter(p => p.id !== "about").forEach(p => {
+      const item = document.createElement("div");
+      item.className = "sm-item";
+      item.innerHTML = `
+        <span class="pico" style="background:${p.iconBg};">
+          <i class="ti ${p.icon}" style="color:${p.iconColor};"></i>
+        </span>${p.name}`;
+      item.addEventListener("click", () => { hide(); WM.open(p); });
+      host.appendChild(item);
+    });
+
+    document.getElementById("sm-systems").addEventListener("click", ev => {
+      ev.stopPropagation();
+      toggleSubmenu();
+    });
+    document.getElementById("sm-settings").addEventListener("click", () => {
+      hide();
+      WM.open(Programs.get("systems"));   // settings = systems manager for now
+    });
+    document.getElementById("sm-about").addEventListener("click", () => {
+      hide(); WM.open(Programs.get("about"));
+    });
+    document.getElementById("sm-logout").addEventListener("click", () => {
+      hide(); Login.logout();
+    });
+
+    btn().addEventListener("click", ev => { ev.stopPropagation(); toggle(); });
+    document.addEventListener("pointerdown", ev => {
+      if (!menu().contains(ev.target) && !btn().contains(ev.target) && !submenu().contains(ev.target)) hide();
+    });
+  }
+
+  function refreshSystems() {
+    const sm = submenu();
+    sm.innerHTML = "";
+    SystemRegistry.list().forEach(s => {
+      const item = document.createElement("div");
+      item.className = "sm-item";
+      item.innerHTML = `
+        <span class="led" style="background:var(--wps-led-off);"></span>
+        <span class="mono">${s.name}</span>
+        <span class="hostinfo">${s.host}:${s.port}</span>`;
+      item.addEventListener("click", () => {
+        hideSubmenu(); hide();
+        // Phase 1: open the systems manager focused on that system
+        WM.open(Programs.get("systems"));
+      });
+      sm.appendChild(item);
+      checkSystem(s).then(res => {
+        item.querySelector(".led").style.background =
+          res.status === "connected" ? "var(--wps-led-green)" :
+          (res.status === "auth_failed" || res.status === "cors_blocked") ? "var(--wps-led-yellow)" : "var(--wps-led-red)";
+      });
+    });
+    const manage = document.createElement("div");
+    manage.className = "sm-item";
+    manage.innerHTML = `<span class="gico"><i class="ti ti-settings"></i></span>Manage systems…`;
+    manage.addEventListener("click", () => { hideSubmenu(); hide(); WM.open(Programs.get("systems")); });
+    sm.appendChild(manage);
+  }
+
+  function toggleSubmenu() {
+    const sm = submenu();
+    if (sm.classList.contains("open")) { hideSubmenu(); return; }
+    refreshSystems();
+    const anchor = document.getElementById("sm-systems").getBoundingClientRect();
+    sm.style.left = (anchor.right + 2) + "px";
+    sm.style.top = Math.max(4, anchor.top - 4) + "px";
+    sm.style.bottom = "auto";
+    sm.classList.add("open");
+  }
+  function hideSubmenu() { submenu().classList.remove("open"); }
+  function show() { menu().classList.add("open"); btn().classList.add("open"); }
+  function hide() { menu().classList.remove("open"); btn().classList.remove("open"); hideSubmenu(); }
+  function toggle() { menu().classList.contains("open") ? hide() : show(); }
+
+  return { build, refreshSystems, hide };
+})();

--- a/static/js/systems.js
+++ b/static/js/systems.js
@@ -1,0 +1,165 @@
+/* ============================================================
+   systems.js — persistence, theme, system registry, session
+   Leaf module: imports nothing from the shell, so every other
+   module can import from here without a cycle.
+   Exports: SafeStore, Theme, SystemRegistry, checkSystem, Session
+   ============================================================ */
+
+/* ---------- SafeStore: localStorage with in-memory fallback ----------
+   Sandboxed previews may block localStorage; a real deployment
+   on the HTTPD UFS uses it normally. */
+export const SafeStore = (() => {
+  let mem = {};
+  let ok = false;
+  try { localStorage.setItem("__t", "1"); localStorage.removeItem("__t"); ok = true; } catch (e) { ok = false; }
+  return {
+    get(key, fallback) {
+      try {
+        const raw = ok ? localStorage.getItem(key) : mem[key];
+        return raw ? JSON.parse(raw) : fallback;
+      } catch (e) { return fallback; }
+    },
+    set(key, value) {
+      const raw = JSON.stringify(value);
+      if (ok) { try { localStorage.setItem(key, raw); } catch (e) {} }
+      mem[key] = raw;
+    }
+  };
+})();
+
+/* ---------- Theme: data-theme on <html>, persisted ----------
+   Only the default "os2" theme ships in Phase 1; the mechanism
+   (attribute + persistence) is what Phase 2 themes build on. */
+export const Theme = {
+  KEY: "mvsmf.theme",
+  DEFAULT: "os2",
+  get() { return SafeStore.get(this.KEY, this.DEFAULT); },
+  set(name) {
+    SafeStore.set(this.KEY, name);
+    document.documentElement.setAttribute("data-theme", name);
+  },
+  /* Apply the stored (or default) theme to <html> on boot. */
+  apply() {
+    document.documentElement.setAttribute("data-theme", this.get());
+  }
+};
+
+/* ---------- System registry ---------- */
+export const SystemRegistry = {
+  KEY: "mvsmf.systems",
+  defaults: { systems: [], defaultSystem: null },
+  load() { return SafeStore.get(this.KEY, this.defaults); },
+  save(data) { SafeStore.set(this.KEY, data); },
+  list() { return this.load().systems; },
+  get(name) { return this.list().find(s => s.name === name); },
+  add(sys) {
+    const d = this.load();
+    d.systems = d.systems.filter(s => s.name !== sys.name);
+    d.systems.push(sys);
+    this.save(d);
+  },
+  remove(name) {
+    const d = this.load();
+    d.systems = d.systems.filter(s => s.name !== name);
+    this.save(d);
+  },
+  baseUrl(sys) {
+    // local system follows the page protocol (works behind a TLS proxy);
+    // remote MVS 3.8j systems are plain http
+    const proto = sys.local ? location.protocol : "http:";
+    return `${proto}//${sys.host}:${sys.port}`;
+  },
+  /* Derive the "local" system from the URL this page was served from.
+     When the desktop is deployed on the HTTPD UFS, that host IS the
+     default mvsMF system — no manual configuration needed. */
+  ensureLocal() {
+    if (!/^https?:$/.test(location.protocol) || !location.hostname) return null;
+    const host = location.hostname;
+    const port = location.port ? parseInt(location.port, 10)
+                               : (location.protocol === "https:" ? 443 : 80);
+    const d = this.load();
+    let sys = d.systems.find(s => s.host === host && s.port === port);
+    if (!sys) {
+      // derive a system name from the first hostname label,
+      // e.g. MVSDEV from mvsdev.lan (max 8 chars, mainframe style)
+      let name = host.split(".")[0].toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 8) || "LOCAL";
+      if (d.systems.some(s => s.name === name)) name = "LOCAL";
+      sys = { name, host, port, local: true };
+      d.systems.unshift(sys);
+    } else {
+      sys.local = true;
+    }
+    d.systems.forEach(s => { if (s !== sys) delete s.local; });
+    d.defaultSystem = sys.name;
+    this.save(d);
+    return sys;
+  }
+};
+
+/* ---------- Connection check via /zosmf/info ---------- */
+export async function checkSystem(sys, auth) {
+  // auth: optional {user, pass} to verify credentials
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 4000);
+  try {
+    // Anonymous probe stays a "simple request" (no custom headers) so it
+    // avoids a CORS preflight; authenticated checks send the full headers.
+    const headers = {};
+    if (auth) {
+      headers["Authorization"] = "Basic " + btoa(auth.user + ":" + auth.pass);
+      headers["X-CSRF-ZOSMF-HEADER"] = "true";
+    }
+    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { headers, signal: ctl.signal });
+    clearTimeout(timer);
+    if (resp.ok) {
+      let info = null;
+      try { info = await resp.json(); } catch (e) {}
+      return { status: "connected", info };
+    }
+    if (resp.status === 401 || resp.status === 403) return { status: "auth_failed" };
+    return { status: "error", code: resp.status };
+  } catch (e) {
+    clearTimeout(timer);
+    // Fetch failed — either the host is down or the browser blocked the
+    // response (missing CORS headers on a cross-origin request). An
+    // opaque no-cors probe still resolves when the host is reachable.
+    try {
+      const ctl2 = new AbortController();
+      const t2 = setTimeout(() => ctl2.abort(), 4000);
+      await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { mode: "no-cors", signal: ctl2.signal });
+      clearTimeout(t2);
+      return { status: "cors_blocked" };
+    } catch (e2) {
+      return { status: "unreachable" };
+    }
+  }
+}
+
+/* ---------- Session (current login) ---------- */
+export const Session = {
+  system: null,     // system object from registry
+  user: null,
+  pass: null,
+  demo: false,
+  /* Build a system context handed to every program window. */
+  contextFor(systemName) {
+    const sys = systemName ? SystemRegistry.get(systemName) : this.system;
+    const self = this;
+    return {
+      name: sys ? sys.name : (self.demo ? "DEMO" : "?"),
+      host: sys ? sys.host : "demo.local",
+      port: sys ? sys.port : 0,
+      baseUrl: sys ? SystemRegistry.baseUrl(sys) : "",
+      user: self.user,
+      demo: self.demo,
+      async apiFetch(path, options = {}) {
+        if (self.demo) throw new Error("demo mode: no backend");
+        options.headers = Object.assign({
+          "Authorization": "Basic " + btoa(self.user + ":" + self.pass),
+          "X-CSRF-ZOSMF-HEADER": "true"
+        }, options.headers || {});
+        return fetch(this.baseUrl + path, options);
+      }
+    };
+  }
+};

--- a/static/js/taskbar.js
+++ b/static/js/taskbar.js
@@ -1,0 +1,39 @@
+/* ============================================================
+   taskbar.js — window button strip in the taskbar
+   One button per open window: click toggles minimize / restore /
+   focus. WM keeps the "active" (focused) button in sync.
+   Imports WM only for the click behaviour (runtime); the
+   wm <-> taskbar cycle is safe (see wm.js).
+   ============================================================ */
+import { WM } from "./wm.js";
+
+export const Taskbar = (() => {
+  const container = () => document.getElementById("task-buttons");
+  const buttons = new Map();
+
+  function add(id, program, title) {
+    const b = document.createElement("div");
+    b.className = "task-btn active";
+    b.innerHTML = `<i class="ti ${program.icon}" style="font-size:12px;flex:0 0 auto;"></i><span>${title}</span>`;
+    b.addEventListener("click", () => {
+      if (WM.isMinimized(id)) WM.restore(id);
+      else if (WM.isFocused(id)) WM.minimize(id);
+      else WM.focus(id);
+    });
+    container().appendChild(b);
+    buttons.set(id, b);
+  }
+  function remove(id) {
+    const b = buttons.get(id);
+    if (b) b.remove();
+    buttons.delete(id);
+  }
+  function rename(id, title) {
+    const b = buttons.get(id);
+    if (b) b.querySelector("span").textContent = title;
+  }
+  function setActive(id) {
+    buttons.forEach((b, key) => b.classList.toggle("active", key === id));
+  }
+  return { add, remove, rename, setActive };
+})();

--- a/static/js/wm.js
+++ b/static/js/wm.js
@@ -1,0 +1,288 @@
+/* ============================================================
+   wm.js — window manager
+   Open/close/minimize/maximize/restore, drag, 8-way resize,
+   focus + z-order, cascade. Imports Session for the per-window
+   system context and Taskbar for the button strip.
+   The wm <-> taskbar import cycle is safe: each only calls the
+   other inside event handlers (runtime), never at module load.
+   ============================================================ */
+import { Session } from "./systems.js";
+import { Taskbar } from "./taskbar.js";
+
+export const WM = (() => {
+  const windows = new Map();   // id -> win record
+  let zTop = 10;
+  let seq = 0;
+  let cascade = 0;
+  const desktop = () => document.getElementById("desktop");
+
+  function focus(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    zTop += 1;
+    w.el.style.zIndex = zTop;
+    windows.forEach(x => x.el.classList.toggle("focused", x.id === id));
+    Taskbar.setActive(id);
+  }
+
+  function focusTopmost() {
+    let best = null;
+    windows.forEach(w => {
+      if (w.state === "minimized") return;
+      const z = parseInt(w.el.style.zIndex || "0", 10);
+      if (!best || z > best.z) best = { id: w.id, z };
+    });
+    if (best) focus(best.id); else Taskbar.setActive(null);
+  }
+
+  function open(program, systemName) {
+    const id = "win_" + (++seq);
+    const ctx = Session.contextFor(systemName);
+    const dsk = desktop().getBoundingClientRect();
+
+    const width = Math.min(program.defaultWidth || 500, dsk.width - 40);
+    const height = Math.min(program.defaultHeight || 380, dsk.height - 40);
+    cascade = (cascade + 1) % 8;
+    const x = 60 + cascade * 26;
+    const y = 30 + cascade * 24;
+
+    const el = document.createElement("div");
+    el.className = "wps-window focused";
+    el.style.cssText = `left:${x}px; top:${y}px; width:${width}px; height:${height}px; z-index:${++zTop};`;
+
+    // Title bar
+    const tb = document.createElement("div");
+    tb.className = "wps-titlebar";
+    tb.innerHTML = `
+      <div class="tleft">
+        <div class="ticon"><i class="ti ${program.icon}"></i></div>
+        <span class="ttext">${program.name}<span class="tsys">— ${ctx.name}</span></span>
+      </div>
+      <div class="tbtns">
+        <div class="tbtn" data-act="min">_</div>
+        <div class="tbtn" data-act="max">□</div>
+        <div class="tbtn" data-act="close" style="font-weight:500;">×</div>
+      </div>`;
+    el.appendChild(tb);
+
+    // Optional toolbar
+    if (program.toolbar && program.toolbar.length) {
+      const bar = document.createElement("div");
+      bar.className = "wps-toolbar";
+      program.toolbar.forEach(item => {
+        const b = document.createElement("div");
+        b.className = "tb-btn";
+        b.innerHTML = (item.icon ? `<i class="ti ${item.icon}" style="font-size:13px;"></i>` : "") + item.label;
+        b.addEventListener("click", () => item.onClick && item.onClick(winCtx));
+        bar.appendChild(b);
+      });
+      el.appendChild(bar);
+    }
+
+    // Content
+    const content = document.createElement("div");
+    content.className = "wps-content";
+    el.appendChild(content);
+
+    // Optional status bar
+    let statusEl = null;
+    if (program.statusBar) {
+      statusEl = document.createElement("div");
+      statusEl.className = "wps-statusbar";
+      statusEl.innerHTML = `<span class="sb-l"></span><span class="sb-r">${ctx.name} — ${ctx.user || ""}</span>`;
+      el.appendChild(statusEl);
+    }
+
+    // Resize handles
+    ["n","s","e","w","ne","nw","se","sw"].forEach(dir => {
+      const h = document.createElement("div");
+      h.className = "rs rs-" + dir;
+      h.dataset.dir = dir;
+      el.appendChild(h);
+    });
+
+    desktop().appendChild(el);
+
+    const win = {
+      id, program, el, content, statusEl,
+      state: "normal",
+      prevRect: null,
+      title: program.name,
+      systemName: ctx.name
+    };
+    windows.set(id, win);
+
+    // Context object handed to the program instance
+    const winCtx = {
+      windowId: id,
+      system: ctx,
+      contentEl: content,
+      setTitle(t) {
+        win.title = t;
+        tb.querySelector(".ttext").innerHTML = `${t}<span class="tsys">— ${ctx.name}</span>`;
+        Taskbar.rename(id, t);
+      },
+      setStatus(text) { if (statusEl) statusEl.querySelector(".sb-l").textContent = text; },
+      close() { close(id); }
+    };
+    win.ctx = winCtx;
+
+    // Mount program content
+    try {
+      const node = program.create(winCtx);
+      if (node) content.appendChild(node);
+    } catch (e) {
+      content.innerHTML = `<div class="prog-pad prog-err">Program error: ${e.message}</div>`;
+    }
+
+    // --- events ---
+    el.addEventListener("pointerdown", () => focus(id));
+
+    tb.addEventListener("pointerdown", ev => {
+      if (ev.target.closest(".tbtn")) return;
+      startDrag(win, ev);
+    });
+    tb.addEventListener("dblclick", ev => {
+      if (ev.target.closest(".tbtn")) return;
+      toggleMax(id);
+    });
+    tb.querySelectorAll(".tbtn").forEach(btn => {
+      btn.addEventListener("click", ev => {
+        ev.stopPropagation();
+        const act = btn.dataset.act;
+        if (act === "close") close(id);
+        else if (act === "min") minimize(id);
+        else if (act === "max") toggleMax(id);
+      });
+    });
+
+    el.querySelectorAll(".rs").forEach(h => {
+      h.addEventListener("pointerdown", ev => startResize(win, ev, h.dataset.dir));
+    });
+
+    Taskbar.add(id, program, win.title);
+    focus(id);
+    return id;
+  }
+
+  function close(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    try { w.program.destroy && w.program.destroy(w.ctx); } catch (e) {}
+    w.el.remove();
+    windows.delete(id);
+    Taskbar.remove(id);
+    focusTopmost();
+  }
+
+  function minimize(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    w.state = "minimized";
+    w.el.classList.add("minimized");
+    Taskbar.setActive(null);
+    focusTopmost();
+  }
+
+  function restore(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    w.state = w.prevRect ? "maximized" : "normal";
+    w.el.classList.remove("minimized");
+    focus(id);
+  }
+
+  function toggleMax(id) {
+    const w = windows.get(id);
+    if (!w) return;
+    const dsk = desktop().getBoundingClientRect();
+    if (w.state !== "maximized") {
+      w.prevRect = {
+        left: w.el.style.left, top: w.el.style.top,
+        width: w.el.style.width, height: w.el.style.height
+      };
+      w.el.style.left = "0px"; w.el.style.top = "0px";
+      w.el.style.width = dsk.width + "px"; w.el.style.height = dsk.height + "px";
+      w.el.classList.add("maximized");
+      w.state = "maximized";
+    } else {
+      const p = w.prevRect || { left: "60px", top: "40px", width: "500px", height: "380px" };
+      w.el.style.left = p.left; w.el.style.top = p.top;
+      w.el.style.width = p.width; w.el.style.height = p.height;
+      w.el.classList.remove("maximized");
+      w.state = "normal";
+      w.prevRect = null;
+    }
+  }
+
+  /* Dragging via pointer events; keeps the title bar reachable. */
+  function startDrag(win, ev) {
+    if (win.state === "maximized") return;
+    ev.preventDefault();
+    focus(win.id);
+    const startX = ev.clientX, startY = ev.clientY;
+    const rect = win.el.getBoundingClientRect();
+    const dsk = desktop().getBoundingClientRect();
+    const offX = startX - rect.left, offY = startY - rect.top;
+
+    function move(e) {
+      let nx = e.clientX - offX;
+      let ny = e.clientY - offY;
+      // constraints: keep >= 60px of window on screen, titlebar never above top
+      nx = Math.max(-(rect.width - 60), Math.min(nx, dsk.width - 60));
+      ny = Math.max(0, Math.min(ny, dsk.height - 24));
+      win.el.style.left = nx + "px";
+      win.el.style.top = ny + "px";
+    }
+    function up() {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+    }
+    document.addEventListener("pointermove", move);
+    document.addEventListener("pointerup", up);
+  }
+
+  /* Resizing from any edge/corner; respects program min sizes. */
+  function startResize(win, ev, dir) {
+    if (win.state === "maximized") return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    focus(win.id);
+    const rect = win.el.getBoundingClientRect();
+    const dskRect = desktop().getBoundingClientRect();
+    const startX = ev.clientX, startY = ev.clientY;
+    const minW = win.program.minWidth || 240;
+    const minH = win.program.minHeight || 140;
+    const orig = { left: rect.left - dskRect.left, top: rect.top - dskRect.top, w: rect.width, h: rect.height };
+
+    function move(e) {
+      const dx = e.clientX - startX, dy = e.clientY - startY;
+      let { left, top, w, h } = orig;
+      if (dir.includes("e")) w = Math.max(minW, orig.w + dx);
+      if (dir.includes("s")) h = Math.max(minH, orig.h + dy);
+      if (dir.includes("w")) { w = Math.max(minW, orig.w - dx); left = orig.left + (orig.w - w); }
+      if (dir.includes("n")) { h = Math.max(minH, orig.h - dy); top = Math.max(0, orig.top + (orig.h - h)); h = orig.h + (orig.top - top); }
+      win.el.style.left = left + "px";
+      win.el.style.top = top + "px";
+      win.el.style.width = w + "px";
+      win.el.style.height = h + "px";
+    }
+    function up() {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+    }
+    document.addEventListener("pointermove", move);
+    document.addEventListener("pointerup", up);
+  }
+
+  function isMinimized(id) {
+    const w = windows.get(id);
+    return w ? w.state === "minimized" : false;
+  }
+  function isFocused(id) {
+    const w = windows.get(id);
+    return w ? w.el.classList.contains("focused") : false;
+  }
+
+  return { open, close, minimize, restore, focus, isMinimized, isFocused };
+})();

--- a/tools/deploy-desktop.sh
+++ b/tools/deploy-desktop.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# =========================================================================
+# deploy-desktop.sh — upload the mvsMF Desktop (static/) to the HTTPD UFS
+#
+# Dogfoods our own USS REST API: creates the target directory tree with
+# POST /zosmf/restfiles/fs{dir} {"type":"directory"} and uploads every
+# file with PUT /zosmf/restfiles/fs{path} in text mode (normal IBM-1047
+# USS conversion). No binary assets exist yet.
+#
+# Target directory defaults to /www/mvsmf (the HTTPD's default DOCROOT
+# is /www, so this is served as /mvsmf/). Override with DESKTOP_UFS_DIR
+# if your HTTPD DOCROOT differs, e.g. /wwwroot/mvsmf.
+#
+# Connection is read from .env at the repo root. It uses the same
+# MVSMF_* variables as the curl test suites, falling back to the mbt
+# MBT_MVS_* variables when those are not set.
+#
+# Usage:
+#   tools/deploy-desktop.sh              deploy static/ to the UFS
+#   tools/deploy-desktop.sh --dry-run    print what would happen, no upload
+#   DESKTOP_UFS_DIR=/wwwroot/mvsmf tools/deploy-desktop.sh
+# =========================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ] && DRY_RUN=1
+
+ENV_FILE="${ROOT_DIR}/.env"
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found. Copy .env.example to .env and fill it in." >&2
+	exit 1
+fi
+# shellcheck source=/dev/null
+. "$ENV_FILE"
+
+# Prefer the test-suite variables; fall back to the mbt deploy variables.
+MVS_HOST="${MVSMF_HOST:-${MBT_MVS_HOST:-}}"
+MVS_PORT="${MVSMF_PORT:-${MBT_MVS_PORT:-1080}}"
+MVS_USER="${MVSMF_USER:-${MBT_MVS_USER:-}}"
+MVS_PASS="${MVSMF_PASS:-${MBT_MVS_PASS:-}}"
+DESKTOP_UFS_DIR="${DESKTOP_UFS_DIR:-/www/mvsmf}"
+
+if [ "$DRY_RUN" != "1" ] && { [ -z "$MVS_HOST" ] || [ -z "$MVS_USER" ]; }; then
+	echo "ERROR: set MVSMF_HOST/MVSMF_USER/MVSMF_PASS (or MBT_MVS_*) in .env" >&2
+	exit 1
+fi
+
+BASE_URL="http://${MVS_HOST}:${MVS_PORT}"
+AUTH="${MVS_USER}:${MVS_PASS}"
+API="${BASE_URL}/zosmf/restfiles/fs"
+
+echo "Deploying static/ -> ${BASE_URL}${DESKTOP_UFS_DIR}  (as ${MVS_USER})"
+[ "$DRY_RUN" = "1" ] && echo "(dry run — no requests sent)"
+
+FAILED=0
+
+# --- create a directory (idempotent: UFSD_RC_EXIST maps to HTTP 400) ---
+create_dir() {
+	local d="$1" code
+	if [ "$DRY_RUN" = "1" ]; then echo "  mkdir  ${d}"; return 0; fi
+	code=$(curl -s -o /dev/null -w '%{http_code}' \
+		-X POST -u "$AUTH" \
+		-H "Content-Type: application/json" \
+		-d '{"type":"directory"}' \
+		"${API}${d}")
+	case "$code" in
+		200|201|204)  echo "  mkdir  ${d}  (${code})";;
+		400|409)      echo "  mkdir  ${d}  (exists)";;
+		*)            echo "  mkdir  ${d}  FAILED (${code})"; FAILED=$((FAILED+1));;
+	esac
+}
+
+# --- upload a file in text mode (EBCDIC conversion on the server) ---
+put_file() {
+	local src="$1" dst="$2" code
+	if [ "$DRY_RUN" = "1" ]; then echo "  put    ${dst}"; return 0; fi
+	code=$(curl -s -o /dev/null -w '%{http_code}' \
+		-X PUT -u "$AUTH" \
+		-H "X-IBM-Data-Type: text" \
+		-H "Content-Type: text/plain" \
+		--data-binary @"${src}" \
+		"${API}${dst}")
+	case "$code" in
+		200|201|204)  echo "  put    ${dst}  (${code})";;
+		*)            echo "  put    ${dst}  FAILED (${code})"; FAILED=$((FAILED+1));;
+	esac
+}
+
+# --- 1. create the directory tree (ancestors first, then subdirs) ---
+echo "Creating directories…"
+acc=""
+IFS='/' read -ra parts <<< "${DESKTOP_UFS_DIR#/}"
+for p in "${parts[@]}"; do
+	acc="${acc}/${p}"
+	create_dir "$acc"
+done
+while IFS= read -r d; do
+	rel="${d#static}"            # /css, /js, /js/programs  (empty for static itself)
+	[ -z "$rel" ] && continue
+	create_dir "${DESKTOP_UFS_DIR}${rel}"
+done < <(find static -type d | sort)
+
+# --- 2. upload every file ---
+echo "Uploading files…"
+while IFS= read -r f; do
+	rel="${f#static/}"          # index.html, css/desktop.css, js/…
+	put_file "$f" "${DESKTOP_UFS_DIR}/${rel}"
+done < <(find static -type f -not -name '.DS_Store' | sort)
+
+echo "---"
+if [ "$FAILED" -gt 0 ]; then
+	echo "Done with ${FAILED} failure(s)."
+	exit 1
+fi
+echo "Done. Open ${BASE_URL}/$(basename "$DESKTOP_UFS_DIR")/ in a browser."


### PR DESCRIPTION
Fixes #146

Ports the single-file PoC into the production module structure per `docs/desktop-spec.md`, with a full theme-hardening pass and a deploy target.

## What changed
- **PoC → reference:** `static/index.html` (the single-file PoC) moved to `docs/desktop-poc.html` (behavioral reference).
- **Modular `static/`** (ES modules, `<script type="module">`, English comments):
  - `index.html` — markup only, links `css/desktop.css`, boots `js/shell.js`, `data-theme="os2"` on `<html>`.
  - `css/desktop.css` — all styles.
  - `js/` — `systems.js` (SafeStore, Theme, SystemRegistry, checkSystem, Session), `wm.js`, `taskbar.js`, `startmenu.js`, `login.js`, `shell.js` (boot/glue).
  - `js/programs/` — `registry.js`, `welcome.js`, `sysinfo.js`, `systems.js`, `about.js`, `stubs.js` (7 Phase-2 placeholders), and a documented `_template.js`.
- **Theme-hardening:** every chrome colour and 3D bezel style is now a `--wps-*` custom property (logo gradient, login-status tints, content background, grays, `--wps-bezel-*`). Theme is applied via `data-theme` on `<html>` and persisted through SafeStore. Program `iconBg`/`iconColor` stay in the program definitions (per spec — they belong to the program, not the theme).
- **Plugin API unchanged** — `Programs.register({...})`, window `ctx` with `system.apiFetch()`, `setTitle`/`setStatus`/`close`. Phase 2 programs build on it as-is.
- **Deploy:** `make deploy-desktop` + `tools/deploy-desktop.sh` upload `static/` to the HTTPD UFS via our own USS REST API (POST create-dir tree, then PUT each file in text mode), dogfooding it. Idempotent (`UFSD_RC_EXIST`/400 ignored). `make deploy-desktop-dry` previews without touching MVS.

## Verification
Served `static/` locally and drove it in headless Chrome (DevTools protocol):
- **0 JS exceptions, 0 console errors** on module load — the whole ES-module graph (incl. the intentional `wm ↔ taskbar` runtime cycle) wires up cleanly.
- Demo mode enters the desktop; Welcome opens; 9 desktop icons + 10 start-menu items registered in the right order.
- Window manager: open / focus / maximize (title dbl-click) / minimize / close all correct; taskbar buttons track windows; tray → systems manager cross-module glue works; `data-theme="os2"` applied.
- `make deploy-desktop-dry` produces the correct directory tree + file list.

Scope note: the headless run proves the **module graph + WM/taskbar/glue/theme** are correct; drag and 8-way resize were ported verbatim from the PoC but not behaviorally driven in the harness.

## Serve-time gates — confirmed against the HTTPD source (`../httpd`)
No `.js`/`.css` had ever been served from the HTTPD UFS before (the PoC was one self-contained `.html`), so both static-serve gates were checked in `httpd/src`:
- **MIME (`httpmime.c`):** `.js` → `application/x-javascript` (a valid JavaScript MIME type — module scripts execute), `.css` → `text/css`. Both `binary=0`.
- **Encoding (`httpopen.c`):** character files (`binary=0`) open in text mode, so they are served with EBCDIC→ASCII translation — matching the text-mode (IBM-1047) PUT the deploy uses.
- **Docroot (`httpprm.c`):** the HTTPD prepends `DOCROOT` (default `/www`) to the request path, so the deploy dir defaults to **`/www/mvsmf`** (served at `/mvsmf/`). Override with `make deploy-desktop DESKTOP_UFS_DIR=/wwwroot/mvsmf` for a custom docroot.

## Notes for the reviewer
- **Extra files beyond the spec's list:** `programs/registry.js` (the registry needs a leaf module so program files can self-register without a TDZ), plus `programs/about.js` and `programs/stubs.js` (required for PoC feature parity). No change to the plugin API shape.
- **`.env` convention:** the script reads `MVSMF_*` (same as the curl test suites), falling back to `MBT_MVS_*`.
- **`file://` demo mode — known deviation:** the spec's "demo mode works from `file://`" cannot be met by an ES-module build (Chromium blocks module imports over `file://`). The spec mandates ES modules *and* no build step, which is exactly what breaks `file://`. Test demo mode with a static server, e.g. `python3 -m http.server --directory static`.

## Post-deploy sanity check (on the live system)
```
curl -sI http://<host>:<port>/mvsmf/js/shell.js | grep -i content-type   # expect application/x-javascript
curl -s  http://<host>:<port>/mvsmf/js/shell.js | head                    # expect readable ASCII
```
Then open `http://<host>:<port>/mvsmf/` and log in against the local system (same-origin).
