### PR TITLE
Increase MAX_PORT_LENGTH to fit 5-digit ports

### DIFF
--- a/src/infoapi.c
+++ b/src/infoapi.c
@@ -5,8 +5,8 @@
 /** Maximum length of a hostname string */
 #define MAX_HOST_NAME_LENGTH 256
 
-/** Maximum length of a port string */
-#define MAX_PORT_LENGTH 5
+/** Maximum length of a port string (max port 65535 = 5 digits + nul) */
+#define MAX_PORT_LENGTH 6
 
 /** Default port if none specified */
 #define DEFAULT_PORT "8080"


### PR DESCRIPTION
## Summary

`/zosmf/info` failed to load whenever the `Host` header carried a port above 9999.

The port string buffer (`port_str` in `infoHandler`) was sized at `MAX_PORT_LENGTH = 5` — enough for 4 digits + nul (e.g. `"8080"`). In `parse_port_string()`, a 5-digit port makes `needed = strlen(port) + 1 = 6`, which exceeds `outSize = 5`, so the function returns `-2` and the handler bails out with an error.

Valid TCP ports go up to **65535** (5 digits), so the buffer needs 6 bytes (5 digits + nul). This bumps `MAX_PORT_LENGTH` from 5 to 6.

## Testing

- `make compiledb` — OK (15 entries)
- `make` — host build compiles `infoapi.c` and links `MVSMF` cleanly under `-Wall -Werror`

## Manual verification on MVS

After deploy, request `/zosmf/info` through a listener bound to a 5-digit port (e.g. `10080`) and confirm the response returns HTTP 200 with the correct `zosmf_port` value instead of failing to load.

Fixes #170