### PR TITLE
fix: purge answers 404 for an unknown job and reports the owner

### DIFF
--- a/docs/endpoints/jobs/purge.md
+++ b/docs/endpoints/jobs/purge.md
@@ -17,14 +17,20 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
 
 ```json
 {
-    "owner": "string",       // Owner of the job
-    "jobid": "string",       // Job ID
-    "job-correlator": "",    // Job correlator (not supported in MVS 3.8j)
-    "message": "string",     // Success message
-    "jobname": "string",     // Name of the job
-    "status": 0             // Status of the delete operation
+    "owner": "string",           // Owner of the job
+    "jobid": "string",           // Job ID
+    "original-jobid": "string",  // Same as jobid
+    "message": "string",         // Success message
+    "jobname": "string",         // Name of the job
+    "status": 0                  // Status of the delete operation
 }
 ```
+
+`job-correlator` is not emitted — MVS 3.8j has no job correlators.
+
+The job is looked up before it is purged. That lookup is what supplies `owner`
+(it cannot be read afterwards, the job is gone) and what makes an unknown job
+answer 404 the same way `GET /jobs/{name}/{id}` does.
 
 ## Error Responses
 - HTTP 400 (Bad Request)
@@ -32,7 +38,10 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
 - HTTP 403 (Forbidden)
     - No permission (e.g. attempt to delete HTTPD itself)
 - HTTP 404 (Not Found)
-    - Job not found
+    - Job not found. This also covers a jobid JES2 rejects as malformed —
+      on 3.8j anything outside `JOB00001`–`JOB09999`, e.g. `JOB99999`, or a
+      non-conforming string. `jescanj()` reports those as `CANJ_SYNTX`, which
+      used to surface as 500 (issue #190).
 - HTTP 500 (Internal Server Error)
     - JES2 system error
     - VSAM error

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -319,7 +319,10 @@ jobPurgeHandler(Session *session)
 	const char *jobname = getPathParam(session, "job-name");
 	const char *jobid = getPathParam(session, "jobid");
 
+	JESJOB *job = NULL;
+	JESJOB **joblist = NULL;
 	JsonBuilder *builder = createJsonBuilder();
+	char owner[JOBNAME_STR_SIZE + 1] = {0};
 
 	if (!jobname || !jobid) {
 		sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST, CATEGORY_UNEXPECTED,
@@ -327,6 +330,26 @@ jobPurgeHandler(Session *session)
 						  NULL, 0);
 		goto quit;
 	}
+
+	/* Resolve the job before purging it. Two reasons (issue #190):
+	   - it is the only chance to read the owner, which the purge feedback
+	     document carries and which is gone once the job is;
+	   - it answers "no such job" the way the status and files handlers do.
+	     jescanj() alone cannot: a jobid JES2 rejects as malformed - anything
+	     outside JOB00001-JOB09999 on 3.8j, e.g. JOB99999 - comes back as
+	     CANJ_SYNTX, which used to fall through to a 500. */
+	job = find_job_by_name_and_id(session, jobname, jobid, &joblist);
+	if (!job) {
+		char msg[MAX_ERR_MSG_LENGTH] = {0};
+		snprintf(msg, sizeof(msg), ERR_MSG_JOB_NOT_FOUND, jobname, jobid);
+		sendErrorResponse(session, HTTP_STATUS_NOT_FOUND, CATEGORY_SERVICE,
+						RC_WARNING, REASON_JOB_NOT_FOUND,
+						msg, NULL, 0);
+		goto quit;
+	}
+
+	/* copy it out now - the job the pointer describes is about to be purged */
+	snprintf(owner, sizeof(owner), "%.8s", (char *) job->owner);
 
 	rc = jescanj(jobname, jobid, 1);
 
@@ -338,6 +361,7 @@ jobPurgeHandler(Session *session)
 		rc = addJsonString(builder, "message", "Request was successful.");
 		rc = addJsonString(builder, "original-jobid", jobid);
 		rc = addJsonString(builder, "jobname", jobname);
+		rc = addJsonString(builder, "owner", owner);
 		rc = addJsonNumber(builder, "status", 0);
 
 		rc = endJsonObject(builder);
@@ -350,6 +374,9 @@ jobPurgeHandler(Session *session)
 		break;
 	case CANJ_NOJB:
 	case CANJ_BADI:
+	case CANJ_SYNTX:
+		/* the lookup above found it, so this is a job that went away between
+		   the two calls - still "not found" from the client's side */
 		{
 			char msg[MAX_ERR_MSG_LENGTH] = {0};
 			snprintf(msg, sizeof(msg), ERR_MSG_JOB_NOT_FOUND, jobname, jobid);
@@ -372,6 +399,10 @@ jobPurgeHandler(Session *session)
 	}
 
 quit:
+	if (joblist) {
+		jesjobfr(&joblist);
+	}
+
 	if (builder) {
 		freeJsonBuilder(builder);
 	}

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -856,11 +856,19 @@ test_purge_not_found() {
 	echo ""
 	echo "--- Purge Job: not found ---"
 
-	local resp
-	resp=$(do_curl DELETE "${BASE_URL}/zosmf/restjobs/jobs/NOSUCHJB/JOB99999")
-	split_response "$resp"
+	# Three shapes an unknown job can take, all of which must answer 404 the
+	# way GET /jobs/{name}/{id} does (issue #190). Only the first is a plain
+	# "no such job": JES2 on 3.8j accepts JOB00001-JOB09999, so JOB99999 and
+	# a non-conforming string come back from jescanj() as CANJ_SYNTX, which
+	# used to fall through to a 500.
+	local jid resp
+	for jid in JOB09999 JOB99999 NOTAJOBID; do
+		resp=$(do_curl DELETE "${BASE_URL}/zosmf/restjobs/jobs/NOSUCHJB/${jid}")
+		split_response "$resp"
 
-	assert_http_status "404" "$HTTP_STATUS" "purge job not found"
+		assert_http_status "404" "$HTTP_STATUS" "purge job not found (${jid})"
+		assert_json_field "$BODY" '.reason' "2" "purge not found: reason 2 (${jid})"
+	done
 }
 
 # =========================================================================


### PR DESCRIPTION
Fixes #190.

Beide Defekte kommen aus derselben Ursache: `jobPurgeHandler()` ging ohne Lookup direkt auf `jescanj()`.

## 1. Unbekannter Job antwortete 500

`jescanj()` meldet einen jobid, den JES2 als syntaktisch ungültig ansieht, mit `CANJ_SYNTX` (24). Der Switch führte den Code nicht, also fiel er in den `default`-Zweig auf den generischen Serverfehler. Nachgemessen auf dem Zielsystem:

| jobid | jescanj rc | vorher | jetzt |
|---|---|---|---|
| `JOB09999` | `CANJ_NOJB` (4) | 404 | 404 |
| `JOB99999` | `CANJ_SYNTX` (24) | **500** | **404** |
| `NOTAJOBID` | `CANJ_SYNTX` (24) | **500** | **404** |

JES2 akzeptiert auf 3.8j nur `JOB00001`–`JOB09999`, deshalb ist `JOB99999` — genau der Wert, den die Testsuite benutzt — bereits ein Syntaxfehler und kein „nicht gefunden".

Entscheidend für die Wahl von 404 statt 400: `GET /jobs/{name}/{id}` und `GET .../files` antworten auf **alle drei** Eingaben bereits mit 404. Purge war schlicht der Ausreißer.

## 2. Fehlender owner

Das Purge-Feedback-Dokument führte kein `owner` — obwohl `docs/endpoints/jobs/purge.md` es seit jeher dokumentiert. Nach dem Purge ist es nicht mehr lesbar, es muss also von vorher kommen.

## Fix

Ein vorgeschaltetes `find_job_by_name_and_id()` — derselbe Helper, der Status und /files ihr konsistentes 404 gibt — löst beides: eine nicht auflösbare Referenz ist 404, unabhängig davon, warum JES2 sie ablehnt, und der `owner` wird gelesen, solange der Job noch existiert. `CANJ_SYNTX` ist zusätzlich neben `NOJB`/`BADI` gemappt, für den Fall, dass ein Job zwischen Lookup und Cancel verschwindet. Das `joblist` wird jetzt freigegeben.

Kosten: ein zusätzlicher `jesjob()`-Scan pro Purge — denselben machen Status und /files bereits.

## Verifiziert auf mvsdev.lan

Rote Baseline vor der Aktivierung, gleiche Aufrufe danach:

```
vorher:  JOB09999 -> 404 | JOB99999 -> 500 | NOTAJOBID -> 500
nachher: JOB09999 -> 404 | JOB99999 -> 404 | NOTAJOBID -> 404
```

`tests/curl-jobs.sh` geht von **64 passed / 2 failed** auf **71 passed / 0 failed**. Der Test deckt jetzt alle drei Formen ab und prüft zusätzlich `reason: 2`.

Gesamtstand aller Suites: jobs 71/0, datasets 55/1 (#191), binary 10/0, console 61/61, uss 64/0, auth 14/14.

## Doku

`docs/endpoints/jobs/purge.md` versprach ein `job-correlator`, das nie emittiert wurde, und verschwieg `original-jobid`, das emittiert wird — korrigiert, plus der 404-Fall.

https://claude.ai/code/session_019ibLZobVRy47xfNgEKxpS2