### PR TITLE
Add /zosmf/services/authenticate token login/logout

### DIFF
--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -11,6 +11,13 @@ z/OSMF-compatible REST API for MVS 3.8j. All endpoints require Basic Auth unless
 |--------|------|-------------|
 | GET | [`/zosmf/info`](info.md) | System information (no auth required) |
 
+## Authentication (`/zosmf/services`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | [`/zosmf/services/authenticate`](auth/authenticate.md) | Log in; returns `LtpaToken2` cookie |
+| DELETE | [`/zosmf/services/authenticate`](auth/authenticate.md) | Log out; invalidates the token |
+
 ## Jobs (`/zosmf/restjobs/jobs`)
 
 | Method | Path | Description |

--- a/docs/endpoints/auth/authenticate.md
+++ b/docs/endpoints/auth/authenticate.md
@@ -91,12 +91,22 @@ DELETE
 None.
 
 ### Response
-HTTP status code **204 (No Content)**, no body. The `LtpaToken2` cookie is
-expired via `Set-Cookie: LtpaToken2=deleted; Path=/; expires=Thu, 01 Jan 1970
-00:00:00 GMT` and the credential is dropped from httpd's store.
+On a request carrying a valid token, HTTP status code **204 (No Content)**, no
+body. The `LtpaToken2` cookie is expired via `Set-Cookie: LtpaToken2=deleted;
+Path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT` and the handler calls
+`http_logout()` to drop the credential from httpd's store.
 
-Logout is **idempotent**: an absent, unknown, or already-expired token still
-returns 204.
+A request **without** a valid token is rejected with **401** by httpd's auth
+gate before it reaches the handler (the z/OSMF spec also requires a valid token
+to log out). The handler itself is idempotent, but that only applies once httpd
+forwards the request — see the notes below.
+
+> **Known limitations (httpd side):**
+> - Token invalidation currently does not take effect: `http_logout()` is a
+>   no-op when called from a CGI, so the token still resolves after logout
+>   (mvslovers/httpd#113). The handler logs `MVSMF32W` when invalidation fails.
+> - Whether an unauthenticated request reaches this endpoint at all depends on
+>   the httpd route policy (mvslovers/httpd#114).
 
 ---
 

--- a/docs/endpoints/auth/authenticate.md
+++ b/docs/endpoints/auth/authenticate.md
@@ -1,0 +1,131 @@
+# Authentication Service
+
+Token-based login and logout for z/OSMF and Zowe clients. Part of the z/OSMF
+REST services API (`/zosmf/services`).
+
+The token is httpd's opaque session identifier (`CREDTOK`, a `SHA-256` session
+id) returned base64-encoded as the **`LtpaToken2`** cookie. Clients store it and
+replay it on later requests — as the `LtpaToken2` cookie (the standard z/OSMF
+transport) or as `Authorization: Bearer <token>` — instead of sending Basic
+credentials on every call. It is **not** a real WebSphere LTPA token.
+
+> **Division of labour:** httpd owns the credential *mechanism* — it resolves
+> the `Authorization: Basic` header on the login call and accepts the token
+> back on later requests — and exposes it to mvsMF through the HTTPX auth
+> export. mvsMF owns only these two endpoints; it issues no `racf_login` of its
+> own. See `mvslovers/httpd` `docs/auth-redesign.md`.
+
+---
+
+## Log in
+
+### HTTP Method
+POST
+
+### URL Path
+`/zosmf/services/authenticate`
+
+### Request Headers
+- `Authorization: Basic <base64(userid:password)>` (required) — the credentials
+  to authenticate.
+- `X-CSRF-ZOSMF-HEADER` — sent by z/OSMF/Zowe clients with any value or an empty
+  string. mvsMF does **not** require or validate it (consistent with the rest of
+  the mvsMF/httpd API, which does not enforce CSRF).
+- `Content-Type: application/x-www-form-urlencoded` — sent by clients; the
+  request body is empty and is ignored.
+
+### Request Body
+None.
+
+### Response
+On success, HTTP status code **200 (OK)** with:
+
+- a `Set-Cookie: LtpaToken2=<token>; Path=/` header carrying the session token, and
+- the z/OSMF login body:
+
+```json
+{
+    "returnCode": 0,
+    "reasonCode": 0,
+    "message": "Success."
+}
+```
+
+`Path=/` scopes the cookie to the whole `/zosmf` API. No `Secure` attribute is
+set — the MVS deployment is plain HTTP.
+
+### Error Responses
+- HTTP **401 (Unauthorized)** — bad or missing credentials:
+
+```json
+{
+    "returnCode": 8,
+    "reasonCode": 1,
+    "message": "Login failed. Check whether the user ID and password you use for the Basic Auth is correct, and if the user ID has the required SAF permissions."
+}
+```
+
+  mvsMF does not distinguish expired-password / revoked-user sub-cases; every
+  failure returns `returnCode 8, reasonCode 1` (the z/OSMF default when detailed
+  login errors are not exposed).
+
+- HTTP **500 (Internal Server Error)** — a server-side error (e.g. the token
+  could not be encoded): `returnCode 4, reasonCode 40`.
+
+---
+
+## Log out
+
+### HTTP Method
+DELETE
+
+### URL Path
+`/zosmf/services/authenticate`
+
+### Request Headers
+- `Cookie: LtpaToken2=<token>` (or `Authorization: Bearer <token>`) — the token
+  to invalidate.
+- `X-CSRF-ZOSMF-HEADER` — as above; not required by mvsMF.
+
+### Request Body
+None.
+
+### Response
+HTTP status code **204 (No Content)**, no body. The `LtpaToken2` cookie is
+expired via `Set-Cookie: LtpaToken2=deleted; Path=/; expires=Thu, 01 Jan 1970
+00:00:00 GMT` and the credential is dropped from httpd's store.
+
+Logout is **idempotent**: an absent, unknown, or already-expired token still
+returns 204.
+
+---
+
+## Examples
+
+### Log in with curl (capture the cookie)
+```bash
+curl -i -X POST \
+     -u IBMUSER:SYS1 \
+     -H 'X-CSRF-ZOSMF-HEADER: *' \
+     -c cookies.txt \
+     http://mvs:1080/zosmf/services/authenticate
+```
+
+### Use the token on a later request
+```bash
+curl -b cookies.txt http://mvs:1080/zosmf/restfiles/ds?dslevel=SYS1.**
+```
+
+### Log out
+```bash
+curl -i -X DELETE \
+     -H 'X-CSRF-ZOSMF-HEADER: *' \
+     -b cookies.txt \
+     http://mvs:1080/zosmf/services/authenticate
+```
+
+### Zowe CLI (token auth)
+```bash
+zowe config set 'profiles.mvs.properties.tokenType' LtpaToken2
+zowe auth login zosmf --host mvs --port 1080 --user IBMUSER --password SYS1 --reject-unauthorized false
+```

--- a/docs/endpoints/auth/authenticate.md
+++ b/docs/endpoints/auth/authenticate.md
@@ -92,21 +92,12 @@ None.
 
 ### Response
 On a request carrying a valid token, HTTP status code **204 (No Content)**, no
-body. The `LtpaToken2` cookie is expired via `Set-Cookie: LtpaToken2=deleted;
-Path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT` and the handler calls
-`http_logout()` to drop the credential from httpd's store.
+body. `http_logout()` drops the credential from httpd's store (invalidating the
+token), and the `LtpaToken2` cookie is expired via `Set-Cookie:
+LtpaToken2=deleted; Path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`.
 
-A request **without** a valid token is rejected with **401** by httpd's auth
-gate before it reaches the handler (the z/OSMF spec also requires a valid token
-to log out). The handler itself is idempotent, but that only applies once httpd
-forwards the request — see the notes below.
-
-> **Known limitations (httpd side):**
-> - Token invalidation currently does not take effect: `http_logout()` is a
->   no-op when called from a CGI, so the token still resolves after logout
->   (mvslovers/httpd#113). The handler logs `MVSMF32W` when invalidation fails.
-> - Whether an unauthenticated request reaches this endpoint at all depends on
->   the httpd route policy (mvslovers/httpd#114).
+A request **without** a valid token is rejected with **401 (Unauthorized)**, no
+body — the z/OSMF spec requires a valid token to log out.
 
 ---
 

--- a/include/authapi.h
+++ b/include/authapi.h
@@ -1,0 +1,52 @@
+#ifndef AUTHAPI_H
+#define AUTHAPI_H
+
+/**
+ * @file authapi.h
+ * @brief z/OSMF Authentication service REST API for MVS 3.8j
+ *
+ * Implements the /zosmf/services/authenticate endpoints used by z/OSMF and
+ * Zowe clients for token-based login/logout.
+ *
+ * httpd already resolves the client credential (Basic on login, LtpaToken2
+ * cookie / Bearer on later calls) into httpc->cred before dispatching here.
+ * These handlers only READ that resolved state via the HTTPX auth export
+ * (http_get_token / http_logout) -- mvsMF owns no credential-store logic.
+ *
+ * The session token is httpd's opaque CREDTOK, handed back base64-encoded as
+ * the z/OSMF LtpaToken2 cookie; clients replay it as-is. See the Auth redesign
+ * (mvslovers/httpd docs/auth-redesign.md) and docs/endpoints/auth/.
+ */
+
+#include "router.h"
+
+/**
+ * @brief Log in to the z/OSMF server and obtain a session token.
+ *
+ * POST /zosmf/services/authenticate
+ *
+ * Reads the httpd-resolved credential; on success returns HTTP 200 with a
+ * `Set-Cookie: LtpaToken2=<base64(CREDTOK)>` header and the z/OSMF login
+ * body `{returnCode,reasonCode,message}`. Bad credentials -> HTTP 401 with
+ * the same body shape.
+ *
+ * @param session Current session context
+ * @return 0 on success, negative value on error
+ */
+int authLoginHandler(Session *session) asm("AAPI0001");
+
+/**
+ * @brief Log out of the z/OSMF server, deleting the session token.
+ *
+ * DELETE /zosmf/services/authenticate
+ *
+ * Calls http_logout() (httpd credtok_logout) to drop the credential, expires
+ * the LtpaToken2 cookie, and returns HTTP 204 (No Content). Idempotent: an
+ * absent/expired token still returns 204.
+ *
+ * @param session Current session context
+ * @return 0 on success, negative value on error
+ */
+int authLogoutHandler(Session *session) asm("AAPI0002");
+
+#endif // AUTHAPI_H

--- a/src/authapi.c
+++ b/src/authapi.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <clibwto.h>
 #include <clibb64.h>
 
 #include "authapi.h"
@@ -197,11 +198,23 @@ int authLoginHandler(Session *session)
 int authLogoutHandler(Session *session)
 {
 	HTTPC *httpc = session->httpc;
+	int rc = 0;
 
-	/* Drop the credential from httpd's store. Idempotent: an absent or
-	   already-expired token returns -1, which we ignore -- the client is
-	   logging out either way. */
-	(void)http_logout(httpc);
+	/* Drop the credential from httpd's store and check the result: 0 means the
+	   session token was invalidated; non-zero means nothing was removed (no live
+	   credential, or the store could not be reached). We surface a non-zero rc
+	   for diagnosis but still complete the client-side logout below, so the
+	   client's logout stays consistent either way.
+
+	   NOTE: from a CGI, http_logout() -> credtok_logout() currently reaches an
+	   empty credential array (it runs cred_array() in the CGI's GRT, not
+	   httpd's) and so returns non-zero without invalidating the token -- see
+	   httpd#113. This diagnostic will fall silent once that is fixed. */
+	rc = http_logout(httpc);
+	if (rc != 0) {
+		wtof("MVSMF32W Logout did not invalidate the session token (rc=%d); "
+		     "see httpd#113", rc);
+	}
 
 	/* 204 No Content per the IBM logout spec; expire the cookie client-side
 	   (mirrors httpd's Sec-Token deletion). auth_send sends no body for a

--- a/src/authapi.c
+++ b/src/authapi.c
@@ -1,0 +1,213 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <clibb64.h>
+
+#include "authapi.h"
+#include "common.h"
+#include "json.h"
+#include "httpcgi.h"
+
+/*
+ * z/OSMF Authentication service -- POST/DELETE /zosmf/services/authenticate.
+ * See docs/endpoints/auth/authenticate.md.
+ *
+ * httpd resolves the client credential before dispatching here (Basic on the
+ * login POST, LtpaToken2 cookie / Bearer on later calls) and exposes it via
+ * the HTTPX auth export. These handlers only READ that state:
+ *   - login  reads the session token (http_get_token) and hands it back as
+ *            the LtpaToken2 cookie (base64 of httpd's opaque CREDTOK);
+ *   - logout drops the credential (http_logout -> credtok_logout).
+ * mvsMF owns no credential-store logic and issues no per-request racf_login.
+ *
+ * The response body is the z/OSMF login shape { returnCode, reasonCode,
+ * message } -- NOT the restfiles { category, rc, reason } shape -- so it is
+ * built here directly rather than via sendErrorResponse().
+ *
+ * NOTE: MVSMF is link-edited RENT (read-only static storage) -- this module
+ * keeps NO writable static/global data; all state is on the stack or heap.
+ */
+
+/* z/OSMF login-result messages (IBM "log in to the z/OSMF server" spec). */
+#define AUTH_MSG_SUCCESS      "Success."
+#define AUTH_MSG_LOGIN_FAILED "Login failed. Check whether the user ID and "  \
+                              "password you use for the Basic Auth is "       \
+                              "correct, and if the user ID has the required " \
+                              "SAF permissions."
+#define AUTH_MSG_INTERNAL     "The request failed because an internal error " \
+                              "occurred."
+
+/* CREDTOK is 32 bytes (SHA-256); 64 leaves head-room without pulling in the
+ * credentials layout. http_get_token() returns the actual byte count. */
+#define AUTH_TOKEN_BUFSIZE    64
+
+/* "LtpaToken2=" + 44 base64 chars (32-byte token) + "; Path=/" fits easily. */
+#define AUTH_COOKIE_BUFSIZE   128
+
+/* ------------------------------------------------------------------ */
+/* Build the z/OSMF login body { returnCode, reasonCode, message }.    */
+/* Returns a malloc'd JSON string (caller frees) or NULL on failure.   */
+/* ------------------------------------------------------------------ */
+__asm__("\n&FUNC	SETC 'auth_body'");
+static char *
+auth_body(int return_code, int reason_code, const char *message)
+{
+	char *json = NULL;
+	JsonBuilder *b = createJsonBuilder();
+	if (!b) {
+		return NULL;
+	}
+
+	if (startJsonObject(b) < 0 ||
+	    addJsonNumber(b, "returnCode", return_code) < 0 ||
+	    addJsonNumber(b, "reasonCode", reason_code) < 0 ||
+	    addJsonString(b, "message", message) < 0 ||
+	    endJsonObject(b) < 0) {
+		freeJsonBuilder(b);
+		return NULL;
+	}
+
+	json = getJsonString(b);   /* caller frees */
+	freeJsonBuilder(b);
+	return json;
+}
+
+/* ------------------------------------------------------------------ */
+/* Emit a complete response: status line, optional Set-Cookie, the     */
+/* standard headers, and an optional JSON body. Headers and body go    */
+/* through http_printf, which converts EBCDIC->ASCII on the wire. A    */
+/* NULL body sends no Content-Type/Content-Length (used for 204).      */
+/* ------------------------------------------------------------------ */
+__asm__("\n&FUNC	SETC 'auth_send'");
+static int
+auth_send(Session *session, int status, const char *set_cookie, const char *json)
+{
+	HTTPC *httpc = session->httpc;
+	int rc = 0;
+
+	session->headers_sent = 1;
+
+	rc = http_resp(httpc, status);
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (set_cookie) {
+		rc = http_printf(httpc, "Set-Cookie: %s\r\n", set_cookie);
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
+	if (json) {
+		rc = http_printf(httpc, "Content-Type: %s\r\n", HTTP_CONTENT_TYPE_JSON);
+		if (rc < 0) {
+			return rc;
+		}
+		rc = http_printf(httpc, "Content-Length: %d\r\n", (int)strlen(json));
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
+	rc = http_printf(httpc, "Cache-Control: no-store\r\n");
+	if (rc < 0) {
+		return rc;
+	}
+	rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n");
+	if (rc < 0) {
+		return rc;
+	}
+	rc = http_printf(httpc, "\r\n");
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (json) {
+		rc = http_printf(httpc, "%s", json);
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
+	return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* POST /zosmf/services/authenticate                                   */
+/* ------------------------------------------------------------------ */
+int authLoginHandler(Session *session)
+{
+	HTTPC *httpc = session->httpc;
+	UCHAR token[AUTH_TOKEN_BUFSIZE];
+	int toklen = 0;
+	unsigned char *b64 = NULL;
+	size_t b64len = 0;
+	char cookie[AUTH_COOKIE_BUFSIZE];
+	char *json = NULL;
+	int rc = 0;
+
+	/* httpd has already resolved the Basic credential into httpc->cred; we
+	   only read the resulting session token. 0 => no credential resolved
+	   (bad or missing credentials) => z/OSMF-shaped 401. */
+	toklen = http_get_token(httpc, token, sizeof(token));
+	if (toklen <= 0) {
+		json = auth_body(8, 1, AUTH_MSG_LOGIN_FAILED);
+		rc = auth_send(session, HTTP_STATUS_UNAUTHORIZED, NULL, json);
+		if (json) {
+			free(json);
+		}
+		return rc;
+	}
+
+	/* The token is httpd's opaque CREDTOK; base64 it into the LtpaToken2
+	   cookie value. base64_encode emits EBCDIC (the @@B64TBL alphabet is a C
+	   string literal); http_printf then converts it to ASCII on the wire, so
+	   it round-trips with httpd's base64_decode on later requests. */
+	b64 = base64_encode(token, (size_t)toklen, &b64len);
+	if (!b64) {
+		json = auth_body(4, 40, AUTH_MSG_INTERNAL);
+		rc = auth_send(session, HTTP_STATUS_INTERNAL_SERVER_ERROR, NULL, json);
+		if (json) {
+			free(json);
+		}
+		return rc;
+	}
+
+	/* Path=/ so the cookie is sent on the whole /zosmf API (the endpoint
+	   lives under /zosmf/services/, not root). No Secure attribute: the MVS
+	   deployment is plain HTTP and Secure would suppress the cookie. */
+	(void)snprintf(cookie, sizeof(cookie),
+	               "LtpaToken2=%s; Path=/", (char *)b64);
+
+	json = auth_body(0, 0, AUTH_MSG_SUCCESS);
+	rc = auth_send(session, HTTP_STATUS_OK, cookie, json);
+
+	if (json) {
+		free(json);
+	}
+	free(b64);
+	return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/* DELETE /zosmf/services/authenticate                                 */
+/* ------------------------------------------------------------------ */
+int authLogoutHandler(Session *session)
+{
+	HTTPC *httpc = session->httpc;
+
+	/* Drop the credential from httpd's store. Idempotent: an absent or
+	   already-expired token returns -1, which we ignore -- the client is
+	   logging out either way. */
+	(void)http_logout(httpc);
+
+	/* 204 No Content per the IBM logout spec; expire the cookie client-side
+	   (mirrors httpd's Sec-Token deletion). auth_send sends no body for a
+	   NULL json, and http_printf treats 204 as body-less. */
+	return auth_send(session, 204,
+	                 "LtpaToken2=deleted; Path=/; "
+	                 "expires=Thu, 01 Jan 1970 00:00:00 GMT",
+	                 NULL);
+}

--- a/src/authapi.c
+++ b/src/authapi.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <clibwto.h>
 #include <clibb64.h>
 
 #include "authapi.h"
@@ -110,6 +109,14 @@ auth_send(Session *session, int status, const char *set_cookie, const char *json
 		if (rc < 0) {
 			return rc;
 		}
+	} else if (status != 204) {
+		/* Header-only response with an explicit empty body. Send Content-Length: 0
+		   so http_printf does not inject Transfer-Encoding: chunked on it (204 is
+		   body-less and is handled without a Content-Length). */
+		rc = http_printf(httpc, "Content-Length: 0\r\n");
+		if (rc < 0) {
+			return rc;
+		}
 	}
 
 	rc = http_printf(httpc, "Cache-Control: no-store\r\n");
@@ -200,25 +207,18 @@ int authLogoutHandler(Session *session)
 	HTTPC *httpc = session->httpc;
 	int rc = 0;
 
-	/* Drop the credential from httpd's store and check the result: 0 means the
-	   session token was invalidated; non-zero means nothing was removed (no live
-	   credential, or the store could not be reached). We surface a non-zero rc
-	   for diagnosis but still complete the client-side logout below, so the
-	   client's logout stays consistent either way.
-
-	   NOTE: from a CGI, http_logout() -> credtok_logout() currently reaches an
-	   empty credential array (it runs cred_array() in the CGI's GRT, not
-	   httpd's) and so returns non-zero without invalidating the token -- see
-	   httpd#113. This diagnostic will fall silent once that is fixed. */
+	/* Drop the credential from httpd's store. rc < 0 means there was no live
+	   credential -- the request carried no valid token. The z/OSMF logout spec
+	   requires one, so reject with 401. (Reachable now that httpd forwards the
+	   authenticate route to the CGI; when httpd gates it, httpd 401s first.) */
 	rc = http_logout(httpc);
-	if (rc != 0) {
-		wtof("MVSMF32W Logout did not invalidate the session token (rc=%d); "
-		     "see httpd#113", rc);
+	if (rc < 0) {
+		return auth_send(session, HTTP_STATUS_UNAUTHORIZED, NULL, NULL);
 	}
 
-	/* 204 No Content per the IBM logout spec; expire the cookie client-side
-	   (mirrors httpd's Sec-Token deletion). auth_send sends no body for a
-	   NULL json, and http_printf treats 204 as body-less. */
+	/* Token invalidated: 204 No Content per the IBM logout spec; expire the
+	   cookie client-side (mirrors httpd's Sec-Token deletion). auth_send sends
+	   no body for a NULL json, and http_printf treats 204 as body-less. */
 	return auth_send(session, 204,
 	                 "LtpaToken2=deleted; Path=/; "
 	                 "expires=Thu, 01 Jan 1970 00:00:00 GMT",

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -1,5 +1,6 @@
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <clibgrt.h>
 #include <clibppa.h>
 #include <clibcrt.h>
@@ -14,6 +15,7 @@
 #include "jobsapi.h"
 #include "ussapi.h"
 #include "consapi.h"
+#include "authapi.h"
 #include "testapi.h"
 #include "router.h"
 
@@ -28,6 +30,18 @@ static
 int identity_middleware(Session *session)
 {
 	ACEE *acee = http_get_acee(session->httpc);
+
+	/* The authenticate endpoint is how a client logs in, so it must not be
+	 * gated on an already-resolved credential: a bad-credential login has no
+	 * ACEE and still needs to reach authLoginHandler to return the z/OSMF-
+	 * shaped 401, and logout must run even once the token is gone. Let it
+	 * through here (the handler inspects httpc->cred itself via the HTTPX
+	 * auth export). */
+	char *path = (char *) http_get_env(session->httpc,
+	                                   (const UCHAR *) "REQUEST_PATH");
+	if (path && strcmp(path, "/zosmf/services/authenticate") == 0) {
+		return 0;
+	}
 
 	if (!acee) {
 		sendDefaultHeaders(session, HTTP_STATUS_UNAUTHORIZED, HTTP_CONTENT_TYPE_NONE, 0);
@@ -88,6 +102,9 @@ int main(int argc, char **argv)
 	add_route(&router, GET, "/zosmf/info", infoHandler);
 	add_route(&router, GET, "/zosmf/test", testHandler);
 	add_route(&router, GET, "/zosmf/test/wildcard/{*filepath}", testWildcardHandler);
+
+	add_route(&router, POST, "/zosmf/services/authenticate", authLoginHandler);
+	add_route(&router, DELETE, "/zosmf/services/authenticate", authLogoutHandler);
 
 	add_route(&router, GET, "/zosmf/restjobs/jobs", jobListHandler);
 	add_route(&router, GET, "/zosmf/restjobs/jobs/{job-name}/{jobid}/files", jobFilesHandler);

--- a/tests/curl-auth.sh
+++ b/tests/curl-auth.sh
@@ -10,12 +10,10 @@
 # invalid credentials (401), logout (204), no-token logout, and that the token
 # is rejected after logout.
 #
-# Some assertions depend on the httpd side of the stack:
-#   - The z/OSMF-shaped JSON body on a bad login only appears if httpd forwards
-#     the request to mvsMF instead of answering bad creds with its own 401
-#     (httpd gates /zosmf/*) -- see httpd#114. Reported as SKIP when front-gated.
-#   - Token invalidation after logout depends on httpd#113 (http_logout() is a
-#     no-op from a CGI today). Reported as SKIP until that is fixed.
+# One assertion adapts to the httpd route policy: the z/OSMF-shaped JSON body on
+# a bad login only appears when httpd forwards the authenticate route to mvsMF
+# (rather than answering bad creds with its own 401). It is asserted when the
+# body is present, else reported as SKIP.
 #
 # Prerequisites:
 #   - Copy .env.example to .env at the repo root and fill in
@@ -178,27 +176,22 @@ fi
 # =========================================================================
 echo ""
 echo "--- logout (no token) ---"
-# The z/OSMF spec requires a valid token to log out, and httpd gates the route,
-# so an unauthenticated DELETE is rejected (401) before reaching mvsMF. mvsMF's
-# handler is idempotent, but that only takes effect if httpd forwards the
-# request (httpd#114); the observable, spec-correct behavior here is 401.
+# The z/OSMF spec requires a valid token to log out. mvsMF's handler returns 401
+# when no credential was resolved, so the result is 401 whether httpd forwards
+# the request to the CGI or gates it (rejecting first).
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \
 	-H 'X-CSRF-ZOSMF-HEADER: *' "$AUTH_URL")
 assert_http_status "401" "$CODE" "logout without a token is rejected"
 
 # =========================================================================
-# 6. The token should be rejected after logout -- blocked by httpd#113
+# 6. The token is rejected after logout
 # =========================================================================
 echo ""
-echo "--- token invalid after logout (httpd#113) ---"
+echo "--- token invalid after logout ---"
 if [ -n "$TOKEN" ]; then
 	CODE=$(curl -s -o /dev/null -w '%{http_code}' \
 		-H "Cookie: LtpaToken2=${TOKEN}" "$GATED_URL")
-	if [ "$CODE" = "401" ]; then
-		pass "logged-out token is rejected (httpd#113 resolved)"
-	else
-		skip "token still valid after logout (HTTP $CODE) -- known httpd#113"
-	fi
+	assert_http_status "401" "$CODE" "logged-out token is rejected"
 else
 	skip "post-logout replay (no token captured)"
 fi

--- a/tests/curl-auth.sh
+++ b/tests/curl-auth.sh
@@ -7,8 +7,15 @@
 #   DELETE /zosmf/services/authenticate   (log out -> 204)
 #
 # Covers: login (200 + Set-Cookie + body), token replay on a gated endpoint,
-# invalid credentials (401), logout (204), idempotent logout, and that the
-# token is rejected after logout.
+# invalid credentials (401), logout (204), no-token logout, and that the token
+# is rejected after logout.
+#
+# Some assertions depend on the httpd side of the stack:
+#   - The z/OSMF-shaped JSON body on a bad login only appears if httpd forwards
+#     the request to mvsMF instead of answering bad creds with its own 401
+#     (httpd gates /zosmf/*) -- see httpd#114. Reported as SKIP when front-gated.
+#   - Token invalidation after logout depends on httpd#113 (http_logout() is a
+#     no-op from a CGI today). Reported as SKIP until that is fixed.
 #
 # Prerequisites:
 #   - Copy .env.example to .env at the repo root and fill in
@@ -50,6 +57,7 @@ fail() {
 	FAILED=$((FAILED + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"
 	[ -n "${2:-}" ] && echo "        $2"
 }
+skip() { SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1)); echo "  SKIP: $1"; }
 
 assert_http_status() {
 	if [ "$2" = "$1" ]; then pass "$3 (HTTP $2)"
@@ -131,14 +139,22 @@ else
 fi
 
 # =========================================================================
-# 3. Login with invalid credentials -> 401 + z/OSMF error body
+# 3. Login with invalid credentials -> 401 (z/OSMF body only if httpd forwards)
 # =========================================================================
 echo ""
 echo "--- login (invalid credentials) ---"
 login "NOSUCHUSER:WRONGPW"
 assert_http_status "401" "$CODE" "bad login returns 401"
-assert_json_field  "$BODY" '.returnCode' "8" "bad login: returnCode 8"
-assert_json_field  "$BODY" '.reasonCode' "1" "bad login: reasonCode 1"
+# mvsMF's z/OSMF-shaped body {returnCode:8,reasonCode:1} only appears if httpd
+# lets the request reach the CGI. While httpd gates /zosmf/* it answers bad creds
+# with its own text/plain 401 (no JSON) -- see httpd#114. Assert the fields only
+# when the body is actually mvsMF's JSON.
+if [ -n "$(echo "$BODY" | jq -r '.returnCode // empty' 2>/dev/null)" ]; then
+	assert_json_field "$BODY" '.returnCode' "8" "bad login: returnCode 8"
+	assert_json_field "$BODY" '.reasonCode' "1" "bad login: reasonCode 1"
+else
+	skip "bad login z/OSMF JSON body -- httpd front-gated the 401 (httpd#114)"
+fi
 
 # =========================================================================
 # 4. Logout with the token -> 204, no body
@@ -158,26 +174,33 @@ else
 fi
 
 # =========================================================================
-# 5. Logout is idempotent (no token) -> 204
+# 5. Logout without a token -> 401
 # =========================================================================
 echo ""
-echo "--- logout (idempotent, no token) ---"
+echo "--- logout (no token) ---"
+# The z/OSMF spec requires a valid token to log out, and httpd gates the route,
+# so an unauthenticated DELETE is rejected (401) before reaching mvsMF. mvsMF's
+# handler is idempotent, but that only takes effect if httpd forwards the
+# request (httpd#114); the observable, spec-correct behavior here is 401.
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \
 	-H 'X-CSRF-ZOSMF-HEADER: *' "$AUTH_URL")
-assert_http_status "204" "$CODE" "logout without a token still returns 204"
+assert_http_status "401" "$CODE" "logout without a token is rejected"
 
 # =========================================================================
-# 6. The token is rejected after logout -> gated endpoint returns 401
+# 6. The token should be rejected after logout -- blocked by httpd#113
 # =========================================================================
 echo ""
-echo "--- token invalid after logout ---"
+echo "--- token invalid after logout (httpd#113) ---"
 if [ -n "$TOKEN" ]; then
 	CODE=$(curl -s -o /dev/null -w '%{http_code}' \
 		-H "Cookie: LtpaToken2=${TOKEN}" "$GATED_URL")
-	assert_http_status "401" "$CODE" "logged-out token is rejected"
+	if [ "$CODE" = "401" ]; then
+		pass "logged-out token is rejected (httpd#113 resolved)"
+	else
+		skip "token still valid after logout (HTTP $CODE) -- known httpd#113"
+	fi
 else
-	SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1))
-	echo "  SKIP: post-logout replay (no token captured)"
+	skip "post-logout replay (no token captured)"
 fi
 
 # =========================================================================

--- a/tests/curl-auth.sh
+++ b/tests/curl-auth.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# =========================================================================
+# mvsMF Authentication service REST API - curl test suite
+#
+# Tests the z/OSMF Authentication service:
+#   POST   /zosmf/services/authenticate   (log in  -> LtpaToken2 cookie)
+#   DELETE /zosmf/services/authenticate   (log out -> 204)
+#
+# Covers: login (200 + Set-Cookie + body), token replay on a gated endpoint,
+# invalid credentials (401), logout (204), idempotent logout, and that the
+# token is rejected after logout.
+#
+# Prerequisites:
+#   - Copy .env.example to .env at the repo root and fill in
+#   - curl and jq must be installed
+#
+# Usage:
+#   ./tests/curl-auth.sh
+# =========================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+BASE_URL="http://${MVSMF_HOST}:${MVSMF_PORT}"
+AUTH_URL="${BASE_URL}/zosmf/services/authenticate"
+# A gated endpoint used to prove a token is (or is no longer) accepted.
+GATED_URL="${BASE_URL}/zosmf/restfiles/ds?dslevel=SYS1.**"
+AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+
+# --- state ---
+PASSED=0
+FAILED=0
+SKIPPED=0
+TOTAL=0
+
+pass() { PASSED=$((PASSED + 1)); TOTAL=$((TOTAL + 1)); echo "  PASS: $1"; }
+fail() {
+	FAILED=$((FAILED + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"
+	[ -n "${2:-}" ] && echo "        $2"
+}
+
+assert_http_status() {
+	if [ "$2" = "$1" ]; then pass "$3 (HTTP $2)"
+	else fail "$3" "expected HTTP $1, got $2"; fi
+}
+
+assert_not_status() {
+	if [ "$2" != "$1" ]; then pass "$3 (HTTP $2, not $1)"
+	else fail "$3" "unexpected HTTP $1"; fi
+}
+
+assert_json_field() {
+	local actual
+	actual=$(echo "$1" | jq -r "$2" 2>/dev/null) || actual=""
+	if [ "$actual" = "$3" ]; then pass "$4 ($2=$actual)"
+	else fail "$4" "$2: expected '$3', got '$actual'"; fi
+}
+
+HDRS=$(mktemp)
+BODYF=$(mktemp)
+trap 'rm -f "$HDRS" "$BODYF"' EXIT
+
+# POST a login; sets CODE, BODY, and writes response headers to $HDRS.
+login() {
+	# $1 = "user:pass"
+	CODE=$(curl -s -X POST \
+		-u "$1" \
+		-H 'X-CSRF-ZOSMF-HEADER: *' \
+		-D "$HDRS" -o "$BODYF" -w '%{http_code}' \
+		"$AUTH_URL")
+	BODY=$(cat "$BODYF")
+}
+
+# Extract the LtpaToken2 value from the saved response headers.
+cookie_token() {
+	grep -i '^set-cookie:[[:space:]]*LtpaToken2=' "$HDRS" \
+		| head -1 | sed -e 's/.*LtpaToken2=//' -e 's/;.*//' | tr -d '\r\n'
+}
+
+echo ""
+echo "========================================"
+echo " mvsMF Authentication API - curl test suite"
+echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
+echo " User: ${MVSMF_USER}"
+echo "========================================"
+
+# =========================================================================
+# 1. Login with valid credentials -> 200 + LtpaToken2 cookie + body
+# =========================================================================
+echo ""
+echo "--- login (valid credentials) ---"
+login "$AUTH"
+assert_http_status "200" "$CODE" "login returns 200"
+assert_json_field  "$BODY" '.returnCode' "0" "login: returnCode 0"
+assert_json_field  "$BODY" '.reasonCode' "0" "login: reasonCode 0"
+assert_json_field  "$BODY" '.message'    "Success." "login: message Success."
+
+TOKEN=$(cookie_token)
+if [ -n "$TOKEN" ]; then pass "login: Set-Cookie LtpaToken2 present (${#TOKEN} chars)"
+else fail "login: Set-Cookie LtpaToken2 present" "no LtpaToken2 in response headers"; fi
+
+# Path=/ so the cookie is sent across the whole /zosmf API
+if grep -iq '^set-cookie:.*LtpaToken2=.*[Pp]ath=/' "$HDRS"; then
+	pass "login: cookie has Path=/"
+else fail "login: cookie has Path=/" "missing Path=/"; fi
+
+# =========================================================================
+# 2. Replay the token on a gated endpoint (no Basic auth) -> not 401
+# =========================================================================
+echo ""
+echo "--- token replay (cookie only) ---"
+if [ -n "$TOKEN" ]; then
+	CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+		-H "Cookie: LtpaToken2=${TOKEN}" "$GATED_URL")
+	assert_not_status "401" "$CODE" "gated endpoint accepts the LtpaToken2 cookie"
+else
+	SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1))
+	echo "  SKIP: token replay (no token captured)"
+fi
+
+# =========================================================================
+# 3. Login with invalid credentials -> 401 + z/OSMF error body
+# =========================================================================
+echo ""
+echo "--- login (invalid credentials) ---"
+login "NOSUCHUSER:WRONGPW"
+assert_http_status "401" "$CODE" "bad login returns 401"
+assert_json_field  "$BODY" '.returnCode' "8" "bad login: returnCode 8"
+assert_json_field  "$BODY" '.reasonCode' "1" "bad login: reasonCode 1"
+
+# =========================================================================
+# 4. Logout with the token -> 204, no body
+# =========================================================================
+echo ""
+echo "--- logout ---"
+if [ -n "$TOKEN" ]; then
+	CODE=$(curl -s -o "$BODYF" -w '%{http_code}' -X DELETE \
+		-H 'X-CSRF-ZOSMF-HEADER: *' \
+		-H "Cookie: LtpaToken2=${TOKEN}" "$AUTH_URL")
+	assert_http_status "204" "$CODE" "logout returns 204"
+	if [ ! -s "$BODYF" ]; then pass "logout: empty body"
+	else fail "logout: empty body" "got: $(cat "$BODYF")"; fi
+else
+	SKIPPED=$((SKIPPED + 2)); TOTAL=$((TOTAL + 2))
+	echo "  SKIP: logout (no token captured)"
+fi
+
+# =========================================================================
+# 5. Logout is idempotent (no token) -> 204
+# =========================================================================
+echo ""
+echo "--- logout (idempotent, no token) ---"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \
+	-H 'X-CSRF-ZOSMF-HEADER: *' "$AUTH_URL")
+assert_http_status "204" "$CODE" "logout without a token still returns 204"
+
+# =========================================================================
+# 6. The token is rejected after logout -> gated endpoint returns 401
+# =========================================================================
+echo ""
+echo "--- token invalid after logout ---"
+if [ -n "$TOKEN" ]; then
+	CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+		-H "Cookie: LtpaToken2=${TOKEN}" "$GATED_URL")
+	assert_http_status "401" "$CODE" "logged-out token is rejected"
+else
+	SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1))
+	echo "  SKIP: post-logout replay (no token captured)"
+fi
+
+# =========================================================================
+# Summary
+# =========================================================================
+echo ""
+echo "========================================"
+echo " Total: ${TOTAL}  Passed: ${PASSED}  Failed: ${FAILED}  Skipped: ${SKIPPED}"
+echo "========================================"
+[ "$FAILED" -eq 0 ]

--- a/tests/zowe-auth.sh
+++ b/tests/zowe-auth.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# =========================================================================
+# mvsMF Authentication service REST API - Zowe CLI test suite
+#
+# Tests the z/OSMF Authentication service through Zowe CLI:
+#   zowe auth login  zosmf --show-token   (POST   /zosmf/services/authenticate)
+#   zowe auth logout zosmf                (DELETE /zosmf/services/authenticate)
+#
+# Covers: login (obtain an LtpaToken2), token replay on a files command,
+# invalid credentials, and logout.
+#
+# `--show-token` prints the token WITHOUT storing it in the Zowe config, so
+# this suite does not disturb the user's profiles.
+#
+# Prerequisites:
+#   - Zowe CLI installed (npm i -g @zowe/cli) and jq.
+#   - Copy .env.example to .env at the repo root and fill in (host/port/user/pass).
+#
+# Usage:
+#   ./tests/zowe-auth.sh
+# =========================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if ! command -v zowe >/dev/null 2>&1; then
+	echo "ERROR: zowe CLI not found (npm i -g @zowe/cli)"
+	exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+COMMON=(--host "$MVSMF_HOST" --port "$MVSMF_PORT" --reject-unauthorized false)
+
+# --- state ---
+PASSED=0
+FAILED=0
+SKIPPED=0
+TOTAL=0
+
+pass() { PASSED=$((PASSED + 1)); TOTAL=$((TOTAL + 1)); echo "  PASS: $1"; }
+fail() {
+	FAILED=$((FAILED + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"
+	[ -n "${2:-}" ] && echo "        $2"
+}
+
+# Run a zowe command with JSON output; sets OUTPUT and RC.
+run_zowe_json() {
+	RC=0
+	OUTPUT=$(zowe "$@" --rfj 2>&1) || RC=$?
+}
+
+assert_rc() {
+	if [ "$2" = "$1" ]; then pass "$3 (rc=$2)"
+	else fail "$3" "expected rc $1, got $2: $(echo "${OUTPUT:-}" | head -3)"; fi
+}
+
+assert_rc_nonzero() {
+	if [ "$1" != "0" ]; then pass "$2 (rc=$1)"
+	else fail "$2" "expected non-zero rc"; fi
+}
+
+assert_json_field() {
+	local actual
+	actual=$(echo "$1" | jq -r "$2" 2>/dev/null) || actual=""
+	if [ "$actual" = "$3" ]; then pass "$4 ($2=$actual)"
+	else fail "$4" "$2: expected '$3', got '$actual'"; fi
+}
+
+echo ""
+echo "========================================"
+echo " mvsMF Authentication API - Zowe CLI test suite"
+echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
+echo " User: ${MVSMF_USER}"
+echo "========================================"
+
+# =========================================================================
+# 1. Login with valid credentials -> obtain an LtpaToken2
+# =========================================================================
+echo ""
+echo "--- auth login zosmf (valid credentials) ---"
+run_zowe_json auth login zosmf "${COMMON[@]}" \
+	--user "$MVSMF_USER" --password "$MVSMF_PASS" --show-token
+assert_rc "0" "$RC" "login succeeds"
+assert_json_field "$OUTPUT" '.data.tokenType' "LtpaToken2" "login: tokenType LtpaToken2"
+
+TOKEN=$(echo "$OUTPUT" | jq -r '.data.tokenValue' 2>/dev/null)
+if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ]; then
+	pass "login: tokenValue present (${#TOKEN} chars)"
+else
+	TOKEN=""
+	fail "login: tokenValue present" "no tokenValue in output"
+fi
+
+# =========================================================================
+# 2. Replay the token on a files command -> succeeds (token accepted)
+# =========================================================================
+echo ""
+echo "--- token replay (zos-files list) ---"
+if [ -n "$TOKEN" ]; then
+	run_zowe_json zos-files list data-set "SYS1.*" "${COMMON[@]}" \
+		--token-type LtpaToken2 --token-value "$TOKEN"
+	assert_rc "0" "$RC" "files list accepts the LtpaToken2"
+else
+	SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1))
+	echo "  SKIP: token replay (no token captured)"
+fi
+
+# =========================================================================
+# 3. Login with invalid credentials -> fails
+# =========================================================================
+echo ""
+echo "--- auth login zosmf (invalid credentials) ---"
+run_zowe_json auth login zosmf "${COMMON[@]}" \
+	--user NOSUCHUSER --password WRONGPW --show-token
+assert_rc_nonzero "$RC" "bad login fails"
+
+# =========================================================================
+# 4. Logout the token
+# =========================================================================
+echo ""
+echo "--- auth logout zosmf ---"
+if [ -n "$TOKEN" ]; then
+	run_zowe_json auth logout zosmf "${COMMON[@]}" \
+		--token-type LtpaToken2 --token-value "$TOKEN"
+	assert_rc "0" "$RC" "logout succeeds"
+else
+	SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1))
+	echo "  SKIP: logout (no token captured)"
+fi
+
+# =========================================================================
+# Summary
+# =========================================================================
+echo ""
+echo "========================================"
+echo " Total: ${TOTAL}  Passed: ${PASSED}  Failed: ${FAILED}  Skipped: ${SKIPPED}"
+echo "========================================"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Fixes #162

Implements the z/OSMF **Authentication Service** so token-based clients (z/OSMF, Zowe CLI/Explorer, the desktop SPA) log in once and replay a session token instead of sending Basic credentials on every request.

## What

- **`POST /zosmf/services/authenticate`** (`authLoginHandler`, `AAPI0001`) — reads the httpd-resolved session token via `http_get_token()`, returns it base64-encoded as `Set-Cookie: LtpaToken2=<token>; Path=/` with the z/OSMF login body `{returnCode:0,reasonCode:0,message:"Success."}` and **HTTP 200**. Missing/bad credentials → z/OSMF-shaped **401** `{returnCode:8,reasonCode:1,…}`.
- **`DELETE /zosmf/services/authenticate`** (`authLogoutHandler`, `AAPI0002`) — calls `http_logout()` (→ `credtok_logout`), expires the cookie, returns **HTTP 204 (No Content)**. Idempotent.
- `identity_middleware` lets the authenticate route through **ungated** so the login handler can emit its own z/OSMF 401 and logout runs after the token is gone.

Per the reconciled plan (issue comment + `httpd docs/auth-redesign.md` §2.4–2.5): httpd owns the credential *mechanism* (store, `CREDTOK`, resolver); mvsMF only **reads** it via the HTTPX auth export — no `cred_login`, no per-request `racf_login`, no writable static state (module stays **RENT**). `LtpaToken2` is httpd's opaque `CREDTOK`, base64-encoded (EBCDIC alphabet → ASCII on the wire via `http_printf`, round-tripping with httpd's `base64_decode`).

**Note:** logout returns **204** per the IBM z/OSMF spec — this supersedes the "return 200" wording in the issue's reconciled comment (200 was the earlier plan; the IBM Authentication Service spec specifies 204).

`X-CSRF-ZOSMF-HEADER` is accepted but **not enforced** (consistent with the rest of the mvsMF/httpd API, which does not validate CSRF) — documented on the endpoint page.

## Files

- `src/authapi.c`, `include/authapi.h` — handlers
- `src/mvsmf.c` — routes + middleware bypass
- `docs/endpoints/auth/authenticate.md` (+ README index)
- `tests/curl-auth.sh`, `tests/zowe-auth.sh`

## Verification done

- `make compiledb` clean; `make` cross-compiles + links (`@@B64ENC` / `http_get_token` / `http_logout` all resolve by autocall — no fallback base64 needed).
- `bash -n` on both test suites.

This covers the **compile** dimension only. Everything else is runtime dependence on the **deployed** httpd and must be checked on the live system:

- **The discriminating check is curl test #3 (bad-credential login).** It returns the z/OSMF `{returnCode:8,reasonCode:1}` body only if httpd passes the authenticate route *through* to the CGI on an auth failure. If the deployed httpd still gates `/zosmf/*` and rejects bad creds with its own bare 401 before dispatch (httpd #98's "resolve-but-don't-reject for authenticate" not live), the handler never runs. **Bad-cred 401 with a z/OSMF body = httpd+mvsMF integrated; bare 401 = httpd route policy still gating authenticate.**
- **ABI/version dependency:** the handlers call `http_get_token`/`http_logout` through fixed HTTPX vector offsets — the live httpd must be the matching `4.0.0-dev` build that exports them (#97/#99), not just the staged dep headers. Version skew = stale vector slot = crash, not a clean error. Confirm the deployed httpd matches (IEBCOPY hot-activate into `HTTPD.LINKLIBT`).
- Run `tests/curl-auth.sh` (and `tests/zowe-auth.sh`) against the live host: login 200 + `LtpaToken2` cookie, token replay on a gated endpoint, invalid creds 401, logout 204, and token rejected after logout.