### PR TITLE
Honor server quiesce/shutdown in the console poll loops

### DIFF
--- a/docs/endpoints/console/issue-command.md
+++ b/docs/endpoints/console/issue-command.md
@@ -85,6 +85,7 @@ Console services use a `return-code`/`reason-code`/`reason` body (not `category`
 | 400 | 1 | 25 | Regex `sol-key`/`unsol-key` not supported |
 | 400 | 1 | 5  | `system` is not the local system |
 | 500 | 8 | 14 | Cannot get command response (MTT/SVC unavailable) |
+| 503 | 8 | 15 | Server quiescing/shutting down; command/detection poll interrupted |
 
 ## Implementation (MVS 3.8j)
 mvsMF has no EMCS consoles or TSO address spaces. The command is issued with **SVC 34 (MGCR)** under the authenticated user's ACEE (so RAKF evaluates command authority for that user); the response is read from the **Master Trace Table (MTT)** via `clibmtt`, correlating the command echo and its responses by jobid + command text + MLWTO number. EMCS OPERPARM fields (`auth`, `routcode`, `mscope`, `storage`, `auto`) are accepted but ignored.

--- a/docs/endpoints/console/issue-command.md
+++ b/docs/endpoints/console/issue-command.md
@@ -85,7 +85,14 @@ Console services use a `return-code`/`reason-code`/`reason` body (not `category`
 | 400 | 1 | 25 | Regex `sol-key`/`unsol-key` not supported |
 | 400 | 1 | 5  | `system` is not the local system |
 | 500 | 8 | 14 | Cannot get command response (MTT/SVC unavailable) |
-| 503 | 8 | 15 | Server quiescing/shutting down; command/detection poll interrupted |
+| 503 | 8 | 15 | Command **was issued**; response/detection poll abandoned (server quiescing). |
+
+> **`503 / 8 / 15` is a post-issue outcome, not a pre-issue failure.** The command
+> has already executed (SVC 34 / MGCR) when the server begins quiescing; only the
+> synchronous response capture or unsolicited-message detection is abandoned. A
+> blind retry **re-issues the command** — harmless for a display (`D T`) but not
+> for a state-changing command (`S`, `V`, `$P`). Treat it as "issued, result
+> unavailable," not "not issued."
 
 ## Implementation (MVS 3.8j)
 mvsMF has no EMCS consoles or TSO address spaces. The command is issued with **SVC 34 (MGCR)** under the authenticated user's ACEE (so RAKF evaluates command authority for that user); the response is read from the **Master Trace Table (MTT)** via `clibmtt`, correlating the command echo and its responses by jobid + command text + MLWTO number. EMCS OPERPARM fields (`auth`, `routcode`, `mscope`, `storage`, `auto`) are accepted but ignored.

--- a/src/consapi.c
+++ b/src/consapi.c
@@ -36,7 +36,13 @@
  * offset.  WARNING: unlike httpx at offset 0x08 (which httpcgi.h documents as an
  * ABI commitment), offset 0x2C for `flag` is NOT a published ABI -- it hardcodes
  * httpd's private struct layout (httpd/include/httpd.h: "volatile UCHAR flag",
- * masks 0x40/0x80).  If httpd reorders a field before `flag`, this reads garbage.
+ * masks 0x40/0x80).  If httpd's struct layout changes and this offset lands on
+ * an unrelated byte, the failure is SILENT (read-only, nothing is corrupted) and
+ * has two equally confusing shapes: if that byte happens to have 0x40/0x80 set,
+ * EVERY console request returns 503; if it does not, this quiesce check is
+ * silently INACTIVE and long polls stop draining at shutdown again. Neither
+ * announces itself -- keep this offset in lockstep with httpd's struct, and
+ * migrate to the accessor when it lands.
  * Read-only, so no httpd or libc370 change is needed now; the durable fix is an
  * httpd-provided accessor (follow-up).  Mirrors the http_get_httpx() offset idiom. */
 #define HTTPD_OFF_FLAG        0x2C     /* volatile UCHAR flag   (httpd.h layout) */
@@ -593,8 +599,14 @@ int consoleIssueHandler(Session *session)
 	if (!is_async) {
 		int captured = capture_response(session, cmd_upper, resp, RESP_CAP);
 		if (captured == CONS_POLL_INTERRUPTED) {
+			/* The command has already been ISSUED (issue_command/MGCR above);
+			 * only the response capture was abandoned. This is NOT a pre-issue
+			 * failure -- a blind retry RE-ISSUES the command (harmless for a
+			 * display like D T, not for S / V / $P). Reason-code 8/15 carries
+			 * that meaning; see docs/endpoints/console/issue-command.md. */
 			send_console_error(session, HTTP_STATUS_SERVICE_UNAVAILABLE, 8, 15,
-			    "Server is quiescing; command response capture interrupted.");
+			    "Command was issued; response capture abandoned (server "
+			    "quiescing). Do not blindly retry -- retry re-issues the command.");
 			rc = -1;
 			goto quit;
 		}
@@ -628,10 +640,15 @@ int consoleIssueHandler(Session *session)
 		strcpy(det_status, "timeout");
 		for (;;) {
 			if (server_quiescing(session)) {
+				/* Command already ISSUED above; only unsolicited-message
+				 * detection was abandoned. As with capture, reason-code 8/15
+				 * means "issued, poll abandoned" -- a blind retry re-issues
+				 * the command. */
 				send_console_error(session,
 				    HTTP_STATUS_SERVICE_UNAVAILABLE, 8, 15,
-				    "Server is quiescing; unsolicited-message "
-				    "detection interrupted.");
+				    "Command was issued; unsolicited-message detection "
+				    "abandoned (server quiescing). Do not blindly retry -- "
+				    "retry re-issues the command.");
 				rc = -1;
 				goto quit;
 			}

--- a/src/consapi.c
+++ b/src/consapi.c
@@ -29,6 +29,22 @@
 #define RESP_CAP       32768      /* cap on captured cmd-response bytes        */
 #define POLL_SECONDS   3          /* sync capture window (~ TOD high-word ticks)*/
 
+/* Server quiesce/shutdown, read from the OPAQUE HTTPD control block.
+ *
+ * httpd hands each CGI an opaque HTTPD* (httpcgi.h forward-declares struct
+ * httpd), so we read the processing-flags byte directly at its fixed layout
+ * offset.  WARNING: unlike httpx at offset 0x08 (which httpcgi.h documents as an
+ * ABI commitment), offset 0x2C for `flag` is NOT a published ABI -- it hardcodes
+ * httpd's private struct layout (httpd/include/httpd.h: "volatile UCHAR flag",
+ * masks 0x40/0x80).  If httpd reorders a field before `flag`, this reads garbage.
+ * Read-only, so no httpd or libc370 change is needed now; the durable fix is an
+ * httpd-provided accessor (follow-up).  Mirrors the http_get_httpx() offset idiom. */
+#define HTTPD_OFF_FLAG        0x2C     /* volatile UCHAR flag   (httpd.h layout) */
+#define HTTPD_FLAG_QUIESCE    0x40     /* server: stop accepting new requests    */
+#define HTTPD_FLAG_SHUTDOWN   0x80     /* server: shutting down now              */
+
+#define CONS_POLL_INTERRUPTED (-1)     /* capture_response(): quiesced mid-poll  */
+
 /* Column layout of a formatted MTT line (see /zosmf/test?fn=mtt output):
  *   "0000  9.24.38 STC  320  IEE136I ..."
  *    flags^   time^    jobtype+num^    message^
@@ -48,6 +64,29 @@ static unsigned tod_hi(void)
 	unsigned char clk[8];
 	__asm__ volatile("STCK %0" : "=m"(clk) : : "cc");
 	return *(unsigned *)clk;
+}
+
+/* Non-zero once the server is quiescing or shutting down.  A worker parked in a
+ * poll loop must notice this and drain promptly: libc370's worker-shutdown gives
+ * each task only ~5 s before a force-DETACH (httpd#122 / mvsmf#179). */
+__asm__("\n&FUNC	SETC 'SRVQUIES'");
+static int server_quiescing(Session *session)
+{
+	const volatile unsigned char *flag;
+
+	if (!session || !session->httpd) return 0;
+	flag = (const volatile unsigned char *)session->httpd + HTTPD_OFF_FLAG;
+	return (*flag & (HTTPD_FLAG_QUIESCE | HTTPD_FLAG_SHUTDOWN)) != 0;
+}
+
+/* Sub-second pause between MTT snapshots.  The MTT is second-granular, so a
+ * 0.10 s wait loses no fidelity while dropping the former CPU-bound spin to near
+ * zero.  BINTVL is in 0.01 s units -- the same STIMER primitive libc370's thread
+ * manager uses for its own drain loop. */
+__asm__("\n&FUNC	SETC 'CPOLLNAP'");
+static void cons_poll_nap(void)
+{
+	__asm__("STIMER WAIT,BINTVL==F'10'   0.10 seconds" : : : "0", "1");
 }
 
 /* Minimal JSON string-field extractor (body is already EBCDIC).
@@ -319,6 +358,7 @@ static int capture_response(Session *session, const char *cmd_upper, char *out,
 	unsigned total = 0;
 
 	for (;;) {
+		if (server_quiescing(session)) return CONS_POLL_INTERRUPTED;
 		correlate_once(session, cmd_upper, out, outsz, 0, &total);
 		if (total > 0) {
 			if (total == prev_total) {
@@ -329,6 +369,7 @@ static int capture_response(Session *session, const char *cmd_upper, char *out,
 		}
 		prev_total = total;
 		if (tod_hi() - start >= (unsigned)POLL_SECONDS) break;
+		cons_poll_nap();
 	}
 
 	return (int)total;
@@ -550,7 +591,14 @@ int consoleIssueHandler(Session *session)
 	resp[0] = '\0';
 
 	if (!is_async) {
-		delivered = (unsigned)capture_response(session, cmd_upper, resp, RESP_CAP);
+		int captured = capture_response(session, cmd_upper, resp, RESP_CAP);
+		if (captured == CONS_POLL_INTERRUPTED) {
+			send_console_error(session, HTTP_STATUS_SERVICE_UNAVAILABLE, 8, 15,
+			    "Server is quiescing; command response capture interrupted.");
+			rc = -1;
+			goto quit;
+		}
+		delivered = (unsigned)captured;
 		if (solkey[0] && strstr(resp, solkey)) sol_detected = 1;
 	}
 
@@ -579,12 +627,21 @@ int consoleIssueHandler(Session *session)
 		if (to == 0 || to > 60) to = 20;            /* sane bound */
 		strcpy(det_status, "timeout");
 		for (;;) {
+			if (server_quiescing(session)) {
+				send_console_error(session,
+				    HTTP_STATUS_SERVICE_UNAVAILABLE, 8, 15,
+				    "Server is quiescing; unsolicited-message "
+				    "detection interrupted.");
+				rc = -1;
+				goto quit;
+			}
 			if (detect_count(session, unsol_upper, det_msg, sizeof(det_msg))
 			    > unsol_base) {
 				strcpy(det_status, "detected");
 				break;
 			}
 			if (tod_hi() - start >= to) break;
+			cons_poll_nap();
 		}
 		if (strcmp(det_status, "detected") != 0) det_msg[0] = '\0';
 	} else if (has_unsol) {


### PR DESCRIPTION
## Summary

Both console poll loops in `consapi.c` now honour the server's quiesce/shutdown
flag and pace themselves with a sub-second delay:

- `capture_response` (~3 s sync capture)
- `unsol_sync` (`consapi.c`, up to `unsol-detect-timeout` seconds)

## Why

A worker parked in `unsol_sync` at `P HTTPD` cannot drain inside libc370's ~5 s
worker-shutdown window (the loop runs up to 60 s; `60 > 5`), so the dispatch
thread never stops and the address space ends abnormally — the `SA03` in
httpd#122. The tight, delay-free spin also burned CPU for the entire poll
duration (up to a full minute per `unsol_sync`). This is the root of the
shutdown chain: with no worker parked at teardown, neither libc370 teardown path
is reached.

## Change (both loops, identical treatment)

- **Quiesce check.** Each iteration tests the HTTPD `flag` for
  `QUIESCE | SHUTDOWN` and, when set, returns promptly with **HTTP 503**
  (`return-code 8`, `reason-code 15`) rather than falling through into response
  assembly with a partial result. `capture_response` signals the interrupt to
  its caller via a sentinel; the `unsol_sync` loop emits the 503 directly.
  The 503 is **post-issue**: the command has already been issued (MGCR) when the
  interrupt fires, so `8/15` is documented — and worded in the reason string — as
  *"command issued, poll abandoned"*, deliberately distinct from a pre-issue
  failure. A blind retry **re-issues** the command: safe for a display like
  `D T`, not for `S` / `V` / `$P`.
- **Inter-poll delay.** A `0.10 s` `STIMER WAIT` at the **end** of each loop
  iteration — *after* the quiesce/response/timeout checks, so it naps only before
  waiting again, never before returning. Normal-operation latency: an `unsol_sync`
  that detects immediately pays **no** nap; only a waiting poll naps (~10×/s,
  replacing the former CPU-bound spin). `capture_response` converges via its
  3-equal-reads rule, which now spaces those reads by the nap — so a normal sync
  command pays ~0.3 s it did not before. That spacing is deliberate: three reads
  0.10 s apart is what makes "stable" meaningful instead of a microsecond
  false-positive. `BINTVL` is in 0.01 s units, the same primitive libc370's own
  thread-manager drain loop uses; the MTT is second-granular, so no fidelity is lost.
- Documented the new `503 / 8 / 15` row in `docs/endpoints/console/issue-command.md`.

## Behavior note — convergence may change response CONTENT, not just timing

`capture_response`'s "3 equal reads → stable" convergence check previously ran at
microsecond spacing. Three MTT snapshots a microsecond apart are near-certain to
match, so the stability test was effectively a **no-op** — it could declare
convergence while the command's output was still arriving. The `0.10 s` nap
spaces those reads out, so the check finally does what it was always meant to.

**Consequence:** a command whose output trickles in with any delay may previously
have been **truncated** (convergence fired early) and should now capture the
fuller response. That is an improvement, but an **unplanned** one: any regression
test asserting on the exact current `cmd-response` text may now legitimately
differ. Worth a spot-check of ordinary commands after deploy.

**Cheap thing to re-check post-deploy — mvsmf#174.** #174 reports an *empty*
`cmd-response` for `MODIFY` replies from some STCs (NSF reproduces, HTTPD does
not). Its mechanism differs from what this PR changes: an *empty* response means
`correlate_once()` returned **0** lines, so the `total > 0` gate means the
convergence path never even runs — premature convergence *truncates* a non-empty
response, it does not empty one. So a change here is **not expected**; but the
#174 case is cheap to re-run once this deploys, so it is worth doing. No claim
either way on #174's root cause.

## ABI note (read before merging)

The flag is read from the **opaque** `HTTPD*` at its fixed layout offset
`0x2C` (`httpd/include/httpd.h`: `volatile UCHAR flag`; masks `0x40`/`0x80`),
mirroring the existing `http_get_httpx()` offset idiom. Unlike httpx at offset
`0x08`, which `httpcgi.h` documents as an ABI commitment, `0x2C` is **not** a
published ABI — it hardcodes httpd's private struct layout, and that struct has
churned before. It is read-only, so no httpd/libc370 change is needed now, but
the durable fix is an **httpd-provided accessor** (e.g. `http_get_flag()` in
`httpcgi.h`) — proposed as a follow-up. The code comment states this loudly.

## Verification

- Host build: `cc370 -O1` clean, `MVSMF` links; a strict `-Wall -Werror`
  recompile of `consapi.c` is warning-clean.
- Generated assembly confirmed: `session->httpd + 0x2C`, byte load, mask `0xC0`,
  NULL-guarded; `STIMER WAIT,BINTVL==F'10'` emitted; `PDPPRLG`/`PDPEPIL` + `LTORG`
  confirm RENT-safe. No 64-bit constants (the `-O1` cc370 constant bug does not
  apply).

## Acceptance

The acceptance criterion is `tests/shutdown-acceptance.sh` (mvslovers/httpd), run
with **`PROVOKE=longpoll`** (added in mvslovers/httpd#126), going **green**
against the post-relink build. The **default** `PROVOKE=abend` mode drives the
recovery-drain path and does **not** exercise this fix — only `longpoll` parks a
worker in an in-flight poll at `P HTTPD`. With this fix the workers should drain
inside libc370's ~5 s window, the dispatch thread should stop, and the address
space should terminate normally. This must be observed on the live MVS system —
it cannot be verified on the host build.

**Do not close on a single green run.** Per the issue, one clean shutdown is an
observation, not proof, given the run-to-run variance already seen; the live test
should be repeated 2–3 times before this is considered settled.

Refs #179 (epic #177)
