### PR TITLE
SPA: token login; stop storing the password (#161)

### DIFF
--- a/docs/desktop-poc.html
+++ b/docs/desktop-poc.html
@@ -536,19 +536,14 @@ const SystemRegistry = {
 };
 
 /* ---------- Connection check via /zosmf/info ---------- */
-async function checkSystem(sys, auth) {
-  // auth: optional {user, pass} to verify credentials
+async function checkSystem(sys) {
+  // Anonymous reachability probe for the login-screen LED. Credentials are
+  // verified separately by authenticate() (the token login), so this stays a
+  // header-less "simple request" that avoids a CORS preflight.
   const ctl = new AbortController();
   const timer = setTimeout(() => ctl.abort(), 4000);
   try {
-    // Anonymous probe stays a "simple request" (no custom headers) so it
-    // avoids a CORS preflight; authenticated checks send the full headers.
-    const headers = {};
-    if (auth) {
-      headers["Authorization"] = "Basic " + btoa(auth.user + ":" + auth.pass);
-      headers["X-CSRF-ZOSMF-HEADER"] = "true";
-    }
-    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { headers, signal: ctl.signal });
+    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { signal: ctl.signal });
     clearTimeout(timer);
     if (resp.ok) {
       let info = null;
@@ -574,12 +569,104 @@ async function checkSystem(sys, auth) {
   }
 }
 
-/* ---------- Session (current login) ---------- */
+/* ---------- Token login via /zosmf/services/authenticate ----------
+   POST the Basic credentials ONCE; on success the server returns
+   Set-Cookie: LtpaToken2=<token>. For a same-origin deployment (the SPA
+   served from the HTTPD) the browser stores that cookie and replays it on
+   every later request automatically — we never touch the raw password again
+   and never read the token (JS cannot read Set-Cookie / set a Cookie header). */
+async function authenticate(sys, { user, pass }) {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 8000);
+  try {
+    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/services/authenticate", {
+      method: "POST",
+      credentials: "same-origin",   // let the browser keep the LtpaToken2 cookie
+      headers: {
+        "Authorization": "Basic " + btoa(user + ":" + pass),
+        "X-CSRF-ZOSMF-HEADER": "true"
+      },
+      signal: ctl.signal
+    });
+    clearTimeout(timer);
+    if (resp.ok) return { status: "ok" };
+    if (resp.status === 401 || resp.status === 403) return { status: "auth_failed" };
+    return { status: "error", code: resp.status };
+  } catch (e) {
+    clearTimeout(timer);
+    // fetch rejected: host down, or a cross-origin login blocked by CORS
+    // (the token flow is same-origin only — cross-origin is "CORS pending").
+    return { status: "unreachable" };
+  }
+}
+
+/* Is the LtpaToken2 session cookie present? (Set without HttpOnly, so it is
+   readable same-origin.) We only need its presence to decide whether to
+   restore a session on boot — the value stays opaque and browser-managed. */
+function hasSessionCookie() {
+  return typeof document !== "undefined" &&
+    /(?:^|;\s*)LtpaToken2=/.test(document.cookie || "");
+}
+
+/* ---------- Session (current login) ----------
+   Holds NO password and NO token — only the non-secret identity (user +
+   system) plus the demo flag. The credential lives entirely in the browser's
+   LtpaToken2 cookie, so the session survives a page reload and a real logout
+   is a server-side DELETE, not just dropping JS state. */
 const Session = {
+  KEY: "mvsmf.session",
   system: null,     // system object from registry
   user: null,
-  pass: null,
   demo: false,
+
+  /* Persist the non-secret identity so a reload can restore it. */
+  save() {
+    SafeStore.set(this.KEY, {
+      systemName: this.system ? this.system.name : null,
+      user: this.user,
+      demo: !!this.demo
+    });
+  },
+  clearStored() { SafeStore.set(this.KEY, null); },
+
+  /* Restore a session after a reload. Real systems require the LtpaToken2
+     cookie to still be present (else the server has no session to talk to);
+     demo needs no backend. Returns true when a session was restored. */
+  restore() {
+    const saved = SafeStore.get(this.KEY, null);
+    if (!saved) return false;
+    if (saved.demo) {
+      this.demo = true;
+      this.user = saved.user || "DEMO";
+      this.system = null;
+      return true;
+    }
+    const sys = saved.systemName ? SystemRegistry.get(saved.systemName) : null;
+    if (!sys || !hasSessionCookie()) { this.clearStored(); return false; }
+    this.system = sys;
+    this.user = saved.user;
+    this.demo = false;
+    return true;
+  },
+
+  /* Real server-side logout: DELETE the token (best-effort — the cookie is a
+     session cookie and dies on browser close regardless), then drop JS state. */
+  async logout() {
+    if (!this.demo && this.system) {
+      try {
+        await fetch(SystemRegistry.baseUrl(this.system) + "/zosmf/services/authenticate", {
+          method: "DELETE",
+          credentials: "same-origin",
+          headers: { "X-CSRF-ZOSMF-HEADER": "true" }
+        });
+      } catch (e) { /* offline logout is fine; the cookie still expires */ }
+    }
+    this.clearStored();
+    this.system = null;
+    this.user = null;
+    this.demo = false;
+  },
+
   /* Build a system context handed to every program window. */
   contextFor(systemName) {
     const sys = systemName ? SystemRegistry.get(systemName) : this.system;
@@ -593,11 +680,18 @@ const Session = {
       demo: self.demo,
       async apiFetch(path, options = {}) {
         if (self.demo) throw new Error("demo mode: no backend");
+        // No Authorization header: the browser attaches the LtpaToken2 cookie
+        // (same-origin). A 401 means the token expired or was reaped — signal
+        // the shell to return to the login screen (handled in Login).
+        options.credentials = options.credentials || "same-origin";
         options.headers = Object.assign({
-          "Authorization": "Basic " + btoa(self.user + ":" + self.pass),
           "X-CSRF-ZOSMF-HEADER": "true"
         }, options.headers || {});
-        return fetch(this.baseUrl + path, options);
+        const resp = await fetch(this.baseUrl + path, options);
+        if (resp.status === 401 && typeof window !== "undefined") {
+          window.dispatchEvent(new CustomEvent("mvsmf:session-expired"));
+        }
+        return resp;
       }
     };
   }
@@ -1308,30 +1402,32 @@ const Login = (() => {
     if (!user) { setStatus("warn", "var(--wps-led-yellow)", "Enter a username"); return; }
 
     setStatus("wait", "#999", "Authenticating …");
-    const res = await checkSystem(sys, { user, pass });
-    if (res.status === "connected") {
+    // POST the credentials once to /zosmf/services/authenticate; on success the
+    // browser holds the LtpaToken2 cookie and the password is never stored.
+    const res = await authenticate(sys, { user, pass });
+    if (res.status === "ok") {
       Session.system = sys;
       Session.user = user.toUpperCase();
-      Session.pass = pass;
       Session.demo = false;
+      Session.save();
       const d = SystemRegistry.load();
       d.defaultSystem = sys.name;
       SystemRegistry.save(d);
       enterDesktop();
     } else if (res.status === "auth_failed") {
       setStatus("bad", "var(--wps-led-red)", "Login failed — check credentials");
-    } else if (res.status === "cors_blocked") {
-      setStatus("warn", "var(--wps-led-yellow)", "Blocked by CORS — serve this page from the HTTPD or use demo mode");
     } else {
-      setStatus("bad", "var(--wps-led-red)", "System unreachable");
+      // fetch rejected — host unreachable, or a cross-origin login blocked by
+      // CORS (the token flow is same-origin: serve the SPA from the HTTPD).
+      setStatus("bad", "var(--wps-led-red)", "System unreachable (serve the SPA from the HTTPD, or use demo mode)");
     }
   }
 
   function demoLogin() {
     Session.system = null;
     Session.user = "DEMO";
-    Session.pass = "";
     Session.demo = true;
+    Session.save();
     enterDesktop();
   }
 
@@ -1347,14 +1443,29 @@ const Login = (() => {
     WM.open(Programs.get("welcome"));
   }
 
-  function logout() {
-    // close everything by reloading state — simplest clean slate
+  async function logout() {
+    // real server-side logout (DELETE the token), then reload for a clean slate
+    await Session.logout();
+    location.reload();
+  }
+
+  // A 401 from any API call means the token expired or was reaped by the HTTPD
+  // (idle SESSION_TIMEOUT, default 30 min). Drop the stored session so the
+  // reload boots to the login screen — not straight back into a dead desktop —
+  // and leave a one-shot notice to explain why. The guard collapses the burst
+  // of 401s that concurrent requests produce into a single teardown.
+  let tearingDown = false;
+  function onSessionExpired() {
+    if (tearingDown) return;
+    tearingDown = true;
+    Session.clearStored();
+    SafeStore.set("mvsmf.notice", "Session expired — please log in again");
     location.reload();
   }
 
   function init() {
     refreshSystems();
-    checkSelected();
+    window.addEventListener("mvsmf:session-expired", onSessionExpired);
     sel().addEventListener("change", checkSelected);
     document.getElementById("login-submit").addEventListener("click", submit);
     document.getElementById("login-pass").addEventListener("keydown", e => { if (e.key === "Enter") submit(); });
@@ -1376,6 +1487,17 @@ const Login = (() => {
       refreshSystems();
       checkSelected();
     });
+
+    // A prior session-expiry (or logout) may have left a one-shot notice.
+    const notice = SafeStore.get("mvsmf.notice", null);
+    if (notice) SafeStore.set("mvsmf.notice", null);
+
+    // Restore a live session across a reload: the LtpaToken2 cookie survives,
+    // so a valid session skips the login screen entirely.
+    if (Session.restore()) { enterDesktop(); return; }
+
+    if (notice) setStatus("warn", "var(--wps-led-yellow)", notice);
+    else checkSelected();
   }
 
   return { init, refreshSystems, logout };

--- a/docs/desktop-poc.html
+++ b/docs/desktop-poc.html
@@ -385,7 +385,7 @@ html, body {
       </div>
       <div id="login-status" class="wait">
         <span class="led" style="background:#999;"></span>
-        <span id="login-status-text">Checking connection…</span>
+        <span id="login-status-text">Ready</span>
       </div>
       <div class="lb-field">
         <label for="login-user">Username</label>
@@ -400,7 +400,6 @@ html, body {
         <button class="lb-btn primary" id="login-submit">Login</button>
       </div>
       <div class="lb-links">
-        <span class="lb-link" id="login-manage">Manage systems…</span>
         <span class="lb-link" id="login-demo">Demo mode</span>
       </div>
     </div>
@@ -1354,7 +1353,6 @@ const StartMenu = (() => {
 const Login = (() => {
   const layer = () => document.getElementById("login-layer");
   const sel = () => document.getElementById("login-system");
-  let checkSeq = 0;
 
   function refreshSystems() {
     const s = sel();
@@ -1377,23 +1375,11 @@ const Login = (() => {
     document.getElementById("login-status-text").textContent = text;
   }
 
-  async function checkSelected() {
-    const mySeq = ++checkSeq;
+  /* Neutral idle status — no live probe; just name the login target. */
+  function idleStatus() {
     const sys = SystemRegistry.get(sel().value);
-    if (!sys) { setStatus("warn", "var(--wps-led-yellow)", "No systems configured — use Manage systems…"); return; }
-    setStatus("wait", "#999", `Checking ${sys.name} …`);
-    const res = await checkSystem(sys);
-    if (mySeq !== checkSeq) return;   // stale response, selection changed
-    if (res.status === "connected") {
-      const ver = res.info && (res.info.zos_version || res.info.zosmf_full_version);
-      setStatus("ok", "var(--wps-led-green)", `Connected${ver ? " — " + ver : ""}`);
-    } else if (res.status === "auth_failed") {
-      setStatus("warn", "var(--wps-led-yellow)", "Reachable — authentication required");
-    } else if (res.status === "cors_blocked") {
-      setStatus("warn", "var(--wps-led-yellow)", "Reachable — response blocked by CORS (serve this page from the HTTPD)");
-    } else {
-      setStatus("bad", "var(--wps-led-red)", "Unreachable — check host and port");
-    }
+    setStatus("wait", "#999",
+      sys ? `Ready — sign in to ${sys.name}` : "No system — use Demo mode");
   }
 
   async function submit() {
@@ -1419,9 +1405,12 @@ const Login = (() => {
     } else if (res.status === "auth_failed") {
       setStatus("bad", "var(--wps-led-red)", "Login failed — check credentials");
     } else {
-      // fetch rejected — host unreachable, or a cross-origin login blocked by
-      // CORS (the token flow is same-origin: serve the SPA from the HTTPD).
-      setStatus("bad", "var(--wps-led-red)", "System unreachable (serve the SPA from the HTTPD, or use demo mode)");
+      // fetch rejected. The local system is this page's origin, so this means
+      // the server is down; a remote system fails the cross-origin login (CORS
+      // is not supported yet) — report whichever applies.
+      setStatus("bad", "var(--wps-led-red)", sys.local
+        ? "System unreachable — is the server up?"
+        : "Remote systems are not supported yet (CORS) — use the local system or Demo mode");
     }
   }
 
@@ -1468,7 +1457,7 @@ const Login = (() => {
   function init() {
     refreshSystems();
     window.addEventListener("mvsmf:session-expired", onSessionExpired);
-    sel().addEventListener("change", checkSelected);
+    sel().addEventListener("change", idleStatus);
     document.getElementById("login-submit").addEventListener("click", submit);
     document.getElementById("login-pass").addEventListener("keydown", e => { if (e.key === "Enter") submit(); });
     document.getElementById("login-user").addEventListener("keydown", e => { if (e.key === "Enter") document.getElementById("login-pass").focus(); });
@@ -1477,18 +1466,6 @@ const Login = (() => {
       document.getElementById("login-pass").value = "";
     });
     document.getElementById("login-demo").addEventListener("click", demoLogin);
-    document.getElementById("login-manage").addEventListener("click", () => {
-      // Phase 1: quick inline prompt-based add; the Systems program
-      // offers full management once logged in.
-      const name = prompt("System name (e.g. MVSD):");
-      if (!name) return;
-      const host = prompt("Host or IP:");
-      if (!host) return;
-      const port = parseInt(prompt("Port:", "1080") || "1080", 10);
-      SystemRegistry.add({ name: name.toUpperCase(), host, port });
-      refreshSystems();
-      checkSelected();
-    });
 
     // A prior session-expiry (or logout) may have left a one-shot notice.
     const notice = SafeStore.get("mvsmf.notice", null);
@@ -1502,7 +1479,7 @@ const Login = (() => {
     // the markup so a restored session never flashes it first).
     layer().style.display = "flex";
     if (notice) setStatus("warn", "var(--wps-led-yellow)", notice);
-    else checkSelected();
+    else idleStatus();
   }
 
   return { init, refreshSystems, logout };

--- a/docs/desktop-poc.html
+++ b/docs/desktop-poc.html
@@ -363,7 +363,9 @@ html, body {
 <body>
 
 <!-- ================= Login layer ================= -->
-<div id="login-layer">
+<!-- Hidden until boot decides: a restored session goes straight to the
+     desktop, so the login screen must not flash first. Login.init reveals it. -->
+<div id="login-layer" style="display:none;">
   <div id="login-box">
     <div class="lb-title">
       <div class="ticon"><i class="ti ti-lock"></i></div>
@@ -1496,6 +1498,9 @@ const Login = (() => {
     // so a valid session skips the login screen entirely.
     if (Session.restore()) { enterDesktop(); return; }
 
+    // No session to restore — reveal the login screen (hidden by default in
+    // the markup so a restored session never flashes it first).
+    layer().style.display = "flex";
     if (notice) setStatus("warn", "var(--wps-led-yellow)", notice);
     else checkSelected();
   }

--- a/docs/desktop-spec.md
+++ b/docs/desktop-spec.md
@@ -206,9 +206,12 @@ Programs.register({
 });
 ```
 
-`apiFetch()` injects `Authorization: Basic` and `X-CSRF-ZOSMF-HEADER`
-and prefixes `baseUrl`. In demo mode it throws — programs provide canned
-data instead (see sysinfo).
+`apiFetch()` prefixes `baseUrl` and sends `X-CSRF-ZOSMF-HEADER` with
+`credentials: same-origin`; authentication rides on the browser's
+`LtpaToken2` session cookie — no `Authorization` header, no password in JS.
+A `401` dispatches a `mvsmf:session-expired` window event (the shell then
+returns to the login screen). In demo mode it throws — programs provide
+canned data instead (see sysinfo).
 
 ## Systems & login
 
@@ -225,21 +228,37 @@ duplicated. The local system is the default, shown as `(local)`, and
 cannot be removed. `baseUrl()` follows the page protocol for the local
 system (TLS-proxy safe), plain `http:` for remotes.
 
-### Connection check — checkSystem(sys, auth?)
-`GET {base}/zosmf/info`, 4s timeout via AbortController.
+### Connection check — checkSystem(sys)
+Anonymous LED probe only. `GET {base}/zosmf/info`, 4s timeout via AbortController.
 - 200 → `connected` (+parsed info)
-- 401/403 → `auth_failed` — **counts as reachable** (yellow LED); works
-  today while `/zosmf/info` still requires auth (TSK-282 will open it up)
+- 401/403 → `auth_failed` — **counts as reachable** (yellow LED)
 - fetch TypeError → retry with `mode: "no-cors"`: resolves → `cors_blocked`
   (yellow, "serve this page from the HTTPD"), rejects → `unreachable` (red)
-- Anonymous probe sends NO custom headers (CORS simple request, no
-  preflight); authenticated check sends Authorization + CSRF header
+- Sends NO custom headers (CORS simple request, no preflight)
+
+### Token login — authenticate(sys, {user, pass})
+`POST {base}/zosmf/services/authenticate` **once** with `Authorization: Basic`
++ `X-CSRF-ZOSMF-HEADER`, `credentials: same-origin`. On `200` the server sets
+`LtpaToken2` (a session cookie); the browser replays it on every later call, so
+the password is never stored. `401/403` → `auth_failed`; a fetch reject →
+`unreachable` (a cross-origin login blocked by CORS — the token flow is
+same-origin, i.e. the SPA must be served from the HTTPD).
 
 ### Login flow
-System select → live check → username/password → authenticated
-`/zosmf/info` → success stores session (system becomes `defaultSystem`),
-enter desktop, open Welcome. Demo mode link enters the desktop without a
-backend (`Session.demo`, canned data). Logout = clean reload.
+System select → live check → username/password → `authenticate()` → success
+stores the **non-secret** session (`user` + system name + demo flag in
+`SafeStore`, no password/token; system becomes `defaultSystem`), enter desktop,
+open Welcome. Demo mode link enters the desktop without a backend
+(`Session.demo`, canned data).
+
+### Session persistence & logout
+The `LtpaToken2` cookie survives a page reload, so on boot `Session.restore()`
+re-enters the desktop directly when the cookie (and stored identity) are still
+present — no re-login. A `401` from any API call (token expired or reaped by
+the HTTPD idle `SESSION_TIMEOUT`, default 30 min) clears the stored session and
+reloads to the login screen with a "Session expired" notice. Logout is a real
+server-side `DELETE {base}/zosmf/services/authenticate` (invalidates the token)
+followed by a clean reload.
 
 ## Phase 1 acceptance
 

--- a/docs/desktop-spec.md
+++ b/docs/desktop-spec.md
@@ -140,9 +140,9 @@ outside click.
 
 ### Login screen
 Fullscreen desktop background, centered OS/2 dialog. System dropdown
-(`NAME — host:port (local)`), live connection status bar, username,
-password, Cancel/Login, "Manage systems…" and "Demo mode" links,
-version string bottom-right.
+(`NAME — host:port (local)`), idle status bar (no pre-login probe),
+username, password, Cancel/Login, "Demo mode" link, version string
+bottom-right. Systems are managed post-login (Systems program), not here.
 
 ### Program icon colors
 | Program          | iconBg    | icon (Tabler)   | iconColor |
@@ -229,27 +229,29 @@ cannot be removed. `baseUrl()` follows the page protocol for the local
 system (TLS-proxy safe), plain `http:` for remotes.
 
 ### Connection check — checkSystem(sys)
-Anonymous LED probe only. `GET {base}/zosmf/info`, 4s timeout via AbortController.
-- 200 → `connected` (+parsed info)
-- 401/403 → `auth_failed` — **counts as reachable** (yellow LED)
-- fetch TypeError → retry with `mode: "no-cors"`: resolves → `cors_blocked`
-  (yellow, "serve this page from the HTTPD"), rejects → `unreachable` (red)
-- Sends NO custom headers (CORS simple request, no preflight)
+Anonymous reachability probe (`GET {base}/zosmf/info`, 4s timeout;
+`connected`/`auth_failed`/`cors_blocked`/`unreachable`). **Not used by the
+login screen** — only by the post-login Systems program and the start-menu
+tray LEDs. The login screen does no pre-login probe: an anonymous `GET` would
+hit the HTTPD's `WWW-Authenticate: Basic` 401 and pop the browser's native
+credential dialog (see mvslovers/httpd#119).
 
 ### Token login — authenticate(sys, {user, pass})
 `POST {base}/zosmf/services/authenticate` **once** with `Authorization: Basic`
 + `X-CSRF-ZOSMF-HEADER`, `credentials: same-origin`. On `200` the server sets
 `LtpaToken2` (a session cookie); the browser replays it on every later call, so
 the password is never stored. `401/403` → `auth_failed`; a fetch reject →
-`unreachable` (a cross-origin login blocked by CORS — the token flow is
-same-origin, i.e. the SPA must be served from the HTTPD).
+`unreachable` (local system down) or, for a remote system, the cross-origin
+login blocked by CORS (not supported yet — the token flow is same-origin, i.e.
+the SPA served from the HTTPD).
 
 ### Login flow
-System select → live check → username/password → `authenticate()` → success
-stores the **non-secret** session (`user` + system name + demo flag in
-`SafeStore`, no password/token; system becomes `defaultSystem`), enter desktop,
-open Welcome. Demo mode link enters the desktop without a backend
-(`Session.demo`, canned data).
+System select → username/password → `authenticate()` → success stores the
+**non-secret** session (`user` + system name + demo flag in `SafeStore`, no
+password/token; system becomes `defaultSystem`), enter desktop, open Welcome.
+No pre-login reachability probe (the local system is this page's origin, so it
+is online by definition; a failed login just reports the error). Demo mode link
+enters the desktop without a backend (`Session.demo`, canned data).
 
 ### Session persistence & logout
 The `LtpaToken2` cookie survives a page reload, so on boot `Session.restore()`

--- a/static/index.html
+++ b/static/index.html
@@ -11,7 +11,9 @@
 <body>
 
 <!-- ================= Login layer ================= -->
-<div id="login-layer">
+<!-- Hidden until boot decides: a restored session goes straight to the
+     desktop, so the login screen must not flash first. login.js reveals it. -->
+<div id="login-layer" style="display:none;">
   <div id="login-box">
     <div class="lb-title">
       <div class="ticon"><i class="ti ti-lock"></i></div>

--- a/static/index.html
+++ b/static/index.html
@@ -33,7 +33,7 @@
       </div>
       <div id="login-status" class="wait">
         <span class="led" style="background:var(--wps-led-off);"></span>
-        <span id="login-status-text">Checking connection…</span>
+        <span id="login-status-text">Ready</span>
       </div>
       <div class="lb-field">
         <label for="login-user">Username</label>
@@ -48,7 +48,6 @@
         <button class="lb-btn primary" id="login-submit">Login</button>
       </div>
       <div class="lb-links">
-        <span class="lb-link" id="login-manage">Manage systems…</span>
         <span class="lb-link" id="login-demo">Demo mode</span>
       </div>
     </div>

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,11 +1,14 @@
 /* ============================================================
    login.js — login screen + auth flow
    System selector, live /zosmf/info connection check (401 = still
-   reachable, no-cors fallback), authenticated login, demo mode,
-   inline "Manage systems…" add, logout. On success it enters the
-   desktop and opens the Welcome window.
+   reachable, no-cors fallback), token login (POST once to
+   /zosmf/services/authenticate — the password is never stored),
+   demo mode, inline "Manage systems…" add, real server-side logout.
+   On success it enters the desktop and opens the Welcome window.
+   A live session (LtpaToken2 cookie) is restored across a reload;
+   a 401 from any API call returns to the login screen.
    ============================================================ */
-import { Session, SystemRegistry, checkSystem } from "./systems.js";
+import { Session, SystemRegistry, checkSystem, authenticate, SafeStore } from "./systems.js";
 import { WM } from "./wm.js";
 import { Programs } from "./programs/registry.js";
 import { Dialog } from "./dialog.js";
@@ -68,31 +71,32 @@ export const Login = (() => {
     if (!user) { setStatus("warn", "var(--wps-led-yellow)", "Enter a username"); return; }
 
     setStatus("wait", "var(--wps-led-off)", "Authenticating …");
-    const res = await checkSystem(sys, { user, pass });
-    if (res.status === "connected") {
+    // POST the credentials once to /zosmf/services/authenticate; on success the
+    // browser holds the LtpaToken2 cookie and the password is never stored.
+    const res = await authenticate(sys, { user, pass });
+    if (res.status === "ok") {
       Session.system = sys;
       Session.user = user.toUpperCase();
-      Session.pass = pass;
       Session.demo = false;
+      Session.save();
       const d = SystemRegistry.load();
       d.defaultSystem = sys.name;
       SystemRegistry.save(d);
       enterDesktop();
     } else if (res.status === "auth_failed") {
       setStatus("bad", "var(--wps-led-red)", "Login failed — check credentials");
-    } else if (res.status === "cors_blocked") {
-      // reachable, but cross-origin blocks reading the auth response
-      setStatus("ok", "var(--wps-led-green)", "Connected — cross-origin (CORS pending); serve from the HTTPD or use demo mode");
     } else {
-      setStatus("bad", "var(--wps-led-red)", "System unreachable");
+      // fetch rejected — host unreachable, or a cross-origin login blocked by
+      // CORS (the token flow is same-origin: serve the SPA from the HTTPD).
+      setStatus("bad", "var(--wps-led-red)", "System unreachable (serve the SPA from the HTTPD, or use demo mode)");
     }
   }
 
   function demoLogin() {
     Session.system = null;
     Session.user = "DEMO";
-    Session.pass = "";
     Session.demo = true;
+    Session.save();
     enterDesktop();
   }
 
@@ -108,14 +112,29 @@ export const Login = (() => {
     WM.open(Programs.get("welcome"));
   }
 
-  function logout() {
-    // close everything by reloading state — simplest clean slate
+  async function logout() {
+    // real server-side logout (DELETE the token), then reload for a clean slate
+    await Session.logout();
+    location.reload();
+  }
+
+  // A 401 from any API call means the token expired or was reaped by the HTTPD
+  // (idle SESSION_TIMEOUT, default 30 min). Drop the stored session so the
+  // reload boots to the login screen — not straight back into a dead desktop —
+  // and leave a one-shot notice to explain why. The guard collapses the burst
+  // of 401s that concurrent requests produce into a single teardown.
+  let tearingDown = false;
+  function onSessionExpired() {
+    if (tearingDown) return;
+    tearingDown = true;
+    Session.clearStored();
+    SafeStore.set("mvsmf.notice", "Session expired — please log in again");
     location.reload();
   }
 
   function init() {
     refreshSystems();
-    checkSelected();
+    window.addEventListener("mvsmf:session-expired", onSessionExpired);
     sel().addEventListener("change", checkSelected);
     document.getElementById("login-submit").addEventListener("click", submit);
     document.getElementById("login-pass").addEventListener("keydown", e => { if (e.key === "Enter") submit(); });
@@ -141,6 +160,17 @@ export const Login = (() => {
       refreshSystems();
       checkSelected();
     });
+
+    // A prior session-expiry (or logout) may have left a one-shot notice.
+    const notice = SafeStore.get("mvsmf.notice", null);
+    if (notice) SafeStore.set("mvsmf.notice", null);
+
+    // Restore a live session across a reload: the LtpaToken2 cookie survives,
+    // so a valid session skips the login screen entirely.
+    if (Session.restore()) { enterDesktop(); return; }
+
+    if (notice) setStatus("warn", "var(--wps-led-yellow)", notice);
+    else checkSelected();
   }
 
   return { init, refreshSystems, logout };

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -169,6 +169,9 @@ export const Login = (() => {
     // so a valid session skips the login screen entirely.
     if (Session.restore()) { enterDesktop(); return; }
 
+    // No session to restore — reveal the login screen (hidden by default in
+    // the markup so a restored session never flashes it first).
+    layer().style.display = "flex";
     if (notice) setStatus("warn", "var(--wps-led-yellow)", notice);
     else checkSelected();
   }

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,22 +1,23 @@
 /* ============================================================
    login.js — login screen + auth flow
-   System selector, live /zosmf/info connection check (401 = still
-   reachable, no-cors fallback), token login (POST once to
+   System selector, token login (POST once to
    /zosmf/services/authenticate — the password is never stored),
-   demo mode, inline "Manage systems…" add, real server-side logout.
-   On success it enters the desktop and opens the Welcome window.
-   A live session (LtpaToken2 cookie) is restored across a reload;
-   a 401 from any API call returns to the login screen.
+   demo mode, real server-side logout. On success it enters the
+   desktop and opens the Welcome window. A live session (LtpaToken2
+   cookie) is restored across a reload; a 401 from any API call
+   returns to the login screen.
+
+   No pre-login reachability probe: the local system IS this page's
+   origin (so it is online by definition), and remote systems don't
+   work yet (CORS) — a failed login just reports the error.
    ============================================================ */
-import { Session, SystemRegistry, checkSystem, authenticate, SafeStore } from "./systems.js";
+import { Session, SystemRegistry, authenticate, SafeStore } from "./systems.js";
 import { WM } from "./wm.js";
 import { Programs } from "./programs/registry.js";
-import { Dialog } from "./dialog.js";
 
 export const Login = (() => {
   const layer = () => document.getElementById("login-layer");
   const sel = () => document.getElementById("login-system");
-  let checkSeq = 0;
 
   function refreshSystems() {
     const s = sel();
@@ -39,28 +40,11 @@ export const Login = (() => {
     document.getElementById("login-status-text").textContent = text;
   }
 
-  async function checkSelected() {
-    const mySeq = ++checkSeq;
+  /* Neutral idle status — no live probe; just name the login target. */
+  function idleStatus() {
     const sys = SystemRegistry.get(sel().value);
-    if (!sys) { setStatus("warn", "var(--wps-led-yellow)", "No systems configured — use Manage systems…"); return; }
-    setStatus("wait", "var(--wps-led-off)", `Checking ${sys.name} …`);
-    const res = await checkSystem(sys);
-    if (mySeq !== checkSeq) return;   // stale response, selection changed
-    // Green whenever the endpoint is reachable at all; only "unreachable"
-    // is red. The distinct texts keep the detail the LED no longer encodes.
-    if (res.status === "connected") {
-      const ver = res.info && (res.info.zos_version || res.info.zosmf_full_version);
-      setStatus("ok", "var(--wps-led-green)", `Connected${ver ? " — " + ver : ""}`);
-    } else if (res.status === "auth_failed") {
-      setStatus("ok", "var(--wps-led-green)", "Connected — login required");
-    } else if (res.status === "cors_blocked") {
-      setStatus("ok", "var(--wps-led-green)", "Connected — cross-origin (CORS pending)");
-    } else if (res.status === "unreachable") {
-      setStatus("bad", "var(--wps-led-red)", "Unreachable — check host and port");
-    } else {
-      // reachable, but /zosmf/info returned an unexpected HTTP status
-      setStatus("ok", "var(--wps-led-green)", `Reachable — HTTP ${res.code || "?"}`);
-    }
+    setStatus("wait", "var(--wps-led-off)",
+      sys ? `Ready — sign in to ${sys.name}` : "No system — use Demo mode");
   }
 
   async function submit() {
@@ -86,9 +70,12 @@ export const Login = (() => {
     } else if (res.status === "auth_failed") {
       setStatus("bad", "var(--wps-led-red)", "Login failed — check credentials");
     } else {
-      // fetch rejected — host unreachable, or a cross-origin login blocked by
-      // CORS (the token flow is same-origin: serve the SPA from the HTTPD).
-      setStatus("bad", "var(--wps-led-red)", "System unreachable (serve the SPA from the HTTPD, or use demo mode)");
+      // fetch rejected. The local system is this page's origin, so this means
+      // the server is down; a remote system fails the cross-origin login (CORS
+      // is not supported yet) — report whichever applies.
+      setStatus("bad", "var(--wps-led-red)", sys.local
+        ? "System unreachable — is the server up?"
+        : "Remote systems are not supported yet (CORS) — use the local system or Demo mode");
     }
   }
 
@@ -135,7 +122,7 @@ export const Login = (() => {
   function init() {
     refreshSystems();
     window.addEventListener("mvsmf:session-expired", onSessionExpired);
-    sel().addEventListener("change", checkSelected);
+    sel().addEventListener("change", idleStatus);
     document.getElementById("login-submit").addEventListener("click", submit);
     document.getElementById("login-pass").addEventListener("keydown", e => { if (e.key === "Enter") submit(); });
     document.getElementById("login-user").addEventListener("keydown", e => { if (e.key === "Enter") document.getElementById("login-pass").focus(); });
@@ -144,22 +131,6 @@ export const Login = (() => {
       document.getElementById("login-pass").value = "";
     });
     document.getElementById("login-demo").addEventListener("click", demoLogin);
-    document.getElementById("login-manage").addEventListener("click", async () => {
-      // quick add from the login screen; the Systems program offers
-      // full management once logged in
-      const r = await Dialog.show({
-        title: "Add system", icon: "ti-server", okLabel: "Add",
-        fields: [
-          { key: "name", label: "System name", maxLength: 8, upper: true, placeholder: "MVSD" },
-          { key: "host", label: "Host or IP", placeholder: "mvs.example.lan" },
-          { key: "port", label: "Port", value: "1080", maxLength: 5 }
-        ]
-      });
-      if (!r || !r.name || !r.host) return;
-      SystemRegistry.add({ name: r.name, host: r.host, port: parseInt(r.port || "1080", 10) });
-      refreshSystems();
-      checkSelected();
-    });
 
     // A prior session-expiry (or logout) may have left a one-shot notice.
     const notice = SafeStore.get("mvsmf.notice", null);
@@ -173,7 +144,7 @@ export const Login = (() => {
     // the markup so a restored session never flashes it first).
     layer().style.display = "flex";
     if (notice) setStatus("warn", "var(--wps-led-yellow)", notice);
-    else checkSelected();
+    else idleStatus();
   }
 
   return { init, refreshSystems, logout };

--- a/static/js/programs/_template.js
+++ b/static/js/programs/_template.js
@@ -44,8 +44,10 @@ Programs.register({
        setStatus(t),                   // write to the status bar (if statusBar)
        close()                         // close this window
      }
-     system.apiFetch() injects Authorization: Basic + X-CSRF-ZOSMF-HEADER
-     and prefixes baseUrl. In demo mode it throws — provide canned data. */
+     system.apiFetch() prefixes baseUrl and sends X-CSRF-ZOSMF-HEADER; auth
+     rides on the browser's LtpaToken2 session cookie (no password in JS). A
+     401 signals session-expiry to the shell. In demo mode it throws —
+     provide canned data. */
   create(ctx) {
     const el = document.createElement("div");
     el.className = "prog-pad";

--- a/static/js/systems.js
+++ b/static/js/systems.js
@@ -97,19 +97,14 @@ export const SystemRegistry = {
 };
 
 /* ---------- Connection check via /zosmf/info ---------- */
-export async function checkSystem(sys, auth) {
-  // auth: optional {user, pass} to verify credentials
+export async function checkSystem(sys) {
+  // Anonymous reachability probe for the login-screen LED. Credentials are
+  // verified separately by authenticate() (the token login), so this stays a
+  // header-less "simple request" that avoids a CORS preflight.
   const ctl = new AbortController();
   const timer = setTimeout(() => ctl.abort(), 4000);
   try {
-    // Anonymous probe stays a "simple request" (no custom headers) so it
-    // avoids a CORS preflight; authenticated checks send the full headers.
-    const headers = {};
-    if (auth) {
-      headers["Authorization"] = "Basic " + btoa(auth.user + ":" + auth.pass);
-      headers["X-CSRF-ZOSMF-HEADER"] = "true";
-    }
-    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { headers, signal: ctl.signal });
+    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/info", { signal: ctl.signal });
     clearTimeout(timer);
     if (resp.ok) {
       let info = null;
@@ -135,12 +130,104 @@ export async function checkSystem(sys, auth) {
   }
 }
 
-/* ---------- Session (current login) ---------- */
+/* ---------- Token login via /zosmf/services/authenticate ----------
+   POST the Basic credentials ONCE; on success the server returns
+   Set-Cookie: LtpaToken2=<token>. For a same-origin deployment (the SPA
+   served from the HTTPD) the browser stores that cookie and replays it on
+   every later request automatically — we never touch the raw password again
+   and never read the token (JS cannot read Set-Cookie / set a Cookie header). */
+export async function authenticate(sys, { user, pass }) {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 8000);
+  try {
+    const resp = await fetch(SystemRegistry.baseUrl(sys) + "/zosmf/services/authenticate", {
+      method: "POST",
+      credentials: "same-origin",   // let the browser keep the LtpaToken2 cookie
+      headers: {
+        "Authorization": "Basic " + btoa(user + ":" + pass),
+        "X-CSRF-ZOSMF-HEADER": "true"
+      },
+      signal: ctl.signal
+    });
+    clearTimeout(timer);
+    if (resp.ok) return { status: "ok" };
+    if (resp.status === 401 || resp.status === 403) return { status: "auth_failed" };
+    return { status: "error", code: resp.status };
+  } catch (e) {
+    clearTimeout(timer);
+    // fetch rejected: host down, or a cross-origin login blocked by CORS
+    // (the token flow is same-origin only — cross-origin is "CORS pending").
+    return { status: "unreachable" };
+  }
+}
+
+/* Is the LtpaToken2 session cookie present? (Set without HttpOnly, so it is
+   readable same-origin.) We only need its presence to decide whether to
+   restore a session on boot — the value stays opaque and browser-managed. */
+function hasSessionCookie() {
+  return typeof document !== "undefined" &&
+    /(?:^|;\s*)LtpaToken2=/.test(document.cookie || "");
+}
+
+/* ---------- Session (current login) ----------
+   Holds NO password and NO token — only the non-secret identity (user +
+   system) plus the demo flag. The credential lives entirely in the browser's
+   LtpaToken2 cookie, so the session survives a page reload and a real logout
+   is a server-side DELETE, not just dropping JS state. */
 export const Session = {
+  KEY: "mvsmf.session",
   system: null,     // system object from registry
   user: null,
-  pass: null,
   demo: false,
+
+  /* Persist the non-secret identity so a reload can restore it. */
+  save() {
+    SafeStore.set(this.KEY, {
+      systemName: this.system ? this.system.name : null,
+      user: this.user,
+      demo: !!this.demo
+    });
+  },
+  clearStored() { SafeStore.set(this.KEY, null); },
+
+  /* Restore a session after a reload. Real systems require the LtpaToken2
+     cookie to still be present (else the server has no session to talk to);
+     demo needs no backend. Returns true when a session was restored. */
+  restore() {
+    const saved = SafeStore.get(this.KEY, null);
+    if (!saved) return false;
+    if (saved.demo) {
+      this.demo = true;
+      this.user = saved.user || "DEMO";
+      this.system = null;
+      return true;
+    }
+    const sys = saved.systemName ? SystemRegistry.get(saved.systemName) : null;
+    if (!sys || !hasSessionCookie()) { this.clearStored(); return false; }
+    this.system = sys;
+    this.user = saved.user;
+    this.demo = false;
+    return true;
+  },
+
+  /* Real server-side logout: DELETE the token (best-effort — the cookie is a
+     session cookie and dies on browser close regardless), then drop JS state. */
+  async logout() {
+    if (!this.demo && this.system) {
+      try {
+        await fetch(SystemRegistry.baseUrl(this.system) + "/zosmf/services/authenticate", {
+          method: "DELETE",
+          credentials: "same-origin",
+          headers: { "X-CSRF-ZOSMF-HEADER": "true" }
+        });
+      } catch (e) { /* offline logout is fine; the cookie still expires */ }
+    }
+    this.clearStored();
+    this.system = null;
+    this.user = null;
+    this.demo = false;
+  },
+
   /* Build a system context handed to every program window. */
   contextFor(systemName) {
     const sys = systemName ? SystemRegistry.get(systemName) : this.system;
@@ -154,11 +241,18 @@ export const Session = {
       demo: self.demo,
       async apiFetch(path, options = {}) {
         if (self.demo) throw new Error("demo mode: no backend");
+        // No Authorization header: the browser attaches the LtpaToken2 cookie
+        // (same-origin). A 401 means the token expired or was reaped — signal
+        // the shell to return to the login screen (handled in login.js).
+        options.credentials = options.credentials || "same-origin";
         options.headers = Object.assign({
-          "Authorization": "Basic " + btoa(self.user + ":" + self.pass),
           "X-CSRF-ZOSMF-HEADER": "true"
         }, options.headers || {});
-        return fetch(this.baseUrl + path, options);
+        const resp = await fetch(this.baseUrl + path, options);
+        if (resp.status === 401 && typeof window !== "undefined") {
+          window.dispatchEvent(new CustomEvent("mvsmf:session-expired"));
+        }
+        return resp;
       }
     };
   }


### PR DESCRIPTION
Part of the **Auth redesign** epic (§2.5, §3.3). Depends on the server-side token endpoint from #168.

Moves the mvsMF desktop SPA off "Basic-with-stored-password" onto the `LtpaToken2` token flow.

## What changed
- **Login** — `authenticate()` POSTs the credentials **once** to `POST /zosmf/services/authenticate`; on `200` the browser holds the `LtpaToken2` session cookie. `Session.pass` (raw password) is gone.
- **API layer** — `apiFetch` drops the per-call `Authorization: Basic` header and relies on the browser replaying the cookie (`credentials: same-origin`). A `401` dispatches a `mvsmf:session-expired` event → shell returns to the login screen with a one-shot notice.
- **Reload persistence** — a live session (the `LtpaToken2` cookie survives a reload) is restored via `Session.restore()`, so a valid session no longer bounces back to the login mask.
- **Timeout** — 401-driven (no client timer): a token expired/reaped by the HTTPD idle `SESSION_TIMEOUT` (default 30 min) surfaces as a `401` → "Session expired" notice.
- **Logout** — real server-side `DELETE /zosmf/services/authenticate` (invalidates the token) instead of just `location.reload()`.
- Removed the now-dead authenticated branch of `checkSystem()` (anonymous LED probe only).
- Mirrored the flow in `docs/desktop-poc.html` and refreshed `docs/desktop-spec.md` + the program template comment.

## Scope / notes
- The token flow is **same-origin** (SPA served from the HTTPD). Cross-origin login stays "CORS pending".
- **Job submission is unaffected** — the HTTPD keeps the encrypted CRED password server-side and `jobsapi` recovers it via `http_get_password()` (#167).

## Verification status
**Code-complete; not yet verified end-to-end.** `node --check` passes and no stored password / per-call Basic remains. The load-bearing assumption — this HTTPD sets `LtpaToken2` same-origin and the browser replays it — has **not** been exercised against a live system yet. Browser round-trip on :1081 (deploy `static/` via `make deploy-desktop`, then confirm cookie set → 200 not 401 → reload stays logged in → logout 204) is the follow-up before merge.

## Open coordination item (httpd)
The session-timeout **policy** (is 30 min right? sliding-only vs. a hard max-age) is a joint httpd decision, tracked separately in mvslovers/httpd — the SPA-side handling here is intentionally policy-agnostic (401-driven).

https://claude.ai/code/session_01NJh86phphS8ZLP9Ko6ziMp