### PR TITLE
Desktop 2.2: JES spool browser with job tree and output viewer

### DIFF
--- a/docs/desktop-spec.md
+++ b/docs/desktop-spec.md
@@ -43,7 +43,8 @@ static/
 │       ├── welcome.js
 │       ├── sysinfo.js      # fetches /zosmf/info via ctx.system.apiFetch
 │       ├── systems.js      # systems manager program
-│       └── datasets.js     # dataset browser (Phase 2.1)
+│       ├── datasets.js     # dataset browser (Phase 2.1)
+│       └── spool.js        # JES spool browser (Phase 2.2)
 ├── vendor/
 │   ├── prism.js            # Prism 1.29.0 core+clike+c (pinned, air-gap safe)
 │   └── prism.css           # Prism default theme

--- a/static/css/desktop.css
+++ b/static/css/desktop.css
@@ -431,8 +431,13 @@ html, body {
 .spl-active { color: var(--wps-led-green); font-size: 12px; }
 .dsb-node.selected .spl-rc-ok, .dsb-node.selected .spl-rc-bad,
 .dsb-node.selected .spl-rc-dim { color: var(--wps-title-text); }
-.spl-step { font-size: 9px; color: var(--wps-text-muted); margin-left: 4px; }
-.dsb-node.selected .spl-step { color: var(--wps-title-system); }
+.spl-ddname { white-space: pre; }
+.spl-step {
+  font-size: 9px; color: var(--wps-text-muted); margin-left: 6px;
+  overflow: hidden; text-overflow: ellipsis;
+}
+.spl-recs { margin-left: auto; padding-left: 8px; font-size: 9px; color: var(--wps-text-muted); flex: 0 0 auto; }
+.dsb-node.selected .spl-step, .dsb-node.selected .spl-recs { color: var(--wps-title-system); }
 /* spool output: monospace, columns preserved — never wrap or trim
    (ASA carriage control in col 1; listings are column-significant) */
 pre.spl-out {

--- a/static/css/desktop.css
+++ b/static/css/desktop.css
@@ -419,6 +419,36 @@ html, body {
 }
 .sys-add .in-name { width: 80px; } .sys-add .in-host { flex: 1; } .sys-add .in-port { width: 56px; }
 
+/* ---------- JES spool browser program ---------- */
+.spl-in { width: 80px; text-transform: uppercase; }
+.spl-auto { display: flex; align-items: center; gap: 4px; font-size: 11px; color: var(--wps-text-dim); cursor: pointer; }
+.spl-tree { width: 250px; }
+.spl-jobname { font-weight: 500; }
+.spl-rc { margin-left: auto; font-size: 10px; padding-left: 8px; }
+.spl-rc-ok  { color: var(--wps-status-ok-fg); }
+.spl-rc-bad { color: var(--wps-status-bad-fg); font-weight: 500; }
+.spl-rc-dim { color: var(--wps-text-muted); }
+.spl-active { color: var(--wps-led-green); font-size: 12px; }
+.dsb-node.selected .spl-rc-ok, .dsb-node.selected .spl-rc-bad,
+.dsb-node.selected .spl-rc-dim { color: var(--wps-title-text); }
+.spl-step { font-size: 9px; color: var(--wps-text-muted); margin-left: 4px; }
+.dsb-node.selected .spl-step { color: var(--wps-title-system); }
+/* spool output: monospace, columns preserved — never wrap or trim
+   (ASA carriage control in col 1; listings are column-significant) */
+pre.spl-out {
+  position: absolute; inset: 0; margin: 0; overflow: auto;
+  padding: 8px 10px; background: var(--wps-content-bg);
+}
+pre.spl-out code {
+  font-family: var(--wps-font-mono); font-size: 12px; line-height: 18px;
+  white-space: pre; tab-size: 8; user-select: text;
+}
+.spl-more {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  display: flex; justify-content: center; padding: 4px;
+  background: var(--wps-chrome-dark); border-top: 1px solid var(--wps-border-mid);
+}
+
 /* ---------- Modal dialogs (OS/2 style, replace native popups) ---------- */
 .dlg-layer {
   position: fixed; inset: 0; z-index: 10500;

--- a/static/js/programs/spool.js
+++ b/static/js/programs/spool.js
@@ -1,0 +1,486 @@
+/* ============================================================
+   spool.js — JES spool browser (Desktop Phase 2.2)
+
+   Split view: filter bar (prefix/owner/status) → job tree (left,
+   lazy DD loading per job expand) → spool output panel (right).
+   Reuses the dataset browser's tree classes (.dsb-node etc.).
+
+   API (all via ctx.system.apiFetch, see docs/endpoints/jobs/):
+     GET    /zosmf/restjobs/jobs?prefix=&owner=&status=   list (JSON array)
+     GET    .../jobs/{name}/{id}/files                    DD list (JSON array)
+     GET    .../jobs/{name}/{id}/files/{ddid}/records     output (text/plain)
+     DELETE .../jobs/{name}/{id}                          purge
+
+   Notes validated against the backend docs:
+   - retcode may be null for completed jobs (MVS 3.8j NOTIFY quirk) —
+     shown dimmed as "-".
+   - No record-range paging in the API: the full output is fetched
+     once, but RENDERING is capped and extended via "Load more" so a
+     huge SYSPRINT cannot freeze the window.
+   - Auto-refresh (5s) re-lists jobs/statuses only and preserves tree
+     expansion + selection; the open output is never touched (manual
+     "Reload output" instead).
+   - Purge is the only cancel-style action (server refuses active
+     STC/TSU); confirmation dialog, extra confirm for ACTIVE jobs.
+   ============================================================ */
+import { Programs } from "./registry.js";
+import { Dialog } from "../dialog.js";
+
+const RENDER_CHUNK = 2000;   // lines rendered initially / per "Load more"
+
+/* ---------- demo-mode canned data ---------- */
+const DEMO_JOBS = [
+  { jobname: "TSTCOMP", jobid: "JOB00101", owner: "IBMUSER", type: "JOB",
+    class: "A", status: "OUTPUT", retcode: "CC 0000" },
+  { jobname: "TSTASM",  jobid: "JOB00102", owner: "IBMUSER", type: "JOB",
+    class: "A", status: "OUTPUT", retcode: "ABEND S0C4" },
+  { jobname: "TSTNTFY", jobid: "JOB00103", owner: "IBMUSER", type: "JOB",
+    class: "A", status: "OUTPUT", retcode: null },
+  { jobname: "HTTPD",   jobid: "STC00042", owner: "IBMUSER", type: "STC",
+    class: "S", status: "ACTIVE", retcode: null }
+];
+const DEMO_FILES = {
+  "TSTCOMP/JOB00101": [
+    { id: 2, ddname: "JESMSGLG", stepname: "JES2", procstep: "", "record-count": 4 },
+    { id: 3, ddname: "JESJCL",   stepname: "JES2", procstep: "", "record-count": 3 },
+    { id: 4, ddname: "SYSPRINT", stepname: "CC",   procstep: "", "record-count": 6 },
+    { id: 5, ddname: "SYSUT2",   stepname: "CC",   procstep: "", "record-count": 4500 }
+  ],
+  "TSTASM/JOB00102": [
+    { id: 2, ddname: "JESMSGLG", stepname: "JES2", procstep: "", "record-count": 5 },
+    { id: 4, ddname: "SYSPRINT", stepname: "ASM",  procstep: "", "record-count": 7 }
+  ],
+  "TSTNTFY/JOB00103": [
+    { id: 2, ddname: "JESMSGLG", stepname: "JES2", procstep: "", "record-count": 3 }
+  ],
+  "HTTPD/STC00042": [
+    { id: 2, ddname: "JESMSGLG", stepname: "JES2", procstep: "", "record-count": 3 }
+  ]
+};
+const DEMO_RECORDS = {
+  "TSTCOMP/JOB00101/2":
+    "1                    J E S 2  J O B  L O G\n" +
+    "0\n 09.15.01 JOB00101  $HASP373 TSTCOMP  STARTED - INIT  1 - CLASS A\n" +
+    " 09.15.02 JOB00101  $HASP395 TSTCOMP  ENDED - RC=0000\n",
+  "TSTCOMP/JOB00101/3":
+    "1 //TSTCOMP  JOB (ACCT),'COMPILE',CLASS=A,MSGCLASS=H\n" +
+    "  //CC       EXEC PGM=CC370\n  //SYSPRINT DD SYSOUT=*\n",
+  "TSTCOMP/JOB00101/4":
+    "1cc370 (GCC 3.4.6 MVS370)                     page   1\n" +
+    "0  source: HELLO.C\n   0 errors, 0 warnings\n" +
+    "   text     data      bss      dec  filename\n" +
+    "    1234       56        8     1298  hello.o\n" +
+    "0compilation complete\n",
+  "TSTASM/JOB00102/2":
+    "1                    J E S 2  J O B  L O G\n" +
+    "0\n 09.20.11 JOB00102  $HASP373 TSTASM   STARTED - INIT  1 - CLASS A\n" +
+    " 09.20.12 JOB00102  IEF450I TSTASM ASM - ABEND=S0C4 U0000\n" +
+    " 09.20.12 JOB00102  $HASP395 TSTASM   ENDED - ABEND S0C4\n",
+  "TSTASM/JOB00102/4":
+    "1  ASSEMBLER H  LISTING                                page   1\n" +
+    "0  LOC  OBJECT CODE    ADDR1 ADDR2  STMT   SOURCE STATEMENT\n" +
+    "   000000                          1      TEST     CSECT\n" +
+    "   000000 05C0                     2               BALR  R12,0\n" +
+    "   000002                          3               USING *,R12\n" +
+    "   000002 0000           00000     4               L     R1,0(,R0)\n" +
+    "0  *** ABEND S0C4 AT +000002\n",
+  "TSTNTFY/JOB00103/2":
+    "1                    J E S 2  J O B  L O G\n" +
+    " 09.30.00 JOB00103  $HASP373 TSTNTFY  STARTED\n" +
+    " 09.30.01 JOB00103  $HASP395 TSTNTFY  ENDED\n",
+  "HTTPD/STC00042/2":
+    "1                    J E S 2  J O B  L O G\n" +
+    " 08.00.00 STC00042  $HASP373 HTTPD    STARTED\n" +
+    " 08.00.01 STC00042  HTTPD001I LISTENING ON PORT 1080\n"
+};
+// large canned DD so the render cap / "Load more" is demoable offline
+{
+  let big = "1  SYSUT2 LISTING                               page   1\n";
+  for (let i = 1; i <= 4500; i++)
+    big += ` ${String(i).padStart(6)}  RECORD ${String(i).padStart(6, "0")}  DATA DATA DATA\n`;
+  DEMO_RECORDS["TSTCOMP/JOB00101/5"] = big;
+}
+
+/* ---------- helpers ---------- */
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text !== undefined) n.textContent = text;
+  return n;
+}
+function jobKey(j) { return j.jobname + "/" + j.jobid; }
+function wildcardToRegex(pat) {
+  return new RegExp("^" + (pat || "*").toUpperCase()
+    .replace(/[.]/g, "\\.").replace(/\*+/g, "[A-Z0-9@#$]*") + "$");
+}
+/* type icon per job class: JOB / STC / TSU */
+function typeIcon(t) {
+  return t === "STC" ? "ti-settings-automation"
+       : t === "TSU" ? "ti-user"
+       : "ti-file-invoice";
+}
+
+Programs.register({
+  id: "spool",
+  name: "JES spool browser",
+  icon: "ti-list",
+  iconBg: "#4db84d", iconColor: "#fff",
+  defaultWidth: 800, defaultHeight: 500,
+  minWidth: 560, minHeight: 340,
+  desktopIcon: true,
+  statusBar: true,
+
+  create(ctx) {
+    const sys = ctx.system;
+    const st = {
+      prefix: "*",
+      owner: sys.demo ? "IBMUSER" : (sys.user || "*").toUpperCase(),
+      status: "*",
+      jobs: [],
+      ddCache: new Map(),      // jobKey -> files array
+      expanded: new Set(),     // jobKeys with open DD list
+      demoJobs: sys.demo ? JSON.parse(JSON.stringify(DEMO_JOBS)) : null,
+      sel: null,               // { job, dd } | { job } | null
+      outText: "",             // full output of the open DD
+      outShown: 0,             // lines currently rendered
+      autoTimer: null
+    };
+    ctx._spl = st;
+
+    /* ---------------- DOM skeleton ---------------- */
+    const root = el("div", "dsb-root");
+
+    const bar1 = el("div", "wps-toolbar dsb-bar");
+    const prefixIn = el("input", "spl-in");
+    prefixIn.value = st.prefix; prefixIn.spellcheck = false;
+    const ownerIn = el("input", "spl-in");
+    ownerIn.value = st.owner; ownerIn.spellcheck = false;
+    const statusSel = document.createElement("select");
+    [["*", "all"], ["ACTIVE", "active"], ["OUTPUT", "output"], ["INPUT", "input"]]
+      .forEach(([v, label]) => {
+        const o = document.createElement("option");
+        o.value = v; o.textContent = label;
+        statusSel.appendChild(o);
+      });
+    const listBtn = el("div", "tb-btn", "List");
+    bar1.append(el("label", null, "Prefix:"), prefixIn,
+                el("label", null, "Owner:"), ownerIn,
+                el("label", null, "Status:"), statusSel, listBtn);
+
+    const bar2 = el("div", "wps-toolbar dsb-bar");
+    const btn = {};
+    [["refresh", "Refresh", "ti-refresh"],
+     ["reload",  "Reload output", "ti-rotate"],
+     ["purge",   "Purge", "ti-trash"]].forEach(([key, label, icon]) => {
+      const b = el("div", "tb-btn");
+      b.innerHTML = `<i class="ti ${icon}" style="font-size:13px;"></i>${label}`;
+      bar2.appendChild(b);
+      btn[key] = b;
+    });
+    bar2.appendChild(el("div", "tb-spacer"));
+    const autoLbl = el("label", "spl-auto");
+    const autoCb = document.createElement("input");
+    autoCb.type = "checkbox";
+    autoLbl.append(autoCb, document.createTextNode(" auto 5s"));
+    bar2.appendChild(autoLbl);
+
+    const split = el("div", "dsb-split");
+    const treeEl = el("div", "dsb-tree spl-tree");
+    const viewEl = el("div", "dsb-view");
+    split.append(treeEl, viewEl);
+    root.append(bar1, bar2, split);
+
+    /* ---------------- API (demo-aware) ---------------- */
+    async function api(path, opts) {
+      const resp = await sys.apiFetch(path, opts);
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      return resp;
+    }
+    async function listJobs() {
+      if (sys.demo) {
+        const pr = wildcardToRegex(st.prefix);
+        const ow = wildcardToRegex(st.owner);
+        return st.demoJobs.filter(j =>
+          pr.test(j.jobname) && ow.test(j.owner) &&
+          (st.status === "*" || j.status === st.status));
+      }
+      const q = new URLSearchParams();
+      if (st.prefix && st.prefix !== "*") q.set("prefix", st.prefix);
+      q.set("owner", st.owner || "*");
+      if (st.status !== "*") q.set("status", st.status);
+      const resp = await api("/zosmf/restjobs/jobs?" + q.toString());
+      return resp.json();   // plain JSON array
+    }
+    async function listFiles(job) {
+      const key = jobKey(job);
+      if (st.ddCache.has(key)) return st.ddCache.get(key);
+      let files;
+      if (sys.demo) {
+        files = DEMO_FILES[key] || [];
+      } else {
+        const resp = await api(`/zosmf/restjobs/jobs/${job.jobname}/${job.jobid}/files`);
+        files = await resp.json();
+      }
+      st.ddCache.set(key, files);
+      return files;
+    }
+    async function readRecords(job, dd) {
+      if (sys.demo) return DEMO_RECORDS[jobKey(job) + "/" + dd.id] || "";
+      const resp = await api(`/zosmf/restjobs/jobs/${job.jobname}/${job.jobid}/files/${dd.id}/records`);
+      return resp.text();
+    }
+    async function purgeJob(job) {
+      if (sys.demo) {
+        st.demoJobs = st.demoJobs.filter(j => jobKey(j) !== jobKey(job));
+        return;
+      }
+      await api(`/zosmf/restjobs/jobs/${job.jobname}/${job.jobid}`, { method: "DELETE" });
+    }
+
+    /* ---------------- tree ---------------- */
+    function rcBadge(job) {
+      const span = el("span", "spl-rc");
+      if (job.status === "ACTIVE" || job.status === "INPUT") {
+        span.classList.add("spl-active");
+        span.textContent = "●";
+        span.title = job.status;
+      } else if (!job.retcode) {
+        span.classList.add("spl-rc-dim");
+        span.textContent = "-";
+        span.title = "no retcode (NOTIFY quirk)";
+      } else {
+        const bad = !/^CC 0000$/.test(job.retcode);
+        span.classList.add(bad ? "spl-rc-bad" : "spl-rc-ok");
+        span.textContent = job.retcode;
+      }
+      return span;
+    }
+
+    function renderTree() {
+      treeEl.innerHTML = "";
+      if (!st.jobs.length) {
+        treeEl.appendChild(el("div", "dsb-empty", "No jobs — adjust the filter"));
+        return;
+      }
+      st.jobs.forEach(job => {
+        const key = jobKey(job);
+        const row = el("div", "dsb-node");
+        row.dataset.job = key;
+        const chev = el("span", "dsb-chev", st.expanded.has(key) ? "▾" : "▸");
+        const ico = el("i", "dsb-ico ti " + typeIcon(job.type));
+        const label = el("span", "spl-jobname", `${job.jobname}(${job.jobid})`);
+        row.append(chev, ico, label, rcBadge(job));
+        treeEl.appendChild(row);
+
+        const kidsEl = el("div", "dsb-kids");
+        treeEl.appendChild(kidsEl);
+        if (st.expanded.has(key)) fillDDs(job, kidsEl);
+
+        row.addEventListener("click", () => {
+          st.sel = { job };
+          markSelected(row);
+          updateButtons();
+          if (st.expanded.has(key)) {
+            st.expanded.delete(key);
+            chev.textContent = "▸";
+            kidsEl.innerHTML = "";
+          } else {
+            st.expanded.add(key);
+            chev.textContent = "▾";
+            fillDDs(job, kidsEl);
+          }
+        });
+      });
+      restoreSelection();
+    }
+
+    async function fillDDs(job, kidsEl) {
+      kidsEl.innerHTML = "";
+      const loading = el("div", "dsb-node spl-dd", "loading…");
+      loading.style.paddingLeft = "26px";
+      kidsEl.appendChild(loading);
+      try {
+        const files = await listFiles(job);
+        kidsEl.innerHTML = "";
+        if (!files.length) {
+          const none = el("div", "dsb-node spl-dd", "(no spool files)");
+          none.style.paddingLeft = "26px";
+          kidsEl.appendChild(none);
+        }
+        files.forEach(dd => {
+          const row = el("div", "dsb-node spl-dd");
+          row.style.paddingLeft = "26px";
+          row.dataset.dd = jobKey(job) + "/" + dd.id;
+          const where = dd.stepname ? ` <span class="spl-step">${dd.stepname}${dd.procstep ? "." + dd.procstep : ""} · ${dd["record-count"]} recs</span>` : "";
+          row.innerHTML = `<span class="dsb-chev"></span><i class="dsb-ico ti ti-file-text"></i><span>${dd.ddname}</span>${where}`;
+          row.addEventListener("click", ev => {
+            ev.stopPropagation();
+            openDD(job, dd, row);
+          });
+          kidsEl.appendChild(row);
+        });
+        restoreSelection();
+      } catch (e) {
+        // degrade gracefully: error row, tree stays usable
+        kidsEl.innerHTML = "";
+        const err = el("div", "dsb-node spl-dd", "error: " + e.message);
+        err.style.paddingLeft = "26px";
+        kidsEl.appendChild(err);
+      }
+    }
+
+    function markSelected(row) {
+      treeEl.querySelectorAll(".dsb-node.selected").forEach(n => n.classList.remove("selected"));
+      if (row) row.classList.add("selected");
+    }
+    function restoreSelection() {
+      if (!st.sel) return;
+      const key = st.sel.dd
+        ? `[data-dd="${jobKey(st.sel.job)}/${st.sel.dd.id}"]`
+        : `[data-job="${jobKey(st.sel.job)}"]`;
+      const row = treeEl.querySelector(key);
+      if (row) row.classList.add("selected");
+    }
+
+    /* ---------------- output panel ---------------- */
+    function renderEmpty(msg) {
+      viewEl.innerHTML = "";
+      viewEl.appendChild(el("div", "dsb-empty", msg || "Select a spool file"));
+    }
+
+    // Render capped: huge SYSPRINTs must not freeze the window.
+    // The full text is kept in st.outText; "Load more" extends the DOM.
+    function renderOutput(reset) {
+      if (reset) {
+        viewEl.innerHTML = "";
+        const pre = el("pre", "spl-out");
+        pre.appendChild(el("code"));
+        viewEl.appendChild(pre);
+        st.outShown = 0;
+      }
+      const pre = viewEl.querySelector("pre.spl-out");
+      const code = pre.querySelector("code");
+      const lines = st.outText.split("\n");
+      const next = Math.min(lines.length, st.outShown + RENDER_CHUNK);
+      code.textContent = lines.slice(0, next).join("\n");
+      st.outShown = next;
+      const old = viewEl.querySelector(".spl-more");
+      if (old) old.remove();
+      if (next < lines.length) {
+        const more = el("div", "spl-more");
+        const b = el("div", "tb-btn", `Load more (${lines.length - next} lines remaining)`);
+        b.addEventListener("click", () => renderOutput(false));
+        more.appendChild(b);
+        viewEl.appendChild(more);
+      }
+    }
+
+    async function openDD(job, dd, row) {
+      st.sel = { job, dd };
+      markSelected(row);
+      updateButtons();
+      renderEmpty("Loading…");
+      try {
+        st.outText = await readRecords(job, dd);
+        renderOutput(true);
+        const lines = st.outText.split("\n").length;
+        ctx.setStatus(`${job.jobname}(${job.jobid}) ${dd.ddname} — ${lines} line(s)`);
+      } catch (e) {
+        // degrade gracefully (TSK-253 edge case): error in panel only
+        renderEmpty("Output failed: " + e.message);
+        ctx.setStatus("Output failed — " + e.message);
+      }
+    }
+
+    /* ---------------- actions ---------------- */
+    function updateButtons() {
+      btn.purge.classList.toggle("disabled", !st.sel);
+      btn.reload.classList.toggle("disabled", !(st.sel && st.sel.dd));
+    }
+
+    async function doList(fromAuto) {
+      st.prefix = prefixIn.value.trim().toUpperCase() || "*";
+      st.owner = ownerIn.value.trim().toUpperCase() || "*";
+      st.status = statusSel.value;
+      prefixIn.value = st.prefix; ownerIn.value = st.owner;
+      if (!fromAuto) ctx.setStatus("Listing jobs …");
+      try {
+        st.jobs = await listJobs() || [];
+        // auto-refresh keeps expansion/selection; the open output is
+        // never touched here
+        renderTree();
+        if (!fromAuto) ctx.setStatus(`${st.jobs.length} job(s) — ${st.prefix} / ${st.owner}`);
+      } catch (e) {
+        if (!fromAuto) {
+          treeEl.innerHTML = "";
+          treeEl.appendChild(el("div", "dsb-empty", "List failed: " + e.message));
+          ctx.setStatus("List failed — " + e.message);
+        }
+      }
+    }
+
+    function doRefresh() {
+      st.ddCache.clear();
+      doList();
+    }
+
+    async function doReloadOutput() {
+      if (!(st.sel && st.sel.dd)) return;
+      await openDD(st.sel.job, st.sel.dd,
+        treeEl.querySelector(`[data-dd="${jobKey(st.sel.job)}/${st.sel.dd.id}"]`));
+    }
+
+    async function doPurge() {
+      if (!st.sel) return;
+      const job = st.sel.job;
+      const what = `${job.jobname}(${job.jobid})`;
+      if (!(await Dialog.confirm("Purge job", `Purge ${what}?`,
+        { okLabel: "Purge", danger: true, icon: "ti-trash" }))) return;
+      if (job.status === "ACTIVE" &&
+          !(await Dialog.confirm("Job is active",
+            `${what} is ACTIVE (${job.type}). Purge anyway?`,
+            { okLabel: "Purge active job", danger: true }))) return;
+      try {
+        await purgeJob(job);
+        st.ddCache.delete(jobKey(job));
+        st.expanded.delete(jobKey(job));
+        if (st.sel && jobKey(st.sel.job) === jobKey(job)) {
+          st.sel = null;
+          renderEmpty();
+        }
+        await doList();
+        ctx.setStatus(`Purged ${what}`);
+      } catch (e) {
+        ctx.setStatus(`Purge failed — ${e.message}`);
+      }
+      updateButtons();
+    }
+
+    /* auto-refresh: job list + statuses only (5s) */
+    function setAuto(on) {
+      if (st.autoTimer) { clearInterval(st.autoTimer); st.autoTimer = null; }
+      if (on) st.autoTimer = setInterval(() => doList(true), 5000);
+    }
+
+    /* ---------------- wire up ---------------- */
+    listBtn.addEventListener("click", () => doList());
+    [prefixIn, ownerIn].forEach(inp =>
+      inp.addEventListener("keydown", e => { if (e.key === "Enter") doList(); }));
+    statusSel.addEventListener("change", () => doList());
+    btn.refresh.addEventListener("click", doRefresh);
+    btn.reload.addEventListener("click", doReloadOutput);
+    btn.purge.addEventListener("click", doPurge);
+    autoCb.addEventListener("change", () => setAuto(autoCb.checked));
+
+    renderEmpty();
+    updateButtons();
+    doList();   // initial listing with the default filters
+    return root;
+  },
+
+  destroy(ctx) {
+    // stop the auto-refresh timer with the window
+    const st = ctx._spl;
+    if (st && st.autoTimer) clearInterval(st.autoTimer);
+  }
+});

--- a/static/js/programs/spool.js
+++ b/static/js/programs/spool.js
@@ -209,7 +209,12 @@ Programs.register({
       q.set("owner", st.owner || "*");
       if (st.status !== "*") q.set("status", st.status);
       const resp = await api("/zosmf/restjobs/jobs?" + q.toString());
-      return resp.json();   // plain JSON array
+      let jobs = await resp.json();   // plain JSON array
+      // jobListHandler currently ignores the status parameter (#157) —
+      // filter client-side; the param stays so the server-side filter
+      // is picked up automatically once implemented
+      if (st.status !== "*") jobs = jobs.filter(j => j.status === st.status);
+      return jobs;
     }
     async function listFiles(job) {
       const key = jobKey(job);
@@ -311,8 +316,16 @@ Programs.register({
           const row = el("div", "dsb-node spl-dd");
           row.style.paddingLeft = "26px";
           row.dataset.dd = jobKey(job) + "/" + dd.id;
-          const where = dd.stepname ? ` <span class="spl-step">${dd.stepname}${dd.procstep ? "." + dd.procstep : ""} · ${dd["record-count"]} recs</span>` : "";
-          row.innerHTML = `<span class="dsb-chev"></span><i class="dsb-ico ti ti-file-text"></i><span>${dd.ddname}</span>${where}`;
+          // DDNAME is a fixed 8-char field — pad it so the stepname
+          // column lines up (tree font is monospace); record count is
+          // right-aligned at the row end like the RC badge on job rows
+          const name = el("span", "spl-ddname", (dd.ddname || "").padEnd(8));
+          const step = el("span", "spl-step",
+            dd.stepname ? dd.stepname + (dd.procstep ? "." + dd.procstep : "") : "");
+          const recs = el("span", "spl-recs",
+            dd["record-count"] != null ? dd["record-count"] + " recs" : "");
+          row.append(el("span", "dsb-chev", ""),
+                     el("i", "dsb-ico ti ti-file-text"), name, step, recs);
           row.addEventListener("click", ev => {
             ev.stopPropagation();
             openDD(job, dd, row);

--- a/static/js/programs/stubs.js
+++ b/static/js/programs/stubs.js
@@ -31,8 +31,9 @@ function registerStub(id, name, icon, iconBg, iconColor) {
 
 // datasets (Dataset browser) graduated to a real program in Phase 2.1 —
 // see programs/datasets.js
+// spool (JES spool browser) graduated to a real program in Phase 2.2 —
+// see programs/spool.js
 registerStub("ussfiles",  "USS file manager", "ti-folder",     "#4d8de8", "#fff");
-registerStub("spool",     "JES spool browser","ti-list",       "#4db84d", "#fff");
 registerStub("console",   "MVS console",      "ti-terminal-2", "#1a1a1a", "#33ff33");
 registerStub("rexx",      "REXX workbench",   "ti-code",       "#b84d4d", "#fff");
 registerStub("jobsubmit", "Job submit",       "ti-upload",     "#8855bb", "#fff");

--- a/static/js/shell.js
+++ b/static/js/shell.js
@@ -24,6 +24,7 @@ import "./programs/sysinfo.js";
 import "./programs/systems.js";
 import "./programs/about.js";
 import "./programs/datasets.js";
+import "./programs/spool.js";
 import "./programs/stubs.js";
 
 /* ---------- Desktop icons ---------- */


### PR DESCRIPTION
Fixes #155

Second real Phase 2 program: JES spool browser with job-tree navigation and spool output viewer. Spec: Notion TSK-285/286; backend is the z/OSMF REST API (no httpjes CGI), same `apiFetch()` path as the dataset browser.

## What's in it
- **`js/programs/spool.js`** — split view: filter bar (`Prefix`/`Owner`/`Status` + List) → job tree (flat roots, SDSF-style, type icon per JOB/STC/TSU) → output panel. Expanding a job lazy-loads its DD list (`GET .../files`, cached until Refresh); DD rows show stepname + record count.
- **RC coloring** — `CC 0000` green, non-zero/ABEND red (status-tint tokens), ACTIVE/INPUT green dot, `null` retcode dimmed `-` with a tooltip (the documented MVS 3.8j NOTIFY quirk).
- **Output viewer** — monospace, `white-space: pre`, columns never wrapped or trimmed (ASA carriage control in col 1). The API has no record-range paging, so **rendering is capped at 2000 lines** with a "Load more (n remaining)" control; the full text is fetched once and kept in memory.
- **Auto-refresh (5s)** — re-lists jobs/statuses only; tree expansion, selection and the open output are preserved across ticks (expansion state is tracked and DD lists re-render from cache). Manual "Reload output" button for growing active jobs. The interval is cleared in `destroy()` — first program to use that hook.
- **Purge** — the API's only cancel-style action, labeled accordingly. In-app confirmation dialog (danger), plus an **extra confirm for ACTIVE jobs** (the server refuses active STC/TSU anyway and the error lands in the status bar).
- **Graceful degradation** — a failing `files`/`records` call (TSK-253 edge case) shows an error row/panel and leaves the tree usable.
- **Demo mode** — four canned jobs (CC 0000, ABEND S0C4 with assembler listing, null-retcode, active STC) plus a generated 4500-line DD so the render cap is explorable offline.
- Tree widget/classes reused from the dataset browser per spec; a shared `tree.js` extraction can follow when a third consumer appears.

## Verification (headless Chrome, demo mode)
27/27 assertions, 0 JS exceptions, 0 native browser dialogs:
- list + all four RC render variants (green/red/dim/active dot)
- lazy DD load; output columns byte-exact (ASA col 1 + spacing asserted)
- render cap at exactly 2000 lines → Load more → 4000 → complete, button gone
- prefix/owner/status filters (server-side params in real mode, client-side in demo)
- auto-refresh tick: expansion + selection + open output all survive; expansion also survives filter round-trips
- purge with confirm; ACTIVE purge asks twice, cancel keeps the job
- window close clears the auto-refresh timer (no stray ticks after close)

**Not yet verified live** (needs deploy): job list → files → records against the real JES2, purge of a real job. I'll run that after deploy to `/www/mvsmf` — same flow as the dataset browser live test.
