### PR TITLE
feat: migrate to the new jesprint() signature and answer 410 for purged spool output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,10 +263,13 @@ Use the `ufsd_rc_to_http()`, `ufsd_rc_to_category()`, and `ufsd_rc_message()` ma
 in `ussapi.c`. ALWAYS call `sendErrorResponse()` with the mapped values.
 
 **Note:** httpd supports HTTP 409, 414, and 507 (added in httpd#28 / PR #56,
-reachable from CGIs via `http_resp()`). mvsMF's mapping below still collapses
+reachable from CGIs via `http_resp()`), plus 410 (httpd#132 / PR #133, for the
+spool records endpoint — see below). mvsMF's mapping below still collapses
 these to 400/500 (EXIST/NOTEMPTY → 400 instead of 409, NAMETOOLONG → 400 instead
 of 414, NOSPACE/NOINODES → 500 instead of 507); adopting the precise codes is
-tracked in #102.
+tracked in #102. Any status httpd does not know falls through to
+`500 Internal Server Error` on the wire — check `httpresp()` before sending a
+new one.
 
 | UFSD RC | Constant | HTTP | Category | Description |
 |---------|----------|------|----------|-------------|

--- a/docs/endpoints/jobs/records.md
+++ b/docs/endpoints/jobs/records.md
@@ -18,13 +18,45 @@ On successful completion, this request returns HTTP status code 200 (OK) with Co
 
 For SYSIN datasets (e.g. `JESJCLIN`), the response contains exactly `record-count` records: JES2 pre-formats a "JOB DELETED BY JES2 OR CANCELLED BY OPERATOR BEFORE EXECUTION" line into the JCLIN spool chain behind the real records, and the handler caps the output at the PDDB record count so this line does not leak into every response. SYSOUT datasets are not capped, because their record counts may lag while a job is active.
 
+A spool file that exists but holds nothing returns 200 with an empty body.
+
+## Purged spool output (HTTP 410)
+
+The JES2 checkpoint keeps advertising a spool data set after JES2 has printed and purged it —
+with a non-zero record count — while its tracks have already been reallocated to other jobs.
+Reading such a data set lands on a block belonging to a foreign job and yields no records at
+all. That is a loss, not an empty data set, and this endpoint answers **410 Gone** for it.
+
+The distinction rests on the walk statistics libc370's `jesprint()` reports
+(mvslovers/libc370#31):
+
+| Outcome | Meaning | Response |
+|---|---|---|
+| `JESPR_END` | data set read in full | 200 |
+| `JESPR_OPENEND` | foreign block **after** accepted blocks: the data set is still open, everything written so far was read | 200 |
+| `JESPR_EMPTY` | the PDDB carries no MTTR — nothing was ever written | 200, empty body |
+| `JESPR_FOREIGN`, `record-count > 0` | the **first** block is foreign: nothing was read, and the checkpoint promises records the spool no longer holds | **410** |
+| `JESPR_FOREIGN`, `record-count = 0` | nothing was ever written; the allocated-but-unwritten track carries a foreign key too | 200, empty body |
+| `JESPR_DSID`, `JESPR_IOERR`, `JESPR_LOOP`, `JESPR_CAP`, `JESPR_NOBUF`, `JESPR_NOMEM` | spool read failed or was truncated | 500 |
+
+`JESPR_OPENEND` is why a foreign block alone does not mean "gone": the last written block of an
+open data set chains to a track that is allocated but not yet written, so it carries somebody
+else's key. Every running job reads that way — measured on the target, HTTPD's `JESMSGLG`
+stopped on a foreign block after 350 correctly read lines.
+
+Once the first record has been written to the socket the response is committed to 200. A walk
+that goes wrong after that is reported to the operator as `MVSMF10W`, not turned into an error
+body — the records already sent are valid.
+
 ## Error Responses
 - HTTP 400 (Bad Request)
     - Invalid DDID parameter
 - HTTP 404 (Not Found)
     - Job not found
+- HTTP 410 (Gone)
+    - The spool data set was purged by JES2; the checkpoint entry is stale
 - HTTP 500 (Internal Server Error)
-    - JES2 system error
+    - JES2 system error, or a spool read that failed before any record was sent
 
 ## Examples
 

--- a/include/common.h
+++ b/include/common.h
@@ -42,6 +42,7 @@
 #define HTTP_STATUS_UNAUTHORIZED 401          /**< Unauthorized */
 #define HTTP_STATUS_FORBIDDEN 403             /**< Forbidden */
 #define HTTP_STATUS_NOT_FOUND 404             /**< Resource not found */
+#define HTTP_STATUS_GONE 410                  /**< Resource existed, is gone */
 #define HTTP_STATUS_INTERNAL_SERVER_ERROR 500 /**< Server error */
 #define HTTP_STATUS_SERVICE_UNAVAILABLE 503  /**< Service unavailable */
 

--- a/include/jobsapi_msg.h
+++ b/include/jobsapi_msg.h
@@ -53,8 +53,21 @@
 #define REASON_MISSING_FILE_FIELD 7    /**< Missing file field in JSON */
 #define REASON_SUBMIT_FILE_OPEN 8      /**< Cannot open dataset */
 #define REASON_JES_BUSY 9             /**< JES2 resources busy */
+#define REASON_SPOOL_GONE 10          /**< Spool dataset purged by JES2 */
+#define REASON_SPOOL_READ 11          /**< Spool read failed or truncated */
 
 /** @brief Error message for JES2 busy */
 #define ERR_MSG_JES_BUSY "JES2 subsystem is busy, please retry"
+
+/** @brief Error message for spool output JES2 has already purged */
+#define ERR_MSG_SPOOL_GONE                                                     \
+  "Spool output for job '%.8s(%.8s)' DD id %u is no longer on the spool"
+
+/** @brief Error message for a spool read that failed or was truncated */
+#define ERR_MSG_SPOOL_READ                                                     \
+  "Unable to read spool output for job '%.8s(%.8s)' DD id %u: %s"
+
+/** @brief Operator message for an abnormal spool walk */
+#define MSG_JOB_SPOOL_WALK "MVSMF10W Spool read %-8.8s(%-8.8s) DSID %u: %s"
 
 #endif // JOBSAPI_MSG_H

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -282,8 +282,9 @@ jobRecordsHandler(Session *session)
 			}
 		}
 
-		sendDefaultHeaders(session, HTTP_STATUS_OK, "text/plain", 0);
-
+		/* do_print_sysout() owns the response from here on: it holds the
+		   headers back until the first spool line is ready, so an outcome
+		   with no output at all can still answer 410 or 500 (issue #187) */
 		rc = do_print_sysout(session, job, (unsigned)ddid_val);
 		if (rc < 0) {
 			goto quit;
@@ -495,71 +496,155 @@ quit:
  * block chain to the EOB marker, so without a cap that line leaks into
  * every response. SYSIN record counts are final after input processing,
  * so capping at the PDDB count is exact; SYSOUT datasets stay uncapped
- * (their counts may lag while a job is active). The cap travels to the
- * per-line callback through the per-task GRT (grtapp3) - RENT-safe and
- * private to this worker thread.
+ * (their counts may lag while a job is active).
+ *
+ * The cap and the response target travel to the per-line callback in this
+ * context struct, handed straight through jesprint()'s arg (libc370 #21/#22,
+ * issue #187). Before that signature existed the cap had to ride the per-task
+ * GRT, because the callback took no argument of its own.
  */
-typedef struct spool_cap {
-	unsigned	limit;		/* stop after this many lines (0 = no cap) */
-	unsigned	count;		/* lines printed so far                    */
-} SPOOL_CAP;
+typedef struct spool_ctx {
+	Session		*session;	/* response target, and the httpx anchor   */
+	unsigned	limit;		/* cap for the current dd (0 = no cap)     */
+	unsigned	count;		/* lines printed from the current dd       */
+	unsigned	total;		/* lines printed from all dds so far       */
+} SPOOL_CTX;
 
 #define RC_SPOOL_CAP	(-77)	/* sentinel: cap reached, normal end */
 
+/*
+ * Why jesprint() stopped walking the block chain, in the terms this endpoint
+ * has to answer in. An ordinary end returns NULL; everything else names a
+ * condition the caller either reports as an error or logs as truncation.
+ *
+ * END and EMPTY are ordinary ends, and so is OPENEND: a data set that is
+ * still being written ends on a block whose chain points at a track that is
+ * allocated but not yet written, so that track carries a foreign key. Every
+ * running job reads that way - answering "gone" there would throw away output
+ * that was just read correctly (measured in libc370 #31: 350 and 3170 lines
+ * before the foreign block).
+ *
+ * FOREIGN needs the PDDB record count to be read correctly. It means the very
+ * first block was already foreign, so nothing was read at all - but that alone
+ * does not prove a loss: a data set nobody ever wrote to points at an
+ * allocated-but-unwritten track just the same, and with no accepted block in
+ * front of it libc370 cannot call that OPENEND. Only a non-zero record count
+ * makes it a loss: the checkpoint promises records the spool no longer holds,
+ * because JES2 printed and purged the data set and reallocated its tracks.
+ */
+__asm__("\n&FUNC	SETC 'do_print_sysout_why'");
+static const char *
+do_print_sysout_why(int prc, const JESPRST *st, unsigned records)
+{
+	/* jesprint() rejected the request before the walk started; a completed
+	   walk returns 0 or the callback's negative rc, never a positive one */
+	if (prc > 0) {
+		return "JES2 checkpoint or spool data set not available";
+	}
+
+	switch (st->reason) {
+	case JESPR_IOERR:	return "spool read failed";
+	case JESPR_FOREIGN:	return records ? "no longer on the spool" : NULL;
+	case JESPR_DSID:	return "first spool block belongs to another data set";
+	case JESPR_LOOP:	return "spool block chain loops, output truncated";
+	case JESPR_CAP:		return "spool block limit reached, output truncated";
+	case JESPR_NOBUF:	return "incomplete spanned record, output truncated";
+	case JESPR_NOMEM:	return "out of storage, output truncated";
+	}
+
+	return NULL;
+}
+
+/* HTTP status for an outcome that produced no output at all. 410 is reserved
+   for the one case that really is a loss - see do_print_sysout_why(). */
+__asm__("\n&FUNC	SETC 'do_print_sysout_status'");
+static int
+do_print_sysout_status(int prc, const JESPRST *st, unsigned records)
+{
+	if (prc > 0) {
+		return HTTP_STATUS_INTERNAL_SERVER_ERROR;
+	}
+
+	if (st->reason == JESPR_FOREIGN && records) {
+		return HTTP_STATUS_GONE;
+	}
+
+	return do_print_sysout_why(prc, st, records)
+		? HTTP_STATUS_INTERNAL_SERVER_ERROR : HTTP_STATUS_OK;
+}
+
 __asm__("\n&FUNC	SETC 'do_print_sysout_line'");
 static int
-do_print_sysout_line(const char *line, unsigned linelen)
+do_print_sysout_line(const char *line, unsigned linelen, void *arg)
 {
+	SPOOL_CTX *ctx = (SPOOL_CTX *) arg;
+	Session *session = ctx->session;	/* the httpx macro reads session->httpd */
 	int rc = 0;
 
-// we do not have httpr in this function,
-// so we have to use httpd
-#undef httpx
-#define httpx http_get_httpx(httpd)
-
-	CLIBGRT *grt = __grtget();
-	HTTPD *httpd = grt->grtapp1;
-	HTTPC *httpc = grt->grtapp2;
-	SPOOL_CAP *cap = (SPOOL_CAP *) grt->grtapp3;
-
 	/* logical end of the dataset reached - stop jesprint */
-	if (cap && cap->limit && cap->count >= cap->limit) {
+	if (ctx->limit && ctx->count >= ctx->limit) {
 		return RC_SPOOL_CAP;
 	}
 
-	rc = http_printf(httpc, "%-*.*s\r\n", linelen, linelen, line);
-
-	if (rc >= 0 && cap) {
-		cap->count++;
+	/* headers are held back until there is something to send, so that an
+	   outcome with no output at all can still pick its own status */
+	if (!session->headers_sent) {
+		rc = sendDefaultHeaders(session, HTTP_STATUS_OK, "text/plain", 0);
+		if (rc < 0) {
+			return rc;
+		}
 	}
 
-// switch back to httpr
-#undef httpx
-#define httpx http_get_httpx(session->httpd)
+	rc = http_printf(session->httpc, "%-*.*s\r\n", linelen, linelen, line);
+
+	if (rc >= 0) {
+		ctx->count++;
+		ctx->total++;
+	}
 
 	return rc;
 }
 
+/*
+ * Streams one spool dataset (dsid) and owns the whole response for it: the
+ * 200 headers are emitted by the callback on the first line, so an outcome
+ * that never produces a line can still answer 410 or 500 instead of an empty
+ * 200 (issue #187). Once a line has gone out the status is committed - a walk
+ * that then goes wrong is logged for the operator, not turned into an error
+ * body, because the records already sent are valid.
+ */
 __asm__("\n&FUNC	SETC 'do_print_sysout'");
-static int 
-do_print_sysout(Session *session, JESJOB *job, unsigned dsid) 
+static int
+do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 {
 	int rc = 0;
+	int prc = 0;
+	int status = HTTP_STATUS_OK;
+	unsigned bad_dsid = 0;
+	const char *bad_why = NULL;
+	char msg[MAX_ERR_MSG_LENGTH] = {0};
+	SPOOL_CTX ctx;
+	JESPRST st;
 
 	JES *jes = jesopen();
 	if (!jes) {
 		wtof(MSG_JOB_JES_ERROR);
+		sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+						CATEGORY_SERVICE, RC_SEVERE, REASON_INCORRECT_JES_VSAM_HANDLE,
+						ERR_MSG_INCORRECT_JES_VSAM_HANDLE, NULL, 0);
 		rc = -1;
 		goto quit;
 	}
 
-	CLIBGRT *grt = __grtget();
-	SPOOL_CAP cap;
-	unsigned printed = 0;
+	ctx.session = session;
+	ctx.limit = 0;
+	ctx.count = 0;
+	ctx.total = 0;
 
 	unsigned ii = 0;
 	for (ii = 0; ii < array_count(&job->jesdd); ii++) {
 		JESDD *dd = job->jesdd[ii];
+		const char *why = NULL;
 
 		if (!dd) {
 			continue;
@@ -578,8 +663,9 @@ do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 			continue;
 		}
 
-		/* dashed separator between multiple DDs - never trailing */
-		if (printed) {
+		/* dashed separator between dds that produced output - never leading,
+		   never trailing */
+		if (ctx.total) {
 			rc = http_printf(session->httpc, "- - - - - - - - - - - - - - - - - - - - "
 											"- - - - - - - - - - - - - - - - - - - - "
 											"- - - - - - - - - - - - - - - - - - - - "
@@ -591,21 +677,61 @@ do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 
 		/* cap SYSIN datasets at their (final) PDDB record count so the
 		   pre-built JES2 deletion line behind the records stays hidden */
-		cap.limit = ((dd->flag & FLAG_SYSIN) && dd->records) ? dd->records : 0;
-		cap.count = 0;
-		grt->grtapp3 = &cap;
-		rc = jesprint(jes, job, dd->dsid, do_print_sysout_line);
-		grt->grtapp3 = NULL;
+		ctx.limit = ((dd->flag & FLAG_SYSIN) && dd->records) ? dd->records : 0;
+		ctx.count = 0;
 
-		if (rc == RC_SPOOL_CAP) {
-			rc = 0;		/* cap reached - normal end of dataset */
+		prc = jesprint(jes, job, dd->dsid, do_print_sysout_line, &ctx, &st);
+
+		if (prc == RC_SPOOL_CAP) {
+			prc = 0;	/* cap reached - normal end of dataset */
 		}
-		if (rc < 0) {
+		if (prc < 0) {
+			/* the callback gave up: the socket is gone, nothing to answer */
+			rc = prc;
 			goto quit;
 		}
 
-		printed++;
+		/* remember the first abnormal outcome; it decides the status only if
+		   no dd ends up producing any output */
+		why = do_print_sysout_why(prc, &st, dd->records);
+		if (why && !bad_why) {
+			bad_why  = why;
+			bad_dsid = dd->dsid;
+			status   = do_print_sysout_status(prc, &st, dd->records);
+		}
 	}
+
+	/* output went out - the response is committed to 200, so an outcome that
+	   truncated it can only be reported to the operator. The no-output cases
+	   need no console message: the error body below says the same thing, and
+	   a purged dataset that a client polls would flood the log. */
+	if (ctx.total) {
+		if (bad_why) {
+			wtof(MSG_JOB_SPOOL_WALK, (char *) job->jobname,
+				(char *) job->jobid, bad_dsid, bad_why);
+		}
+		rc = 0;
+		goto quit;
+	}
+
+	if (status == HTTP_STATUS_GONE) {
+		snprintf(msg, sizeof(msg), ERR_MSG_SPOOL_GONE,
+				(char *) job->jobname, (char *) job->jobid, bad_dsid);
+		rc = sendErrorResponse(session, HTTP_STATUS_GONE, CATEGORY_SERVICE,
+						RC_WARNING, REASON_SPOOL_GONE, msg, NULL, 0);
+		goto quit;
+	}
+
+	if (status != HTTP_STATUS_OK) {
+		snprintf(msg, sizeof(msg), ERR_MSG_SPOOL_READ,
+				(char *) job->jobname, (char *) job->jobid, bad_dsid, bad_why);
+		rc = sendErrorResponse(session, status, CATEGORY_SERVICE,
+						RC_ERROR, REASON_SPOOL_READ, msg, NULL, 0);
+		goto quit;
+	}
+
+	/* nothing was written and nothing went wrong: an empty spool dataset */
+	rc = sendDefaultHeaders(session, HTTP_STATUS_OK, "text/plain", 0);
 
 quit:
 	if (jes) {

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -27,26 +27,37 @@
 /* NOTE: MVSMF is link-edited RENT (loaded into read-only storage), so this
  * module must carry NO writable static/global data -- any write to one S0C4s
  * (protection).  The jesprint callback therefore keeps no counter; it just
- * streams each line, exactly like jobsapi.c's do_print_sysout_line().      */
+ * streams each line, exactly like jobsapi.c's do_print_sysout_line().
+ *
+ * The Session arrives through jesprint()'s arg (libc370 #21/#22, issue #187);
+ * before that signature existed the callback had to fish httpd/httpc out of
+ * the per-task GRT anchors.                                                */
 __asm__("\n&FUNC	SETC 'print_syslog_line'");
-static int print_syslog_line(const char *line, unsigned linelen) {
-  int rc = 0;
+static int print_syslog_line(const char *line, unsigned linelen, void *arg) {
+  Session *session = (Session *)arg; /* the httpx macro reads session->httpd */
 
-/* this callback has no Session in scope; reach httpc via the GRT anchors,
- * exactly like jobsapi.c's do_print_sysout_line() */
-#undef httpx
-#define httpx http_get_httpx(httpd)
+  return http_printf(session->httpc, "%-*.*s\r\n", linelen, linelen, line);
+}
 
-  CLIBGRT *grt = __grtget();
-  HTTPD *httpd = grt->grtapp1;
-  HTTPC *httpc = grt->grtapp2;
+/* JESPR_* as text, so the probe reports why a walk stopped rather than just
+ * how much came out -- that distinction is the whole point of issue #186. */
+__asm__("\n&FUNC	SETC 'jespr_reason_name'");
+static const char *jespr_reason_name(int reason) {
+  switch (reason) {
+  case JESPR_END:     return "END";
+  case JESPR_EMPTY:   return "EMPTY";
+  case JESPR_IOERR:   return "IOERR";
+  case JESPR_FOREIGN: return "FOREIGN";
+  case JESPR_DSID:    return "DSID";
+  case JESPR_LOOP:    return "LOOP";
+  case JESPR_CAP:     return "CAP";
+  case JESPR_STOPPED: return "STOPPED";
+  case JESPR_NOBUF:   return "NOBUF";
+  case JESPR_NOMEM:   return "NOMEM";
+  case JESPR_OPENEND: return "OPENEND";
+  }
 
-  rc = http_printf(httpc, "%-*.*s\r\n", linelen, linelen, line);
-
-#undef httpx
-#define httpx http_get_httpx(session->httpd)
-
-  return rc;
+  return "?";
 }
 
 /* --- fn=abend (ESTAE recovery test hook) --------------------------------
@@ -244,12 +255,19 @@ int testHandler(Session *session) {
         dc = array_count(&job->jesdd);
         for (di = 0; di < dc; di++) {
           JESDD *dd = job->jesdd[di];
+          JESPRST st;
+          int prc;
           if (!dd || !dd->mttr)
             continue;
           http_printf(session->httpc,
                       "----- jobid=%-8.8s dd=%-8.8s dsid=%u -----\r\n",
                       (char *)job->jobid, (char *)dd->ddname, dd->dsid);
-          jesprint(jes, job, dd->dsid, print_syslog_line);
+          prc = jesprint(jes, job, dd->dsid, print_syslog_line, session, &st);
+          http_printf(session->httpc,
+                      "----- rc=%d reason=%s blocks=%u lines=%u mttr=%08X "
+                      "records=%u -----\r\n",
+                      prc, jespr_reason_name(st.reason), st.blocks, st.lines,
+                      st.mttr, dd->records);
         }
       }
     }

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -708,6 +708,101 @@ test_spool_records_exact_count() {
 	fi
 }
 
+test_spool_records_stale_checkpoint() {
+	echo ""
+	echo "--- Spool File Records: stale checkpoint entry (issue #187) ---"
+
+	# A spool data set JES2 has printed and purged stays in the checkpointed
+	# PDDB, record count and all, while its tracks are reallocated. Reading it
+	# lands on a foreign block and yields nothing. Before #187 that came back
+	# as an empty 200, indistinguishable from an empty data set; it must now be
+	# 410 Gone.
+	#
+	# A purge cannot be provoked from the API (purging the job removes it from
+	# the checkpoint entirely, which is a 404), so this walks whatever the
+	# system currently holds: long-lived started tasks such as SYSLOG are where
+	# stale entries collect. The invariant asserted for every spool file that
+	# advertises records is: never an empty 200.
+
+	local jobs_resp jobname jobid
+	jobs_resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?prefix=SYSLOG")
+	split_response "$jobs_resp"
+
+	if [ "$HTTP_STATUS" != "200" ]; then
+		skip "stale checkpoint (job list returned HTTP $HTTP_STATUS)"
+		return
+	fi
+
+	jobname=$(echo "$BODY" | jq -r '.[0].jobname // empty' 2>/dev/null)
+	jobid=$(echo "$BODY" | jq -r '.[0].jobid // empty' 2>/dev/null)
+
+	if [ -z "$jobname" ] || [ -z "$jobid" ]; then
+		# fall back to the job this suite submitted
+		jobname="$SUBMIT_JOBNAME"
+		jobid="$SUBMIT_JOBID"
+	fi
+
+	if [ -z "$jobname" ] || [ -z "$jobid" ]; then
+		skip "stale checkpoint (no job to inspect)"
+		return
+	fi
+
+	local files_resp
+	files_resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs/${jobname}/${jobid}/files")
+	split_response "$files_resp"
+
+	if [ "$HTTP_STATUS" != "200" ]; then
+		skip "stale checkpoint (spool files returned HTTP $HTTP_STATUS)"
+		return
+	fi
+
+	local ids
+	ids=$(echo "$BODY" | jq -r '.[] | select(.["record-count"] > 0) | .id' 2>/dev/null)
+
+	if [ -z "$ids" ]; then
+		skip "stale checkpoint (${jobname}(${jobid}) has no spool file with records)"
+		return
+	fi
+
+	local checked=0 gone=0 bad=0 detail=""
+	local id resp
+	for id in $ids; do
+		resp=$(do_curl GET \
+			"${BASE_URL}/zosmf/restjobs/jobs/${jobname}/${jobid}/files/${id}/records")
+		split_response "$resp"
+		checked=$((checked + 1))
+
+		case "$HTTP_STATUS" in
+			200)
+				if [ -z "$BODY" ]; then
+					bad=$((bad + 1))
+					detail="${detail} id=${id}:empty-200"
+				fi
+				;;
+			410)
+				gone=$((gone + 1))
+				local cat
+				cat=$(echo "$BODY" | jq -r '.category // empty' 2>/dev/null)
+				if [ -z "$cat" ]; then
+					bad=$((bad + 1))
+					detail="${detail} id=${id}:410-without-error-body"
+				fi
+				;;
+			*)
+				bad=$((bad + 1))
+				detail="${detail} id=${id}:HTTP-${HTTP_STATUS}"
+				;;
+		esac
+	done
+
+	if [ "$bad" -eq 0 ]; then
+		pass "${jobname}(${jobid}): ${checked} spool file(s) with records, none empty-200 (${gone} reported 410 Gone)"
+	else
+		fail "${jobname}(${jobid}): spool files with records must never be an empty 200" \
+			"${detail# }"
+	fi
+}
+
 test_spool_records_invalid_ddid() {
 	echo ""
 	echo "--- Spool File Records: invalid DDID ---"
@@ -807,6 +902,7 @@ test_spool_files_not_found
 # Spool records tests
 test_spool_records
 test_spool_records_exact_count
+test_spool_records_stale_checkpoint
 test_spool_records_invalid_ddid
 
 # Purge tests (last, since it removes the test job)

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -720,44 +720,50 @@ test_spool_records_stale_checkpoint() {
 	#
 	# A purge cannot be provoked from the API (purging the job removes it from
 	# the checkpoint entirely, which is a 404), so this walks whatever the
-	# system currently holds: long-lived started tasks such as SYSLOG are where
-	# stale entries collect. The invariant asserted for every spool file that
-	# advertises records is: never an empty 200.
+	# system currently holds. Stale entries collect on long-lived started
+	# tasks: SYSLOG spins its log to a SYSOUT class, a printer drains and
+	# purges it, and the checkpointed PDDB keeps advertising it. The invariant
+	# asserted for every spool file that advertises records is: never an empty
+	# 200 - either the records come back, or the loss is reported as 410.
+	#
+	# The job list does not return STCs, so SYSLOG is located through the
+	# internal /zosmf/test?fn=syslog probe (jobid + dsid/record-count per DD)
+	# and read through the records endpoint directly by name and id. Falls
+	# back to the job this suite submitted when the probe is unavailable.
 
-	local jobs_resp jobname jobid
-	jobs_resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?prefix=SYSLOG")
-	split_response "$jobs_resp"
+	local jobname jobid ids probe
+	jobname="SYSLOG"
+	# the probe writes HTTP text lines: strip CR or the $ anchors never match
+	probe=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/test?fn=syslog&step=4" 2>/dev/null | tr -d '\r')
+	jobid=$(printf '%s\n' "$probe" | sed -n 's/.*jobid=\([A-Z0-9]*\).*/\1/p' | head -1)
 
-	if [ "$HTTP_STATUS" != "200" ]; then
-		skip "stale checkpoint (job list returned HTTP $HTTP_STATUS)"
-		return
+	if [ -n "$jobid" ]; then
+		# dsids the probe reports with a non-zero record count
+		ids=$(printf '%s\n' "$probe" \
+			| sed -n 's/^step4 .*dsid=\([0-9]*\) .*records=\([1-9][0-9]*\)$/\1/p')
 	fi
 
-	jobname=$(echo "$BODY" | jq -r '.[0].jobname // empty' 2>/dev/null)
-	jobid=$(echo "$BODY" | jq -r '.[0].jobid // empty' 2>/dev/null)
-
-	if [ -z "$jobname" ] || [ -z "$jobid" ]; then
+	if [ -z "$jobid" ] || [ -z "$ids" ]; then
 		# fall back to the job this suite submitted
 		jobname="$SUBMIT_JOBNAME"
 		jobid="$SUBMIT_JOBID"
+
+		if [ -z "$jobname" ] || [ -z "$jobid" ]; then
+			skip "stale checkpoint (no job to inspect)"
+			return
+		fi
+
+		local files_resp
+		files_resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs/${jobname}/${jobid}/files")
+		split_response "$files_resp"
+
+		if [ "$HTTP_STATUS" != "200" ]; then
+			skip "stale checkpoint (spool files returned HTTP $HTTP_STATUS)"
+			return
+		fi
+
+		ids=$(echo "$BODY" | jq -r '.[] | select(.["record-count"] > 0) | .id' 2>/dev/null)
 	fi
-
-	if [ -z "$jobname" ] || [ -z "$jobid" ]; then
-		skip "stale checkpoint (no job to inspect)"
-		return
-	fi
-
-	local files_resp
-	files_resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs/${jobname}/${jobid}/files")
-	split_response "$files_resp"
-
-	if [ "$HTTP_STATUS" != "200" ]; then
-		skip "stale checkpoint (spool files returned HTTP $HTTP_STATUS)"
-		return
-	fi
-
-	local ids
-	ids=$(echo "$BODY" | jq -r '.[] | select(.["record-count"] > 0) | .id' 2>/dev/null)
 
 	if [ -z "$ids" ]; then
 		skip "stale checkpoint (${jobname}(${jobid}) has no spool file with records)"


### PR DESCRIPTION
Fixes #187. Needs mvslovers/httpd#132 (PR mvslovers/httpd#133) for the 410 to reach the wire.

## Signature migration

libc370's `jesprint()` now takes a pass-through `arg` and fills a `JESPRST` with why the block
walk stopped (mvslovers/libc370#31, fixing #21/#22). Both mvsmf call sites move to it.

**`src/jobsapi.c`** — the SYSIN line cap (#158) and the response target travel to the per-line
callback in a context struct handed straight through `arg`. The cap only rode the per-task GRT
(`grtapp3`) because the old callback took no argument of its own; that detour and its comment
are gone. `grtapp1`/`grtapp2` are untouched — other code paths still need them.

**`src/testapi.c`** — `fn=syslog` passes the `Session` through `arg` instead of the GRT anchors,
and now prints `rc/reason/blocks/lines/mttr` per data set. That is the distinction #186 needs to
tell deep history apart from a stale checkpoint entry.

## 410 for purged spool output

The 200 headers are no longer written before the walk starts. The callback emits them on the
first line instead, so an outcome that produces no line at all can still pick its own status:

| `st->reason` | | HTTP |
|---|---|---|
| `END` / `OPENEND` / `EMPTY` | ordinary end | 200 |
| `FOREIGN`, `record-count > 0` | purged, checkpoint stale | **410 Gone** |
| `FOREIGN`, `record-count = 0` | never written | 200, empty body |
| `DSID` / `IOERR` / `LOOP` / `CAP` / `NOBUF` / `NOMEM` | failed or truncated | 500 |

`FOREIGN` means the very first spool block already belongs to another job: JES2 printed and
purged the data set and reallocated its tracks while the checkpointed PDDB still advertises it.
Nothing was read, so the empty 200 this used to return was wrong.

**The record count is load-bearing.** A data set nobody ever wrote to points at an
allocated-but-unwritten track that carries a foreign key just the same, and with no accepted
block in front of it libc370 cannot call that `OPENEND`. Only a non-zero count makes it a loss —
the checkpoint promising records the spool no longer holds. This mirrors what httpd's
`do_print_sysout_why()` already does (measured there: SYSLOG dsid 101 `records=32` is a real
loss, HTTPDERR/HTTPDOUT `records=0` are merely empty).

`OPENEND` is deliberately an ordinary end. A data set still being written ends on a block
chaining to a track allocated but not yet written, so **every running job reads that way** —
measured at 350 and 3170 correctly read lines before the foreign block. Answering 410 there
would discard output that was just read correctly.

Once a record has gone out the response is committed to 200; a walk that then truncates is
reported to the operator as `MVSMF10W` rather than turned into an error body. The no-output
cases stay off the console on purpose — the error body carries the same information, and a
purged data set that a client polls would otherwise flood the log.

Falling out of the deferred headers: `jesopen()` failure now answers 500 instead of an empty
200, which the eager header write had made impossible.

## Behaviour change worth calling out

A spool file whose data set was purged used to read as an empty file. It is now an error for
the client. That is the point of the issue, but it is a visible change for Zowe Explorer: an
empty editor tab becomes an error toast.

The dashed separator between multiple DDs now fires between DDs that **produced output**
rather than DDs that were walked, so a DD that yields nothing can no longer leave a leading
separator behind.

## Verified

- `make` clean (`-Wall -Werror`), MVSMF links.
- The sysroot `libc.a` really does carry the new `jesprint`: `ld370` autocalls by symbol name,
  so a stale object would have linked silently and handed the callback garbage. Rebuilt libc370
  from current source and byte-compared — `jesprint.o` in `~/.local/cc370/lib/libc.a` is
  identical to the fresh build.
- `tests/curl-jobs.sh` gains `test_spool_records_stale_checkpoint`. A purge cannot be provoked
  through the API (purging the job removes it from the checkpoint entirely, which is a 404), so
  it walks the spool files the system currently holds — long-lived STCs such as SYSLOG are where
  stale entries collect — and asserts the invariant: **a spool file advertising records is never
  an empty 200.** It reports how many answered 410, and skips when there is nothing to inspect.

Not yet run against the live MVS system — that needs the httpd PR deployed first, otherwise the
410 arrives as `500 Internal Server Error` on the status line.

https://claude.ai/code/session_019ibLZobVRy47xfNgEKxpS2