### PR TITLE
jobsapi: fix job list/submit regressions from dropping authmw.c

### DIFF
--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -1553,6 +1553,12 @@ get_basic_auth_credentials(Session *session, char *user, size_t user_len,
 	size_t n;
 	int rc = -1;
 
+	/* TEMPORARY diagnostic for issue #164/#165 follow-up: lengths only,
+	 * never the header content (it carries the password). Remove once
+	 * the Authorization truncation root cause is confirmed. */
+	wtof("MVSMF97D get_basic_auth_credentials: authhdr=%s len=%d",
+	    authhdr ? "present" : "absent", authhdr ? (int)strlen(authhdr) : -1);
+
 	if (!authhdr || strncmp(authhdr, "Basic ", 6) != 0) {
 		return -1;
 	}
@@ -1561,6 +1567,8 @@ get_basic_auth_credentials(Session *session, char *user, size_t user_len,
 	if (!decoded) {
 		return -1;
 	}
+
+	wtof("MVSMF97D get_basic_auth_credentials: decoded_len=%d", (int)decoded_len);
 
 	n = decoded_len;
 	if (n >= sizeof(creds)) n = sizeof(creds) - 1;

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -2,6 +2,7 @@
 #include <clibb64.h>
 #include <clibio.h>
 #include <clibstr.h>
+#include <ctype.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,7 +65,8 @@ static int submit_file(Session *session, VSFILE *intrdr, const char *filename,
 static char* tokenize(char *str, const char *delim, char **saveptr);
 static int process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass,
                           const char *user, const char *password);
-static int get_basic_auth_password(Session *session, char *password, size_t password_len);
+static int get_basic_auth_credentials(Session *session, char *user, size_t user_len,
+                                      char *password, size_t password_len);
 
 static const unsigned char ASCII_CRLF[] = {CR, LF};
 
@@ -1193,11 +1195,11 @@ submit_file(Session *session, VSFILE *intrdr, const char *filename,
 
 	/* process jobcard: inject USER/PASSWORD */
 	{
-		UCHAR user[64] = {0};
+		char user[64] = {0};
 		char password[256] = {0};
 
-		if (!http_get_userid(session->httpc, user, sizeof(user)) ||
-		    get_basic_auth_password(session, password, sizeof(password)) < 0) {
+		if (get_basic_auth_credentials(session, user, sizeof(user),
+									   password, sizeof(password)) < 0) {
 			sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
 							RC_ERROR, REASON_INVALID_REQUEST,
 							"Job submission requires Basic authentication credentials", NULL, 0);
@@ -1205,7 +1207,7 @@ submit_file(Session *session, VSFILE *intrdr, const char *filename,
 			goto quit;
 		}
 
-		rc = process_jobcard(lines, num_lines, jobname, jobclass, (char *)user, password);
+		rc = process_jobcard(lines, num_lines, jobname, jobclass, user, password);
 		if (rc < 0) {
 			sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
 							RC_ERROR, REASON_INVALID_REQUEST,
@@ -1533,20 +1535,23 @@ find_job_card_range(char **lines, int count, int *start_idx, int *end_idx)
  * USER=/PASSWORD= job-card injection below -- on this JES2 setup, setting
  * the submitting task's ACEE alone does not propagate to the submitted
  * job. httpd's credential resolver deliberately never hands the decrypted
- * password back to the CGI (mvslovers/httpd#96/#97/#99), so recover it
+ * password back to the CGI (mvslovers/httpd#96/#97/#99), so recover both
  * here directly from this request's own Authorization: Basic header. This
  * only works while job submission authenticates with Basic Auth on every
  * call; it has no answer for a token-authenticated session. See issue
  * #164 for the open architecture question.
  *
- * The userid for USER= comes from http_get_userid() instead (the RACF-
- * verified, canonically-cased form from the ACEE httpd already resolved)
- * -- not from re-decoding this header -- so it doesn't depend on however
- * the client happened to case it on the wire.
+ * (http_get_userid() was tried here instead of re-decoding the header for
+ * the userid, to get the RACF-canonical case -- it returned garbage in
+ * live testing against the latest httpd, unrelated to this decode path.
+ * Reverted to the known-working raw decode; the JCL-case requirement is
+ * handled by uppercasing locally instead. See #164 for the httpd-side
+ * follow-up on http_get_userid.)
  */
-__asm__("\n&FUNC    SETC 'get_basic_auth_password'");
+__asm__("\n&FUNC    SETC 'get_basic_auth_credentials'");
 static int
-get_basic_auth_password(Session *session, char *password, size_t password_len)
+get_basic_auth_credentials(Session *session, char *user, size_t user_len,
+                          char *password, size_t password_len)
 {
 	const char *authhdr = getHeaderParam(session, "Authorization");
 	UCHAR *decoded = NULL;
@@ -1576,6 +1581,17 @@ get_basic_auth_password(Session *session, char *password, size_t password_len)
 
 	colon = strchr(creds, ':');
 	if (colon) {
+		size_t i;
+
+		*colon = '\0';
+		strncpy(user, creds, user_len - 1);
+		user[user_len - 1] = '\0';
+		/* JCL keyword values must be uppercase or JES2 rejects the JOB
+		 * card ("UNDEFINED OR ILLEGAL CHARACTERS IN THE USER FIELD") */
+		for (i = 0; user[i]; i++) {
+			user[i] = (char)toupper((unsigned char)user[i]);
+		}
+
 		strncpy(password, colon + 1, password_len - 1);
 		password[password_len - 1] = '\0';
 		rc = 0;
@@ -1750,6 +1766,11 @@ process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass,
         return -1;
     }
 
+    /* TEMPORARY diagnostic for issue #164 follow-up: length only, never
+     * the password itself. Remove once the PASSWORD= empty-on-card
+     * mystery is confirmed as either a real bug or a display artifact. */
+    wtof("MVSMF97D process_jobcard: password strlen=%d", (int)strlen(password));
+
     rc = snprintf(lines[end_idx + 2], 72, "//         PASSWORD=%s", password);
     if (rc < 0 || rc >= 72) {
         wtof("MVSMF24E Buffer overflow in snprintf");
@@ -1844,11 +1865,11 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
     }
 
     /* Analyze and potentially modify job card */
-    UCHAR user[64] = {0};
+    char user[64] = {0};
     char password[256] = {0};
 
-    if (!http_get_userid(session->httpc, user, sizeof(user)) ||
-        get_basic_auth_password(session, password, sizeof(password)) < 0) {
+    if (get_basic_auth_credentials(session, user, sizeof(user),
+                                   password, sizeof(password)) < 0) {
         wtof("MVSMF22E Failed to analyze job card");
         sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
                         RC_ERROR, REASON_INVALID_REQUEST,
@@ -1857,7 +1878,7 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
         goto quit;
     }
 
-    rc = process_jobcard(lines, num_lines, jobname, jobclass, (char *)user, password);
+    rc = process_jobcard(lines, num_lines, jobname, jobclass, user, password);
     if (rc < 0) {
         wtof("MVSMF22E Failed to analyze job card");
         sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -64,8 +64,7 @@ static int submit_file(Session *session, VSFILE *intrdr, const char *filename,
 static char* tokenize(char *str, const char *delim, char **saveptr);
 static int process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass,
                           const char *user, const char *password);
-static int get_basic_auth_credentials(Session *session, char *user, size_t user_len,
-                                      char *password, size_t password_len);
+static int get_basic_auth_password(Session *session, char *password, size_t password_len);
 
 static const unsigned char ASCII_CRLF[] = {CR, LF};
 
@@ -1194,11 +1193,11 @@ submit_file(Session *session, VSFILE *intrdr, const char *filename,
 
 	/* process jobcard: inject USER/PASSWORD */
 	{
-		char user[64] = {0};
+		UCHAR user[64] = {0};
 		char password[256] = {0};
 
-		if (get_basic_auth_credentials(session, user, sizeof(user),
-									   password, sizeof(password)) < 0) {
+		if (!http_get_userid(session->httpc, user, sizeof(user)) ||
+		    get_basic_auth_password(session, password, sizeof(password)) < 0) {
 			sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
 							RC_ERROR, REASON_INVALID_REQUEST,
 							"Job submission requires Basic authentication credentials", NULL, 0);
@@ -1206,7 +1205,7 @@ submit_file(Session *session, VSFILE *intrdr, const char *filename,
 			goto quit;
 		}
 
-		rc = process_jobcard(lines, num_lines, jobname, jobclass, user, password);
+		rc = process_jobcard(lines, num_lines, jobname, jobclass, (char *)user, password);
 		if (rc < 0) {
 			sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
 							RC_ERROR, REASON_INVALID_REQUEST,
@@ -1539,11 +1538,15 @@ find_job_card_range(char **lines, int count, int *start_idx, int *end_idx)
  * only works while job submission authenticates with Basic Auth on every
  * call; it has no answer for a token-authenticated session. See issue
  * #164 for the open architecture question.
+ *
+ * The userid for USER= comes from http_get_userid() instead (the RACF-
+ * verified, canonically-cased form from the ACEE httpd already resolved)
+ * -- not from re-decoding this header -- so it doesn't depend on however
+ * the client happened to case it on the wire.
  */
-__asm__("\n&FUNC    SETC 'get_basic_auth_credentials'");
+__asm__("\n&FUNC    SETC 'get_basic_auth_password'");
 static int
-get_basic_auth_credentials(Session *session, char *user, size_t user_len,
-                          char *password, size_t password_len)
+get_basic_auth_password(Session *session, char *password, size_t password_len)
 {
 	const char *authhdr = getHeaderParam(session, "Authorization");
 	UCHAR *decoded = NULL;
@@ -1553,12 +1556,6 @@ get_basic_auth_credentials(Session *session, char *user, size_t user_len,
 	size_t n;
 	int rc = -1;
 
-	/* TEMPORARY diagnostic for issue #164/#165 follow-up: lengths only,
-	 * never the header content (it carries the password). Remove once
-	 * the Authorization truncation root cause is confirmed. */
-	wtof("MVSMF97D get_basic_auth_credentials: authhdr=%s len=%d",
-	    authhdr ? "present" : "absent", authhdr ? (int)strlen(authhdr) : -1);
-
 	if (!authhdr || strncmp(authhdr, "Basic ", 6) != 0) {
 		return -1;
 	}
@@ -1567,8 +1564,6 @@ get_basic_auth_credentials(Session *session, char *user, size_t user_len,
 	if (!decoded) {
 		return -1;
 	}
-
-	wtof("MVSMF97D get_basic_auth_credentials: decoded_len=%d", (int)decoded_len);
 
 	n = decoded_len;
 	if (n >= sizeof(creds)) n = sizeof(creds) - 1;
@@ -1581,9 +1576,6 @@ get_basic_auth_credentials(Session *session, char *user, size_t user_len,
 
 	colon = strchr(creds, ':');
 	if (colon) {
-		*colon = '\0';
-		strncpy(user, creds, user_len - 1);
-		user[user_len - 1] = '\0';
 		strncpy(password, colon + 1, password_len - 1);
 		password[password_len - 1] = '\0';
 		rc = 0;
@@ -1852,11 +1844,11 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
     }
 
     /* Analyze and potentially modify job card */
-    char user[64] = {0};
+    UCHAR user[64] = {0};
     char password[256] = {0};
 
-    if (get_basic_auth_credentials(session, user, sizeof(user),
-                                   password, sizeof(password)) < 0) {
+    if (!http_get_userid(session->httpc, user, sizeof(user)) ||
+        get_basic_auth_password(session, password, sizeof(password)) < 0) {
         wtof("MVSMF22E Failed to analyze job card");
         sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
                         RC_ERROR, REASON_INVALID_REQUEST,
@@ -1865,7 +1857,7 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
         goto quit;
     }
 
-    rc = process_jobcard(lines, num_lines, jobname, jobclass, user, password);
+    rc = process_jobcard(lines, num_lines, jobname, jobclass, (char *)user, password);
     if (rc < 0) {
         wtof("MVSMF22E Failed to analyze job card");
         sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -1594,6 +1594,14 @@ get_basic_auth_credentials(Session *session, char *user, size_t user_len,
 
 		strncpy(password, colon + 1, password_len - 1);
 		password[password_len - 1] = '\0';
+		/* RACF/RAKF job initiation (RACROUTE VERIFY at JES2 job start)
+		 * checks the password case-sensitively here, unlike the Basic
+		 * Auth login check on this same request -- fold to uppercase
+		 * to match (a mixed-case password was rejected as invalid by
+		 * JES2 in live testing). */
+		for (i = 0; password[i]; i++) {
+			password[i] = (char)toupper((unsigned char)password[i]);
+		}
 		rc = 0;
 	}
 
@@ -1765,11 +1773,6 @@ process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass,
         wtof("MVSMF23E Buffer overflow in snprintf ");
         return -1;
     }
-
-    /* TEMPORARY diagnostic for issue #164 follow-up: length only, never
-     * the password itself. Remove once the PASSWORD= empty-on-card
-     * mystery is confirmed as either a real bug or a display artifact. */
-    wtof("MVSMF97D process_jobcard: password strlen=%d", (int)strlen(password));
 
     rc = snprintf(lines[end_idx + 2], 72, "//         PASSWORD=%s", password);
     if (rc < 0 || rc >= 72) {

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -1,4 +1,5 @@
 #include <clibary.h>
+#include <clibb64.h>
 #include <clibio.h>
 #include <clibstr.h>
 #include <stddef.h>
@@ -61,8 +62,10 @@ static const char *extract_file_value(char *json, size_t len);
 static int submit_file(Session *session, VSFILE *intrdr, const char *filename,
                        char *jobname, char *jobid, char *jobclass);
 static char* tokenize(char *str, const char *delim, char **saveptr);
-static int process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass, 
+static int process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass,
                           const char *user, const char *password);
+static int get_basic_auth_credentials(Session *session, char *user, size_t user_len,
+                                      char *password, size_t password_len);
 
 static const unsigned char ASCII_CRLF[] = {CR, LF};
 
@@ -100,12 +103,15 @@ jobListHandler(Session *session)
 	const char *host = getHeaderParam(session, "HOST");
 	const char *owner = getQueryParam(session, "owner");
 	const unsigned max_jobs = get_max_jobs(session);
+	UCHAR ownerid[64];
 
 	if (owner == NULL) {
-		owner = getHeaderParam(session, "CURRENT_USER");
+		/* z/OSMF default: jobs owned by the caller, from the identity
+		 * httpd already resolved (mvslovers/httpd#99), not env vars. */
+		owner = (const char *)http_get_userid(session->httpc, ownerid, sizeof(ownerid));
 	}
 
-	if (owner[0] == '*') {
+	if (owner && owner[0] == '*') {
 		owner = NULL;
 	}
 
@@ -1188,8 +1194,17 @@ submit_file(Session *session, VSFILE *intrdr, const char *filename,
 
 	/* process jobcard: inject USER/PASSWORD */
 	{
-		const char *user = getHeaderParam(session, "CURRENT_USER");
-		const char *password = getHeaderParam(session, "CURRENT_PASSWORD");
+		char user[64] = {0};
+		char password[256] = {0};
+
+		if (get_basic_auth_credentials(session, user, sizeof(user),
+									   password, sizeof(password)) < 0) {
+			sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
+							RC_ERROR, REASON_INVALID_REQUEST,
+							"Job submission requires Basic authentication credentials", NULL, 0);
+			rc = -1;
+			goto quit;
+		}
 
 		rc = process_jobcard(lines, num_lines, jobname, jobclass, user, password);
 		if (rc < 0) {
@@ -1514,6 +1529,62 @@ find_job_card_range(char **lines, int count, int *start_idx, int *end_idx)
     }
 }
 
+/*
+ * INTRDR job submission runs under the caller's RACF identity via classic
+ * USER=/PASSWORD= job-card injection below -- on this JES2 setup, setting
+ * the submitting task's ACEE alone does not propagate to the submitted
+ * job. httpd's credential resolver deliberately never hands the decrypted
+ * password back to the CGI (mvslovers/httpd#96/#97/#99), so recover it
+ * here directly from this request's own Authorization: Basic header. This
+ * only works while job submission authenticates with Basic Auth on every
+ * call; it has no answer for a token-authenticated session. See issue
+ * #164 for the open architecture question.
+ */
+__asm__("\n&FUNC    SETC 'get_basic_auth_credentials'");
+static int
+get_basic_auth_credentials(Session *session, char *user, size_t user_len,
+                          char *password, size_t password_len)
+{
+	const char *authhdr = getHeaderParam(session, "Authorization");
+	UCHAR *decoded = NULL;
+	size_t decoded_len = 0;
+	char creds[256];
+	char *colon;
+	size_t n;
+	int rc = -1;
+
+	if (!authhdr || strncmp(authhdr, "Basic ", 6) != 0) {
+		return -1;
+	}
+
+	decoded = base64_decode((const UCHAR *)(authhdr + 6), strlen(authhdr + 6), &decoded_len);
+	if (!decoded) {
+		return -1;
+	}
+
+	n = decoded_len;
+	if (n >= sizeof(creds)) n = sizeof(creds) - 1;
+	memcpy(creds, decoded, n);
+	creds[n] = '\0';
+	free(decoded);
+
+	/* the decoded user:pass is ASCII on the wire -> translate to EBCDIC */
+	http_atoe((UCHAR *)creds, (int)n);
+
+	colon = strchr(creds, ':');
+	if (colon) {
+		*colon = '\0';
+		strncpy(user, creds, user_len - 1);
+		user[user_len - 1] = '\0';
+		strncpy(password, colon + 1, password_len - 1);
+		password[password_len - 1] = '\0';
+		rc = 0;
+	}
+
+	memset(creds, 0, sizeof(creds));   /* scrub the password */
+	return rc;
+}
+
 __asm__("\n&FUNC    SETC 'process_jobcard'");
 static int
 process_jobcard(char **lines, int num_lines, char *jobname, char *jobclass, 
@@ -1773,8 +1844,18 @@ int submit_jcl_content(Session *session, VSFILE *intrdr, const char *content, si
     }
 
     /* Analyze and potentially modify job card */
-    const char *user = getHeaderParam(session, "CURRENT_USER");
-    const char *password = getHeaderParam(session, "CURRENT_PASSWORD");
+    char user[64] = {0};
+    char password[256] = {0};
+
+    if (get_basic_auth_credentials(session, user, sizeof(user),
+                                   password, sizeof(password)) < 0) {
+        wtof("MVSMF22E Failed to analyze job card");
+        sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE,
+                        RC_ERROR, REASON_INVALID_REQUEST,
+                        "Job submission requires Basic authentication credentials", NULL, 0);
+        rc = -1;
+        goto quit;
+    }
 
     rc = process_jobcard(lines, num_lines, jobname, jobclass, user, password);
     if (rc < 0) {

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -1,5 +1,6 @@
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <clibgrt.h>
 #include <clibppa.h>
 #include <clibcrt.h>
@@ -28,6 +29,15 @@ static
 int identity_middleware(Session *session)
 {
 	ACEE *acee = http_get_acee(session->httpc);
+
+	/* TEMPORARY diagnostic for issue #164/#165 follow-up: lengths only,
+	 * never the header content (it carries the password). Remove once
+	 * the Authorization truncation root cause is confirmed. */
+	{
+		const char *authhdr = getHeaderParam(session, "Authorization");
+		wtof("MVSMF97D identity_middleware: authhdr=%s len=%d",
+		    authhdr ? "present" : "absent", authhdr ? (int)strlen(authhdr) : -1);
+	}
 
 	if (!acee) {
 		sendDefaultHeaders(session, HTTP_STATUS_UNAUTHORIZED, HTTP_CONTENT_TYPE_NONE, 0);

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -1,6 +1,5 @@
 #include <stddef.h>
 #include <stdio.h>
-#include <string.h>
 #include <clibgrt.h>
 #include <clibppa.h>
 #include <clibcrt.h>
@@ -29,15 +28,6 @@ static
 int identity_middleware(Session *session)
 {
 	ACEE *acee = http_get_acee(session->httpc);
-
-	/* TEMPORARY diagnostic for issue #164/#165 follow-up: lengths only,
-	 * never the header content (it carries the password). Remove once
-	 * the Authorization truncation root cause is confirmed. */
-	{
-		const char *authhdr = getHeaderParam(session, "Authorization");
-		wtof("MVSMF97D identity_middleware: authhdr=%s len=%d",
-		    authhdr ? "present" : "absent", authhdr ? (int)strlen(authhdr) : -1);
-	}
 
 	if (!acee) {
 		sendDefaultHeaders(session, HTTP_STATUS_UNAUTHORIZED, HTTP_CONTENT_TYPE_NONE, 0);


### PR DESCRIPTION
## Summary

Two regressions from #160 (dropping `authmw.c`), both from the same root
cause: `jobsapi.c` read the caller's identity via
`getHeaderParam(session, "CURRENT_USER"/"CURRENT_PASSWORD")`, which reads
the `HTTP_CURRENT_USER`/`HTTP_CURRENT_PASSWORD` env vars — set only by the
now-deleted `authmw.c`. My original audit for #160 missed this because the
`HTTP_` prefix is added inside `get_env_param()`, not present at the read
site, so a literal grep for the env var name didn't find it.

**1. Crash on job listing** (`jobListHandler`): defaulting the `owner`
filter to the current user got `NULL` back, and `owner[0] == '*'`
dereferenced it — an S0C4 on any `GET /zosmf/restjobs/jobs` without an
explicit `owner=` (the common "list my jobs" case, e.g. `zowe jobs list
jobs`). Fixed by reading the userid via httpd's `http_get_userid` HTTPX
export instead, with a `NULL` guard before the dereference regardless.

**2. Job submission broken entirely** (both the dataset and inline-JCL
submit paths): `process_jobcard()` injects `USER=`/`PASSWORD=` onto the
JOB card so JES2 `INTRDR` submission runs under the caller's identity —
that's apparently load-bearing on this JES2 setup (ACEE alone on the
submitting task doesn't propagate to the submitted job). With both `NULL`,
it failed its first parameter check (`MVSMF22E Invalid parameters for
process_jobcard`), so **no job could be submitted at all** — this is how
it was found: it broke the RECEIVE job that deploys a build, which deleted
`HTTPD.V4R0M0D.LINKLIB` without being able to recreate it.

## Fix

Added `get_basic_auth_credentials()`: recovers user/password by decoding
*this request's own* `Authorization: Basic` header directly (the same
decode httpd's resolver already does internally, scoped here to this one
need) instead of depending on `authmw.c`'s env vars.

**This is an explicit stopgap**, not a real fix — it only works because
job submission still authenticates with Basic Auth on every call. Filed
#164 to track the open architecture question: the token flow (#161/#162)
gives the CGI no way to recover a password at all (`CREDTOK` is a one-way
hash), and job submission has no answer for that yet. Left for later,
deliberately, per discussion.

## Test plan

- [x] `make compiledb` clean, no new diagnostics
- [x] `make` builds and links cleanly
- [x] `make test-host` — no regressions (same pre-existing, unrelated
      `TSTNTST` MVS-only host-compile failure as on `main`)
- [ ] Needs verification against a live JES2 system: `GET
      /zosmf/restjobs/jobs` without `owner=`, and job submission
      (dataset + inline JCL) — not verifiable locally

Note: `tests/zowe-jobs.sh` already lists `zowe jobs list jobs` (no owner)
as one of its scenarios, and would likely have caught the crash if
`make test-mvs` had run against the live system after #160 merged.