### PR TITLE
docs: correct stale HTTP 409/414/507 support note in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,8 +262,11 @@ int ussXxxHandler(Session *session) {
 Use the `ufsd_rc_to_http()`, `ufsd_rc_to_category()`, and `ufsd_rc_message()` mapping functions
 in `ussapi.c`. ALWAYS call `sendErrorResponse()` with the mapped values.
 
-**Note:** HTTPD does not support HTTP 409, 414, or 507 status codes. These are
-mapped to the closest supported alternative (400 or 500).
+**Note:** httpd supports HTTP 409, 414, and 507 (added in httpd#28 / PR #56,
+reachable from CGIs via `http_resp()`). mvsMF's mapping below still collapses
+these to 400/500 (EXIST/NOTEMPTY → 400 instead of 409, NAMETOOLONG → 400 instead
+of 414, NOSPACE/NOINODES → 500 instead of 507); adopting the precise codes is
+tracked in #102.
 
 | UFSD RC | Constant | HTTP | Category | Description |
 |---------|----------|------|----------|-------------|


### PR DESCRIPTION
The Error Code Mapping note in `CLAUDE.md` claimed httpd does not support HTTP
409, 414, or 507. That has been false since httpd#28 / PR #56 (merged
2026-04-11): `httpresp()` emits these codes and they are reachable from CGIs via
`http_resp()` (HTTPX slot 68 → `HTTPRESP`).

Because every agent reads `CLAUDE.md` first, the stale line kept generating work
against the wrong repo — it is why the 409/414/507 adoption was tracked as an
httpd dependency instead of the mvsMF-side task it actually is.

This corrects the note only: httpd supports the codes; mvsMF's mapping still
collapses them to 400/500, and adopting the precise codes is tracked in #102.
The table values are unchanged (they reflect current code until #102 lands).

Refs #102 — does not close it; the code-side adoption is the remaining work.
