### PR TITLE
Desktop: LED green whenever a system is reachable

### DIFF
--- a/static/js/login.js
+++ b/static/js/login.js
@@ -42,15 +42,20 @@ export const Login = (() => {
     setStatus("wait", "var(--wps-led-off)", `Checking ${sys.name} …`);
     const res = await checkSystem(sys);
     if (mySeq !== checkSeq) return;   // stale response, selection changed
+    // Green whenever the endpoint is reachable at all; only "unreachable"
+    // is red. The distinct texts keep the detail the LED no longer encodes.
     if (res.status === "connected") {
       const ver = res.info && (res.info.zos_version || res.info.zosmf_full_version);
       setStatus("ok", "var(--wps-led-green)", `Connected${ver ? " — " + ver : ""}`);
     } else if (res.status === "auth_failed") {
-      setStatus("warn", "var(--wps-led-yellow)", "Reachable — authentication required");
+      setStatus("ok", "var(--wps-led-green)", "Connected — login required");
     } else if (res.status === "cors_blocked") {
-      setStatus("warn", "var(--wps-led-yellow)", "Reachable — response blocked by CORS (serve this page from the HTTPD)");
-    } else {
+      setStatus("ok", "var(--wps-led-green)", "Connected — cross-origin (CORS pending)");
+    } else if (res.status === "unreachable") {
       setStatus("bad", "var(--wps-led-red)", "Unreachable — check host and port");
+    } else {
+      // reachable, but /zosmf/info returned an unexpected HTTP status
+      setStatus("ok", "var(--wps-led-green)", `Reachable — HTTP ${res.code || "?"}`);
     }
   }
 
@@ -75,7 +80,8 @@ export const Login = (() => {
     } else if (res.status === "auth_failed") {
       setStatus("bad", "var(--wps-led-red)", "Login failed — check credentials");
     } else if (res.status === "cors_blocked") {
-      setStatus("warn", "var(--wps-led-yellow)", "Blocked by CORS — serve this page from the HTTPD or use demo mode");
+      // reachable, but cross-origin blocks reading the auth response
+      setStatus("ok", "var(--wps-led-green)", "Connected — cross-origin (CORS pending); serve from the HTTPD or use demo mode");
     } else {
       setStatus("bad", "var(--wps-led-red)", "System unreachable");
     }

--- a/static/js/programs/systems.js
+++ b/static/js/programs/systems.js
@@ -52,14 +52,18 @@ Programs.register({
           render();
         });
         listEl.appendChild(row);
-        // async status check per system
+        // async status check per system — green whenever reachable at all,
+        // red only when unreachable; the text keeps the distinct detail
         checkSystem(s).then(res => {
           const led = row.querySelector(".led");
           const stat = row.querySelector(".stat");
-          if (res.status === "connected") { led.style.background = "var(--wps-led-green)"; stat.textContent = "connected"; }
-          else if (res.status === "auth_failed") { led.style.background = "var(--wps-led-yellow)"; stat.textContent = "auth required"; }
-          else if (res.status === "cors_blocked") { led.style.background = "var(--wps-led-yellow)"; stat.textContent = "cors blocked"; }
-          else { led.style.background = "var(--wps-led-red)"; stat.textContent = res.status; }
+          led.style.background = res.status === "unreachable"
+            ? "var(--wps-led-red)" : "var(--wps-led-green)";
+          if (res.status === "connected") stat.textContent = "connected";
+          else if (res.status === "auth_failed") stat.textContent = "login required";
+          else if (res.status === "cors_blocked") stat.textContent = "cross-origin";
+          else if (res.status === "unreachable") stat.textContent = "unreachable";
+          else stat.textContent = "HTTP " + (res.code || "?");
         });
       }
     }

--- a/static/js/startmenu.js
+++ b/static/js/startmenu.js
@@ -66,9 +66,9 @@ export const StartMenu = (() => {
       });
       sm.appendChild(item);
       checkSystem(s).then(res => {
+        // green whenever reachable at all; red only when unreachable
         item.querySelector(".led").style.background =
-          res.status === "connected" ? "var(--wps-led-green)" :
-          (res.status === "auth_failed" || res.status === "cors_blocked") ? "var(--wps-led-yellow)" : "var(--wps-led-red)";
+          res.status === "unreachable" ? "var(--wps-led-red)" : "var(--wps-led-green)";
       });
     });
     const manage = document.createElement("div");


### PR DESCRIPTION
Fixes #149

Simplifies the connection-status LED to two colours: **green whenever the endpoint is reachable at all**, **red only when unreachable**. Yellow is no longer used for connection status.

## Mapping (was → now)
| checkSystem state | LED before | LED now | status text now |
|---|---|---|---|
| connected (200) | green | green | `Connected — <zos_version>` |
| auth_failed (401/403) | 🟡 yellow | 🟢 green | `Connected — login required` |
| cors_blocked | 🟡 yellow | 🟢 green | `Connected — cross-origin (CORS pending)` |
| unreachable | red | red | `Unreachable — check host and port` |
| error (other HTTP, e.g. 500) | red | 🟢 green | `Reachable — HTTP <code>` |

## Touch points
- `js/login.js` — login status bar: 401 and cors_blocked now use the green (`ok`) tint to match the LED. The login **submit** path still shows red on a wrong password (`Login failed — check credentials`).
- `js/programs/systems.js` — systems-manager row LEDs + status text.
- `js/startmenu.js` — start-menu systems submenu LEDs.
- `js/systems.js` (data layer) **unchanged** — `checkSystem()` still returns the distinct states; only the UI colour mapping changed.

## Notes
- **`error` (non-401/403 HTTP response) → green.** A 5xx means the box answered, i.e. reachable, so per "green whenever reachable at all / only unreachable stays red" it is green (text `Reachable — HTTP <code>`). Keeping it red would contradict that rule.
- **Yellow is not fully retired** — it still marks the demo-mode tray LED and two input-validation prompts (`no systems configured`, `enter a username`), which are not connection status.

## Verification
Served the working tree locally and drove **every** `checkSystem` state deterministically in headless Chrome (stubbed `fetch`), asserting LED colour + tint class + text:
- login bar: connected / 401 / cors / 500 → green+`ok`; unreachable → red+`bad` — all texts exact ✓
- systems-manager row: 401 → green + "login required" (was yellow); unreachable → red + "unreachable" ✓
- start-menu submenu: 401 → green (was yellow) ✓
- no connection LED carries the yellow token anymore ✓
- 0 JS exceptions

9/9 assertions pass.
