### PR TITLE
jobsapi: cap SYSIN spool output at record count; separator only between DDs

### DIFF
--- a/docs/endpoints/jobs/records.md
+++ b/docs/endpoints/jobs/records.md
@@ -14,7 +14,9 @@ GET
 - `ddid`: Spool file ID (from the `id` field in the files list)
 
 ## Response
-On successful completion, this request returns HTTP status code 200 (OK) with Content-Type `text/plain`. The response body contains the spool file records as plain text, with each DD's output separated by a dashed line.
+On successful completion, this request returns HTTP status code 200 (OK) with Content-Type `text/plain`. The response body contains the spool file records as plain text. When more than one DD is emitted, the outputs are separated by a dashed line (never trailing).
+
+For SYSIN datasets (e.g. `JESJCLIN`), the response contains exactly `record-count` records: JES2 pre-formats a "JOB DELETED BY JES2 OR CANCELLED BY OPERATOR BEFORE EXECUTION" line into the JCLIN spool chain behind the real records, and the handler caps the output at the PDDB record count so this line does not leak into every response. SYSOUT datasets are not capped, because their record counts may lag while a job is active.
 
 ## Error Responses
 - HTTP 400 (Bad Request)

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -480,9 +480,28 @@ quit:
 // private functions
 //
 
+/*
+ * Line cap for SYSIN spool datasets (issue #158): JES2 pre-formats the
+ * "JOB DELETED BY JES2 OR CANCELLED BY OPERATOR BEFORE EXECUTION" line
+ * into the JCLIN spool chain behind the real records - it is only meant
+ * to be printed when a job dies before execution. jesprint() walks the
+ * block chain to the EOB marker, so without a cap that line leaks into
+ * every response. SYSIN record counts are final after input processing,
+ * so capping at the PDDB count is exact; SYSOUT datasets stay uncapped
+ * (their counts may lag while a job is active). The cap travels to the
+ * per-line callback through the per-task GRT (grtapp3) - RENT-safe and
+ * private to this worker thread.
+ */
+typedef struct spool_cap {
+	unsigned	limit;		/* stop after this many lines (0 = no cap) */
+	unsigned	count;		/* lines printed so far                    */
+} SPOOL_CAP;
+
+#define RC_SPOOL_CAP	(-77)	/* sentinel: cap reached, normal end */
+
 __asm__("\n&FUNC	SETC 'do_print_sysout_line'");
-static int 
-do_print_sysout_line(const char *line, unsigned linelen) 
+static int
+do_print_sysout_line(const char *line, unsigned linelen)
 {
 	int rc = 0;
 
@@ -494,8 +513,18 @@ do_print_sysout_line(const char *line, unsigned linelen)
 	CLIBGRT *grt = __grtget();
 	HTTPD *httpd = grt->grtapp1;
 	HTTPC *httpc = grt->grtapp2;
+	SPOOL_CAP *cap = (SPOOL_CAP *) grt->grtapp3;
+
+	/* logical end of the dataset reached - stop jesprint */
+	if (cap && cap->limit && cap->count >= cap->limit) {
+		return RC_SPOOL_CAP;
+	}
 
 	rc = http_printf(httpc, "%-*.*s\r\n", linelen, linelen, line);
+
+	if (rc >= 0 && cap) {
+		cap->count++;
+	}
 
 // switch back to httpr
 #undef httpx
@@ -517,6 +546,10 @@ do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 		goto quit;
 	}
 
+	CLIBGRT *grt = __grtget();
+	SPOOL_CAP cap;
+	unsigned printed = 0;
+
 	unsigned ii = 0;
 	for (ii = 0; ii < array_count(&job->jesdd); ii++) {
 		JESDD *dd = job->jesdd[ii];
@@ -533,23 +566,38 @@ do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 		if (!dd->mttr) {
 			continue;
 		}
-				
+
 		if ((dd->flag & FLAG_SYSIN) && !dsid) {
 			continue;
 		}
 
+		/* dashed separator between multiple DDs - never trailing */
+		if (printed) {
+			rc = http_printf(session->httpc, "- - - - - - - - - - - - - - - - - - - - "
+											"- - - - - - - - - - - - - - - - - - - - "
+											"- - - - - - - - - - - - - - - - - - - - "
+											"- - - - - -\r\n");
+			if (rc < 0) {
+				goto quit;
+			}
+		}
+
+		/* cap SYSIN datasets at their (final) PDDB record count so the
+		   pre-built JES2 deletion line behind the records stays hidden */
+		cap.limit = ((dd->flag & FLAG_SYSIN) && dd->records) ? dd->records : 0;
+		cap.count = 0;
+		grt->grtapp3 = &cap;
 		rc = jesprint(jes, job, dd->dsid, do_print_sysout_line);
+		grt->grtapp3 = NULL;
+
+		if (rc == RC_SPOOL_CAP) {
+			rc = 0;		/* cap reached - normal end of dataset */
+		}
 		if (rc < 0) {
 			goto quit;
 		}
 
-		rc = http_printf(session->httpc, "- - - - - - - - - - - - - - - - - - - - "
-										"- - - - - - - - - - - - - - - - - - - - "
-										"- - - - - - - - - - - - - - - - - - - - "
-										"- - - - - -\r\n");
-		if (rc < 0) {
-			goto quit;
-		}
+		printed++;
 	}
 
 quit:

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -655,6 +655,59 @@ test_spool_records() {
 	fi
 }
 
+test_spool_records_exact_count() {
+	echo ""
+	echo "--- Spool File Records: exact record count (issue #158) ---"
+
+	if [ -z "$SUBMIT_JOBNAME" ] || [ -z "$SUBMIT_JOBID" ]; then
+		skip "spool records exact count (no submitted job)"
+		return
+	fi
+
+	# JESJCLIN is a SYSIN dataset: its PDDB record count is final, and the
+	# JES2 pre-built deletion line sits in the chain right behind it.
+	local files_resp
+	files_resp=$(do_curl GET \
+		"${BASE_URL}/zosmf/restjobs/jobs/${SUBMIT_JOBNAME}/${SUBMIT_JOBID}/files")
+	split_response "$files_resp"
+
+	local ddid reccount
+	ddid=$(echo "$BODY" | jq '[.[] | select(.ddname | startswith("JESJCLIN"))][0].id' 2>/dev/null)
+	reccount=$(echo "$BODY" | jq '[.[] | select(.ddname | startswith("JESJCLIN"))][0]["record-count"]' 2>/dev/null)
+
+	if [ -z "$ddid" ] || [ "$ddid" = "null" ]; then
+		skip "spool records exact count (no JESJCLIN)"
+		return
+	fi
+
+	local resp
+	resp=$(do_curl GET \
+		"${BASE_URL}/zosmf/restjobs/jobs/${SUBMIT_JOBNAME}/${SUBMIT_JOBID}/files/${ddid}/records")
+	split_response "$resp"
+
+	assert_http_status "200" "$HTTP_STATUS" "read JESJCLIN records"
+
+	local lines
+	lines=$(printf '%s' "$BODY" | grep -c '' 2>/dev/null)
+	if [ "$lines" = "$reccount" ]; then
+		pass "JESJCLIN line count equals record-count ($reccount)"
+	else
+		fail "JESJCLIN line count equals record-count" "expected $reccount, got $lines"
+	fi
+
+	if printf '%s' "$BODY" | grep -q 'JOB DELETED BY JES2'; then
+		fail "no JES2 deletion tombstone in output" "tombstone line present"
+	else
+		pass "no JES2 deletion tombstone in output"
+	fi
+
+	if printf '%s' "$BODY" | grep -q '^- - - - '; then
+		fail "no trailing dashed separator" "separator line present"
+	else
+		pass "no trailing dashed separator"
+	fi
+}
+
 test_spool_records_invalid_ddid() {
 	echo ""
 	echo "--- Spool File Records: invalid DDID ---"
@@ -753,6 +806,7 @@ test_spool_files_not_found
 
 # Spool records tests
 test_spool_records
+test_spool_records_exact_count
 test_spool_records_invalid_ddid
 
 # Purge tests (last, since it removes the test job)


### PR DESCRIPTION
Fixes #158

Removes the two phantom lines from every spool records response (`GET .../files/{ddid}/records`) — visible in the Desktop spool browser and in Zowe/VSCode alike.

## Root causes and fixes
1. **JES2 tombstone line** (`******** JOB DELETED BY JES2 OR CANCELLED BY OPERATOR BEFORE EXECUTION ********`): JES2 pre-formats this line into the JCLIN spool chain *behind* the real records at job input — it is only meant to be printed when a job dies before execution, and JES2 itself honors the PDDB record count. `jesprint()` (libc370) walks the block chain to the EOB marker, so the pre-built line leaked into every JESJCLIN response. **Fix:** `do_print_sysout` caps **SYSIN** datasets at their PDDB `record-count` (final after input processing). SYSOUT datasets stay uncapped — their counts may lag while a job is active, so growing output is never truncated.
2. **Trailing dashed separator**: was printed unconditionally after every DD; on single-DD requests it was always a stray last line. **Fix:** printed only *between* DDs when more than one is emitted.

## Implementation notes
- The cap travels to the per-line callback via the **per-task GRT `grtapp3`** (verified unused across mvsmf/httpd/libc370). The shared per-CGI context (`MVSMF_CTX`) was deliberately NOT used — it is shared across worker threads and would race between concurrent spool reads. RENT-safe: no writable statics.
- Callback returns a sentinel (`RC_SPOOL_CAP`) at the cap; `do_print_sysout` maps it to success.
- No libc370 change needed (root cause noted there, but the mvsMF-side cap is exact for SYSIN).

## Verification (live on MVS, build `d5f4957` hot-activated)
- The reported case IBMUSER/TSU00076 JESJCLIN (record-count 2): **before** 4 lines (2 + tombstone + separator) → **after** exactly 2 lines.
- SYSOUT unaffected: TSU00076 JESJCL returns its full 24 records, no trailing separator, content intact.
- Full `tests/curl-jobs.sh` live: **63 pass** incl. the three new #158 assertions (line count == record-count, no tombstone, no separator). The 2 failures are pre-existing purge quirks in untouched code paths (`.owner` missing in the purge response; purge-not-found returns 500 instead of 404) — happy to file follow-ups.
- Activation: `make deploy` → IEBCOPY to `HTTPD.LINKLIBT` via the jobs API (CC 0000), `fn=version` now reports `d5f4957`.

## Docs / tests
- `docs/endpoints/jobs/records.md`: response semantics updated (exact record count for SYSIN, separator only between DDs).
- `tests/curl-jobs.sh`: new `test_spool_records_exact_count` (JESJCLIN line count, tombstone absence, separator absence).
