### PR TITLE
fix: clamp negative MTT entry length (#176) — HELD for Wed 29 Jul decision

### DIFF
--- a/src/consapi.c
+++ b/src/consapi.c
@@ -270,6 +270,8 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 		int len = e ? (int)e->mtentlen : 0;
 		if (!e) continue;
 		if (len > (int)sizeof(tmp) - 1) len = sizeof(tmp) - 1;
+		if (len < 0) len = 0;   /* mtentlen is a signed short: a bogus/over-read
+		                         * entry can sign-extend negative (#176) */
 		memcpy(tmp, e->mtentdat, len);
 		tmp[len] = '\0';
 		if (strstr(tmp, cmd_upper)) { ei = (int)(i - 1); break; }
@@ -415,6 +417,8 @@ static int detect_count(Session *session, const char *keyword_upper,
 		int k;
 		if (!e) continue;
 		if (len > (int)sizeof(up) - 1) len = sizeof(up) - 1;
+		if (len < 0) len = 0;   /* mtentlen is a signed short: a bogus/over-read
+		                         * entry can sign-extend negative (#176) */
 		for (k = 0; k < len; k++)
 			up[k] = (char)toupper((unsigned char)e->mtentdat[k]);
 		up[len] = '\0';

--- a/test/host/tstmtln.c
+++ b/test/host/tstmtln.c
@@ -61,6 +61,7 @@ static int correlate_once_len(const MTENTRY_T *e)
 	char tmp[160];
 	int len = e ? (int)e->mtentlen : 0;
 	if (len > (int)sizeof(tmp) - 1) len = sizeof(tmp) - 1;
+	if (len < 0) len = 0;       /* #176 fix — mirrors consapi.c */
 	return len;                 /* value handed to memcpy(tmp,...,len) at :273 */
 }
 
@@ -70,6 +71,7 @@ static int detect_count_len(const MTENTRY_T *e)
 	char up[200];
 	int len = e ? (int)e->mtentlen : 0;
 	if (len > (int)sizeof(up) - 1) len = sizeof(up) - 1;
+	if (len < 0) len = 0;       /* #176 fix — mirrors consapi.c */
 	return len;                 /* loop/index bound up[k]/up[len] at :418-420 */
 }
 


### PR DESCRIPTION
> **HELD — do not merge until the Wednesday 29 July release decision.**
> #176 was never the release blocker (#179 was, now merged as #180). This is a
> freshly-found over-write fix; landing it days before the cut is the risk this
> week deliberately avoided. Ready to merge the moment that call is made.

## Fix
`mtentlen` is a signed `short` (ieezb806.h:76). A bogus/over-read entry (from the
libc370 cmttget over-read) can carry a length field that sign-extends **negative**;
the existing high-only clamp in `correlate_once()` and `detect_count()` lets it
through into `memcpy`/the copy loop as a huge 32-bit `size_t` → stack over-write (the
intermittent S0C4 after MGCR).

`if (len < 0) len = 0;` after each high clamp — mirrors the already-immune
hardcopy-log path (consapi.c:1107). Clamp-to-zero, not unsigned: no legitimate
entry exceeds 0x7FFF, so they are identical for real entries and diverge only for
bogus ≥ 0x8000 values (dropped cleanly). One line each.

## Proof
The host repro `TSTMTLN` (`test/host/tstmtln.c`, landed in #183) flips **RED → GREEN**
with this change — its mirror is updated in lockstep (it does not link the real
statics; see that file's header for the limitation).

## Related
- libc370 cmttget over-read (the upstream bogus-entry source) — separate issue,
  belt-and-suspenders.

Fixes #176
