### PR TITLE
fix: a failed open answers 404 when the dataset or member is not there

### DIFF
--- a/docs/endpoints/datasets/get.md
+++ b/docs/endpoints/datasets/get.md
@@ -32,8 +32,10 @@ On successful completion, this request returns HTTP status code 200 (OK) with th
 ## Error Responses
 - HTTP 400 (Bad Request)
     - Dataset is a PDS (use the member endpoint instead)
+- HTTP 404 (Not Found)
+    - Dataset not cataloged (`reason` 4)
 - HTTP 500 (Internal Server Error)
-    - Dataset not found or cannot be opened
+    - The dataset exists but cannot be opened (I/O error)
     - Memory allocation failed
 
 ## Limitations

--- a/docs/endpoints/datasets/members-get.md
+++ b/docs/endpoints/datasets/members-get.md
@@ -27,9 +27,16 @@ or with explicit volume:
 On successful completion, this request returns HTTP status code 200 (OK) with the member content. In text mode, trailing space padding on F/FB records is stripped so the output matches VB-style line endings.
 
 ## Error Responses
+- HTTP 404 (Not Found)
+    - Dataset not cataloged (`reason` 4, `Dataset not found`)
+    - Dataset exists but has no such member (`reason` 5, `PDS member not found`)
 - HTTP 500 (Internal Server Error)
-    - Dataset or member not found
+    - The member exists but cannot be opened (I/O error)
     - Memory allocation failed
+
+A failed open used to be reported as 500 whatever the cause, so a member that
+was simply not there looked like a broken server (issue #191). The two cases are
+now told apart by a catalog lookup and a filtered directory read.
 
 ## Limitations
 - Binary/record mode: no DSCB-based record count limit (reads until fread returns 0). This works correctly for PDS members but may include padding for the last block.

--- a/docs/endpoints/datasets/members-put.md
+++ b/docs/endpoints/datasets/members-put.md
@@ -30,9 +30,14 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 ## Error Responses
 - HTTP 400 (Bad Request)
     - Missing Content-Length or Transfer-Encoding header
+- HTTP 404 (Not Found)
+    - Dataset not cataloged (`reason` 4)
 - HTTP 500 (Internal Server Error)
-    - Dataset or member cannot be opened for writing
+    - The dataset exists but cannot be opened for writing (I/O error)
     - I/O error during write
+
+Only a missing *dataset* is an error here. A member that does not exist yet is
+what a create looks like, and it is written normally.
 
 ## Limitations
 - Text mode: records longer than LRECL are truncated with a warning

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -311,9 +311,10 @@ is_pds(const char *dsname)
  * member: a member that does not exist yet is what a create looks like, only
  * a missing data set is an error there.
  */
-#define OPEN_FAIL_IO     0      /* the object is there - a real I/O error */
-#define OPEN_FAIL_NODSN  1      /* the data set is not cataloged          */
-#define OPEN_FAIL_NOMEM  2      /* the data set has no such member        */
+#define OPEN_FAIL_IO      0     /* the object is there - a real I/O error */
+#define OPEN_FAIL_NODSN   1     /* the data set is not cataloged          */
+#define OPEN_FAIL_NOMEM   2     /* the data set has no such member        */
+#define OPEN_FAIL_NOTPDS  3     /* a member was asked of a non-PDS        */
 
 __asm__("\n&FUNC    SETC 'diagnose_open_failure'");
 static int
@@ -345,6 +346,13 @@ diagnose_open_failure(const char *dsname, const char *member)
         return OPEN_FAIL_IO;
     }
 
+    /* __listpd() reads the directory with BPAM and abends S001 if the data
+       set is not partitioned, so the DSCB has to be checked first - a member
+       request against a sequential data set is a client error, not a dump. */
+    if (!is_pds(dsname)) {
+        return OPEN_FAIL_NOTPDS;
+    }
+
     pdslist = __listpd(dsname, member);
     if (!pdslist) {
         return OPEN_FAIL_NOMEM;
@@ -370,6 +378,10 @@ send_open_failure(Session *session, const char *dsname, const char *member,
         return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
             CATEGORY_SERVICE, RC_ERROR, REASON_MEMBER_NOT_FOUND,
             ERR_MSG_MEMBER_NOT_FOUND, NULL, 0);
+    case OPEN_FAIL_NOTPDS:
+        /* mirror of the "dataset is a PDS, use the member endpoint" 400 */
+        return handle_error(session, ERR_INVALID_PARAM,
+            "Dataset is not partitioned (use the dataset endpoint instead)");
     }
 
     return handle_error(session, ERR_IO, io_message);
@@ -1455,6 +1467,32 @@ int memberPutHandler(Session *session)
     } else {
         snprintf(member_mode, sizeof(member_mode), "%s", "w");
     }
+    /* Verify the data set exists before opening the member for output. Same
+       reason as the sequential path (issue #65): fopen("w") on a name that is
+       not cataloged auto-allocates it, and it does so with the wrong DCB - a
+       PUT to a member of a missing PDS used to leave a RECFM=V sequential data
+       set behind and then answer 500. Checking afterwards cannot help; by then
+       the data set exists. A member that does not exist yet is fine - that is
+       what a create looks like. */
+    {
+        LOCWORK locwork;
+        char    dsn44[44];
+        size_t  len = strlen(dsname);
+
+        if (len > sizeof(dsn44)) {
+            len = sizeof(dsn44);
+        }
+        memset(dsn44, ' ', sizeof(dsn44));
+        memcpy(dsn44, dsname, len);
+        memset(&locwork, 0, sizeof(locwork));
+
+        if (__locate(dsn44, &locwork) != 0) {
+            return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+                CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_NOT_FOUND,
+                ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
+        }
+    }
+
     fp = fopen(dataset, member_mode);
     if (!fp) {
         wtof("MVSMF06E Failed to open dataset member for writing: %s (errno=%d)", dataset, errno);

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -293,6 +293,88 @@ is_pds(const char *dsname)
 	return (dscb.dscb1.dsorg1 & DSGPO) != 0;
 }
 
+/*
+ * Why an fopen() of a data set or member failed (issue #191).
+ *
+ * fopen() only ever reports NULL, so the handlers had nothing to go on and
+ * reported every failure as an I/O error: a member that is simply not there
+ * came back as 500, indistinguishable from a broken server, and a client had
+ * no reason not to retry something that can never succeed.
+ *
+ * Two cheap primitives settle it. __locate() is a catalog lookup, and
+ * __listpd() applies its filter with __patmat() before it allocates, so
+ * passing the exact member name walks the directory but builds at most one
+ * entry - no full member list for a one-name question. Member names cannot
+ * contain pattern characters, so the match is exact.
+ *
+ * Pass member = NULL for a sequential data set, and also for a write to a
+ * member: a member that does not exist yet is what a create looks like, only
+ * a missing data set is an error there.
+ */
+#define OPEN_FAIL_IO     0      /* the object is there - a real I/O error */
+#define OPEN_FAIL_NODSN  1      /* the data set is not cataloged          */
+#define OPEN_FAIL_NOMEM  2      /* the data set has no such member        */
+
+__asm__("\n&FUNC    SETC 'diagnose_open_failure'");
+static int
+diagnose_open_failure(const char *dsname, const char *member)
+{
+    LOCWORK  locwork;
+    PDSLIST  **pdslist;
+    char     dsn44[44];
+    size_t   len;
+
+    if (!dsname) {
+        return OPEN_FAIL_IO;
+    }
+
+    /* __locate() wants a blank-padded 44-byte name */
+    len = strlen(dsname);
+    if (len > sizeof(dsn44)) {
+        len = sizeof(dsn44);
+    }
+    memset(dsn44, ' ', sizeof(dsn44));
+    memcpy(dsn44, dsname, len);
+
+    memset(&locwork, 0, sizeof(locwork));
+    if (__locate(dsn44, &locwork) != 0) {
+        return OPEN_FAIL_NODSN;
+    }
+
+    if (!member) {
+        return OPEN_FAIL_IO;
+    }
+
+    pdslist = __listpd(dsname, member);
+    if (!pdslist) {
+        return OPEN_FAIL_NOMEM;
+    }
+    __freepd(&pdslist);
+
+    return OPEN_FAIL_IO;
+}
+
+/* Answer a failed open with the status it deserves: 404 when the data set or
+   the member is not there, 500 only for a genuine I/O error. */
+__asm__("\n&FUNC    SETC 'send_open_failure'");
+static int
+send_open_failure(Session *session, const char *dsname, const char *member,
+                  const char *io_message)
+{
+    switch (diagnose_open_failure(dsname, member)) {
+    case OPEN_FAIL_NODSN:
+        return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+            CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_NOT_FOUND,
+            ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
+    case OPEN_FAIL_NOMEM:
+        return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+            CATEGORY_SERVICE, RC_ERROR, REASON_MEMBER_NOT_FOUND,
+            ERR_MSG_MEMBER_NOT_FOUND, NULL, 0);
+    }
+
+    return handle_error(session, ERR_IO, io_message);
+}
+
 // Helper function to parse X-IBM-Data-Type header
 static int parse_data_type(const char *data_type) {
     if (!data_type) return DATA_TYPE_TEXT;  // Default is text
@@ -764,7 +846,7 @@ int datasetGetHandler(Session *session)
         fp = fopen(dsname, "rb");
     }
     if (!fp) {
-        return handle_error(session, ERR_IO, "Cannot open dataset");
+        return send_open_failure(session, dsname, NULL, "Cannot open dataset");
     }
     session_register_file(session, fp);
 
@@ -1282,7 +1364,7 @@ int memberGetHandler(Session *session)
         fp = fopen(dataset, "rb");
     }
     if (!fp) {
-        return handle_error(session, ERR_IO, "Cannot open dataset member");
+        return send_open_failure(session, dsname, member, "Cannot open dataset member");
     }
     session_register_file(session, fp);
 
@@ -1376,7 +1458,10 @@ int memberPutHandler(Session *session)
     fp = fopen(dataset, member_mode);
     if (!fp) {
         wtof("MVSMF06E Failed to open dataset member for writing: %s (errno=%d)", dataset, errno);
-        return handle_error(session, ERR_IO, "Cannot open dataset member for writing");
+        /* member = NULL: a member that does not exist yet is a create, not an
+           error - only a missing data set is */
+        return send_open_failure(session, dsname, NULL,
+            "Cannot open dataset member for writing");
     }
     session_register_file(session, fp);
 

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -617,13 +617,40 @@ BODY=$(echo "$RESP" | sed '$d')
 assert_http_status "404" "$HTTP_CODE" "read member of a missing PDS"
 assert_json_field "$BODY" '.reason' "4" "member of missing PDS: reason 4 (dataset not found)"
 
-# writing into a dataset that does not exist
+# asking for a member of a data set that is not partitioned. __listpd() reads
+# the directory with BPAM and abends S001 on a sequential data set, so this
+# used to come back as the router's abend-recovery 500.
+RESP=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}(M1)")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+assert_http_status "400" "$HTTP_CODE" "read a member of a sequential dataset"
+if echo "$BODY" | grep -q "abend"; then
+	fail "member of sequential dataset must not abend" "abend recovery response"
+else
+	pass "member of sequential dataset does not abend"
+fi
+
+# writing into a dataset that does not exist. fopen("w") auto-allocates an
+# unknown name with the wrong DCB, so this used to answer 500 *and* leave a
+# RECFM=V sequential data set behind (same defect as issue #65 on the
+# sequential path). Assert both the status and that nothing was created.
 HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	-X PUT -u "$AUTH" \
 	-H "Content-Type: application/octet-stream" \
 	--data-binary $'X\n' \
 	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.NOSUCH.PDS(M1)")
 assert_http_status "404" "$HTTP_CODE" "write member into a missing PDS"
+
+LOCBODY=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/test?fn=locate&dsn=${MVSMF_USER}.NOSUCH.PDS")
+if echo "$LOCBODY" | grep -q '"rc": 0'; then
+	fail "failed member write must not create the dataset" "${MVSMF_USER}.NOSUCH.PDS now exists"
+	curl -s -o /dev/null -X DELETE -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.NOSUCH.PDS"
+else
+	pass "failed member write did not create the dataset"
+fi
 
 # ... but a member that does not exist YET is a create, not an error. This is
 # the regression guard for the write path: it must not inherit the read path's

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -586,6 +586,59 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR)")
 assert_http_status "404" "$HTTP_CODE" "delete non-existent member"
 
+# --- Open failures: 404 vs 500 (Issue #191) ---
+# fopen() only reports NULL, so every failed open used to be an I/O error 500 —
+# a member that is simply not there was indistinguishable from a broken server,
+# and 500 invites a retry that can never succeed.
+echo ""
+echo "--- Open failures: not found must be 404, not 500 (issue #191) ---"
+
+# missing sequential dataset
+RESP=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.NOSUCH.SEQDS")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+assert_http_status "404" "$HTTP_CODE" "read missing sequential dataset"
+assert_json_field "$BODY" '.reason' "4" "missing dataset: reason 4 (dataset not found)"
+
+# missing member of a dataset that does exist
+RESP=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(NOSUCHMB)")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+assert_http_status "404" "$HTTP_CODE" "read missing member of an existing PDS"
+assert_json_field "$BODY" '.reason' "5" "missing member: reason 5 (member not found)"
+
+# member of a dataset that does not exist — the dataset is the reason, not the member
+RESP=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.NOSUCH.PDS(M1)")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+assert_http_status "404" "$HTTP_CODE" "read member of a missing PDS"
+assert_json_field "$BODY" '.reason' "4" "member of missing PDS: reason 4 (dataset not found)"
+
+# writing into a dataset that does not exist
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary $'X\n' \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.NOSUCH.PDS(M1)")
+assert_http_status "404" "$HTTP_CODE" "write member into a missing PDS"
+
+# ... but a member that does not exist YET is a create, not an error. This is
+# the regression guard for the write path: it must not inherit the read path's
+# member check, or creating a member would start answering 404.
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary $'NEW MEMBER\n' \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(NEWMBR)")
+assert_http_status "204" "$HTTP_CODE" "create a new member in an existing PDS"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(NEWMBR)")
+assert_http_status "204" "$HTTP_CODE" "delete the member just created"
+
 # --- Long DSN(member) name validation (Issue #133) ---
 # DSN <=44 and member <=8 are individually valid even when combined they exceed 44.
 # A 36-char DSN + 8-char member = 36+1+8+1=46 chars qualified: previously false 400, now passes guard.

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -620,15 +620,29 @@ assert_json_field "$BODY" '.reason' "4" "member of missing PDS: reason 4 (datase
 # asking for a member of a data set that is not partitioned. __listpd() reads
 # the directory with BPAM and abends S001 on a sequential data set, so this
 # used to come back as the router's abend-recovery 500.
-RESP=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
-	"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}(M1)")
-HTTP_CODE=$(echo "$RESP" | tail -1)
-BODY=$(echo "$RESP" | sed '$d')
-assert_http_status "400" "$HTTP_CODE" "read a member of a sequential dataset"
-if echo "$BODY" | grep -q "abend"; then
-	fail "member of sequential dataset must not abend" "abend recovery response"
+# Self-contained: TEST_SEQ has already been deleted by the delete tests at
+# this point, and a missing data set would answer 404 instead of 400.
+PROBE_SEQ="${MVSMF_USER}.CURL.NOTPDS"
+curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${PROBE_SEQ}" >/dev/null 2>&1 || true
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X POST -u "$AUTH" -H "Content-Type: application/json" \
+	-d '{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":800,"alcunit":"TRK","primary":1}' \
+	"${BASE_URL}/zosmf/restfiles/ds/${PROBE_SEQ}")
+
+if [ "$HTTP_CODE" = "201" ]; then
+	RESP=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${PROBE_SEQ}(M1)")
+	HTTP_CODE=$(echo "$RESP" | tail -1)
+	BODY=$(echo "$RESP" | sed '$d')
+	assert_http_status "400" "$HTTP_CODE" "read a member of a sequential dataset"
+	if echo "$BODY" | grep -q "abend"; then
+		fail "member of sequential dataset must not abend" "abend recovery response"
+	else
+		pass "member of sequential dataset does not abend"
+	fi
+	curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${PROBE_SEQ}" >/dev/null 2>&1 || true
 else
-	pass "member of sequential dataset does not abend"
+	skip "member of a sequential dataset (could not create ${PROBE_SEQ})"
 fi
 
 # writing into a dataset that does not exist. fopen("w") auto-allocates an


### PR DESCRIPTION
Fixes #191.

`fopen()` meldet nur `NULL`, also hatten die Handler nichts in der Hand und meldeten jeden fehlgeschlagenen Open als I/O-Fehler 500. Ein Member, der schlicht nicht im Directory stand, war von einem kaputten Server nicht zu unterscheiden — und 500 lädt zu einem Retry ein, der nie gelingen kann.

Zwei günstige Primitive klären es, beide in dieser Datei schon in Gebrauch: `__locate()` ist ein Katalog-Lookup, und `__listpd()` prüft seinen Filter mit `__patmat()` **vor** der Allokation. Der exakte Membername liest also das Directory, baut aber höchstens einen Eintrag statt einer kompletten Memberliste. Membernamen können keine Pattern-Zeichen enthalten, der Treffer ist exakt.

| Fall | vorher | jetzt |
|---|---|---|
| Dataset nicht katalogisiert | 500 | **404**, reason 4 |
| Dataset da, Member fehlt | 500 | **404**, reason 5 |
| Member eines Nicht-PDS | 500 | **400** |
| sonst | 500 | 500 |

## Erweiterter Scope, begründet

Die Issue fragte nur nach dem Member-Read. Ich habe nachgemessen, dass derselbe Defekt auch im sequentiellen Read und im Member-Write sitzt — alle drei antworteten 500 auf etwas, das lediglich fehlte. Nur einen zu fixen hätte die API inkonsistent gelassen (GET eines fehlenden SEQ-Datasets weiter 500, GET eines fehlenden Members 404), deshalb laufen alle drei durch einen Helper.

## Zwei Defekte, die erst der Test auf dem Zielsystem gezeigt hat

**Der erste Anlauf baute einen Abend ein.** `__listpd()` liest das Directory mit BPAM und abendet **S001**, wenn das Dataset nicht partitioniert ist. Jeden fehlgeschlagenen Open dorthin zu routen machte `GET /ds/{SEQ-Dataset}(MEMBER)` zum Handler-Abend — schlechter als die 500, die ersetzt werden sollte. Jetzt prüft das vorhandene `is_pds()` den DSCB, bevor das Directory angefasst wird.

> Derselbe Abend ist unabhängig davon über `memberListHandler()` erreichbar (`GET /ds/{SEQ-Dataset}/member`) und war es schon vorher. Das ist nicht Teil dieser Änderung und in **#193** festgehalten.

**Der Write-Pfad brauchte den Check vor dem Open, nicht danach.** `fopen("w")` auf einen nicht katalogisierten Namen legt ihn automatisch an, mit falschem DCB: ein `PUT` auf einen Member eines fehlenden PDS hinterließ ein `RECFM=V`-Sequenzdataset und antwortete dann 500 — exakt der Defekt aus #65, der den sequentiellen Pfad behoben hat, diesen aber nie. Nachträglich diagnostizieren geht prinzipiell nicht: da existiert das Dataset schon und der Katalog findet es. Der Vorab-Check des sequentiellen Pfads ist hier gespiegelt.

Der Write-Pfad übergibt bewusst `member = NULL` — ein noch nicht existierender Member *ist* ein Create. Der Test sichert das explizit ab, sonst hätte der Write-Pfad den Member-Check des Read-Pfads geerbt.

## Verifiziert auf mvsdev.lan

Rote Baseline vor der Aktivierung, gleiche Aufrufe danach:

```
vorher:  GET fehlendes SEQ -> 500 | GET fehlendes PDS(M) -> 500 | GET SEQ(M) -> 500 | PUT fehlendes PDS(M) -> 500 + Dataset angelegt
nachher: 404 reason 4        | 404 reason 4              | 400              | 404, nichts angelegt
```

`tests/curl-datasets.sh` geht von **55 passed / 1 failed** auf **68 passed / 0 failed** (12 neue Assertions). Alle Suites: jobs 71/0, datasets 68/0, binary 10/0, console 61/61, uss 64/0, auth 14/14 — **288 passed, 0 failed, 2 skipped**.

## Nebenbefund

`__listpd()` ruft `calloc` zweimal auf denselben Pointer (`@@listpd.c:48-49`), verliert also einen Block pro Directory-Eintrag. Gemeldet als mvslovers/libc370#34; dieser Fix ruft `__listpd` einmal pro fehlgeschlagenem Open, verliert also bis dahin einen kleinen Block je Fehlerfall.

## Doku

`get.md`, `members-get.md` und `members-put.md` führten alle drei „HTTP 500 — Dataset or member not found", hielten den Defekt also schriftlich fest; korrigiert.

https://claude.ai/code/session_019ibLZobVRy47xfNgEKxpS2