### PR TITLE
fix: check the target is a PDS before reading its directory

### DIFF
--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -36,8 +36,19 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
 ```
 
 ## Error Responses
+- HTTP 400 (Bad Request)
+    - The dataset is not partitioned (use the dataset endpoint instead)
+- HTTP 404 (Not Found)
+    - Dataset not cataloged (`reason` 4)
 - HTTP 500 (Internal Server Error)
-    - Dataset not found or not a PDS
+    - I/O error while reading the directory
+
+The target is checked against the catalog and the DSCB before the directory is
+read. `__listpd()` reads it with BPAM, and against a data set that is not
+partitioned that is an S001 abend rather than an error return — so the check
+has to happen first (issue #193). A dataset that was not cataloged used to be
+answered with an empty `items` list and 200, which reads as "this PDS has no
+members".
 
 ## Limitations
 - No member statistics (TTR, size, dates) are returned yet

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -316,20 +316,20 @@ is_pds(const char *dsname)
 #define OPEN_FAIL_NOMEM   2     /* the data set has no such member        */
 #define OPEN_FAIL_NOTPDS  3     /* a member was asked of a non-PDS        */
 
-__asm__("\n&FUNC    SETC 'diagnose_open_failure'");
+/* Is the data set in the catalog? __locate() wants a blank-padded 44-byte
+   name, which is the only reason this is a function and not a call. */
+__asm__("\n&FUNC    SETC 'dataset_cataloged'");
 static int
-diagnose_open_failure(const char *dsname, const char *member)
+dataset_cataloged(const char *dsname)
 {
-    LOCWORK  locwork;
-    PDSLIST  **pdslist;
-    char     dsn44[44];
-    size_t   len;
+    LOCWORK locwork;
+    char    dsn44[44];
+    size_t  len;
 
     if (!dsname) {
-        return OPEN_FAIL_IO;
+        return 0;
     }
 
-    /* __locate() wants a blank-padded 44-byte name */
     len = strlen(dsname);
     if (len > sizeof(dsn44)) {
         len = sizeof(dsn44);
@@ -338,7 +338,21 @@ diagnose_open_failure(const char *dsname, const char *member)
     memcpy(dsn44, dsname, len);
 
     memset(&locwork, 0, sizeof(locwork));
-    if (__locate(dsn44, &locwork) != 0) {
+
+    return __locate(dsn44, &locwork) == 0;
+}
+
+__asm__("\n&FUNC    SETC 'diagnose_open_failure'");
+static int
+diagnose_open_failure(const char *dsname, const char *member)
+{
+    PDSLIST  **pdslist;
+
+    if (!dsname) {
+        return OPEN_FAIL_IO;
+    }
+
+    if (!dataset_cataloged(dsname)) {
         return OPEN_FAIL_NODSN;
     }
 
@@ -385,6 +399,39 @@ send_open_failure(Session *session, const char *dsname, const char *member,
     }
 
     return handle_error(session, ERR_IO, io_message);
+}
+
+/*
+ * Pre-flight for a directory read (issue #193).
+ *
+ * __listpd() opens the data set and reads its directory with BPAM. Against a
+ * data set that is not partitioned that is an S001 abend, not a NULL return -
+ * so the DSCB has to be checked before the call, not the result after it.
+ * Without this, GET .../{sequential-dataset}/member abends the handler and the
+ * client is answered by the router's ESTAE recovery.
+ *
+ * Returns 0 when the caller may go ahead; otherwise the response has already
+ * been sent.
+ */
+__asm__("\n&FUNC    SETC 'require_pds'");
+static int
+require_pds(Session *session, const char *dsname)
+{
+    if (!dataset_cataloged(dsname)) {
+        sendErrorResponse(session, HTTP_STATUS_NOT_FOUND, CATEGORY_SERVICE,
+            RC_ERROR, REASON_DATASET_NOT_FOUND, ERR_MSG_DATASET_NOT_FOUND,
+            NULL, 0);
+        return -1;
+    }
+
+    if (!is_pds(dsname)) {
+        /* mirror of the "dataset is a PDS, use the member endpoint" 400 */
+        handle_error(session, ERR_INVALID_PARAM,
+            "Dataset is not partitioned (use the dataset endpoint instead)");
+        return -1;
+    }
+
+    return 0;
 }
 
 // Helper function to parse X-IBM-Data-Type header
@@ -1286,6 +1333,11 @@ int memberListHandler(Session *session)
 	start 	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_START"); 
 	pattern = (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_PATTERN"); 
 
+	/* __listpd() abends S001 on a data set that is not partitioned (#193) */
+	if (require_pds(session, dsname) != 0) {
+		goto quit;
+	}
+
 	pdslist = __listpd(dsname, NULL);
 
 	session->headers_sent = 1;
@@ -1474,23 +1526,10 @@ int memberPutHandler(Session *session)
        set behind and then answer 500. Checking afterwards cannot help; by then
        the data set exists. A member that does not exist yet is fine - that is
        what a create looks like. */
-    {
-        LOCWORK locwork;
-        char    dsn44[44];
-        size_t  len = strlen(dsname);
-
-        if (len > sizeof(dsn44)) {
-            len = sizeof(dsn44);
-        }
-        memset(dsn44, ' ', sizeof(dsn44));
-        memcpy(dsn44, dsname, len);
-        memset(&locwork, 0, sizeof(locwork));
-
-        if (__locate(dsn44, &locwork) != 0) {
-            return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
-                CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_NOT_FOUND,
-                ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
-        }
+    if (!dataset_cataloged(dsname)) {
+        return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+            CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_NOT_FOUND,
+            ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
     }
 
     fp = fopen(dataset, member_mode);

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -447,6 +447,44 @@ CONTENT=$(echo "$BODY" | sed '$d')
 assert_http_status "200" "$HTTP_CODE" "list PDS members"
 assert_json_field_exists "$CONTENT" '.items[0].member' "member list has member field"
 
+# --- List members: the target must actually be a PDS (issue #193) ---
+# __listpd() reads the directory with BPAM and abends S001 on a sequential
+# data set, so this used to be answered by the router's abend recovery. A
+# data set that is not cataloged at all used to come back as an empty 200,
+# which reads as "this PDS has no members".
+echo ""
+echo "--- List PDS Members: wrong or missing target (issue #193) ---"
+
+LIST_SEQ="${MVSMF_USER}.CURL.LISTSEQ"
+curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIST_SEQ}" >/dev/null 2>&1 || true
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X POST -u "$AUTH" -H "Content-Type: application/json" \
+	-d '{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":800,"alcunit":"TRK","primary":1}' \
+	"${BASE_URL}/zosmf/restfiles/ds/${LIST_SEQ}")
+
+if [ "$HTTP_CODE" = "201" ]; then
+	BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${LIST_SEQ}/member")
+	HTTP_CODE=$(echo "$BODY" | tail -1)
+	CONTENT=$(echo "$BODY" | sed '$d')
+	assert_http_status "400" "$HTTP_CODE" "list members of a sequential dataset"
+	if echo "$CONTENT" | grep -q "abend"; then
+		fail "list members of a sequential dataset must not abend" "abend recovery response"
+	else
+		pass "list members of a sequential dataset does not abend"
+	fi
+	curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIST_SEQ}" >/dev/null 2>&1 || true
+else
+	skip "list members of a sequential dataset (could not create ${LIST_SEQ})"
+fi
+
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.NOSUCH.LISTPDS/member")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "404" "$HTTP_CODE" "list members of a missing dataset"
+assert_json_field "$CONTENT" '.reason' "4" "missing dataset: reason 4 (dataset not found)"
+
 # --- List PDS members with volume prefix ---
 echo ""
 echo "--- List PDS Members with Volume Prefix ---"


### PR DESCRIPTION
Fixes #193.

`GET /zosmf/restfiles/ds/{sequential-dataset}/member` **abendete den Handler**. `memberListHandler()` reichte durch, was es bekam, an `__listpd()` — und das öffnet den Datensatz und liest das Directory mit BPAM. Gegen einen nicht partitionierten Datensatz ist das ein **S001-Abend**, kein NULL-Return. Der Client wurde von der ESTAE-Recovery des Routers beantwortet, und es kostete einen Dump. Reproduzierbar auf einem frisch angelegten `DSORG=PS`-Datensatz, es braucht also keinen ungewöhnlichen Zustand.

## Zweiter Defekt, beim Messen gefunden

Dieselbe Stelle akzeptierte auch einen gar nicht katalogisierten Namen und antwortete mit leerer `items`-Liste und **200** — das liest sich wie „dieses PDS hat keine Member" statt „das gibt es nicht".

```
vorher:  GET /ds/{SEQ}/member      -> Abend (reason 99, ESTAE-Recovery)
         GET /ds/{fehlend}/member  -> 200, items: []
nachher: GET /ds/{SEQ}/member      -> 400 "Dataset is not partitioned (use the dataset endpoint instead)"
         GET /ds/{fehlend}/member  -> 404, reason 4
```

`require_pds()` prüft Katalog und DSCB, bevor das Directory angefasst wird. Die 400 ist das Spiegelbild der bereits existierenden „dataset is a PDS, use the member endpoint instead" aus `datasetGetHandler` für den umgekehrten Fehler.

## Aufräumen

Der Katalog-Lookup lag nach #191 in drei Kopien vor (`diagnose_open_failure`, der Vorab-Check im Member-Write, und jetzt dieser) — zu `dataset_cataloged()` zusammengefasst. Gleiche Datei, gleiche Sache, deshalb hier statt als eigener Cleanup.

## Verifiziert auf mvsdev.lan

Rote Baseline vor der Aktivierung, gleiche Aufrufe danach; zusätzlich als Regression, dass ein echtes PDS weiter listet (`["M1      "]`, HTTP 200).

`tests/curl-datasets.sh` geht von 68 auf **72 passed / 0 failed**.

## Hinweis zum Suite-Lauf

`curl-console.sh` meldete im Gesamtlauf zweimal 59/61; die beiden Failures sind die Detection-Tests. Sie sind **nicht** von dieser Änderung — `consapi.c` ist unberührt, und die Flakiness reproduziert sich mit einem Handprobe ohne jeden Dataset-Endpunkt. Als **#195** mit Messdaten festgehalten. Isoliert läuft die Console-Suite 61/61.

Gesamtstand: jobs 71/0, datasets 72/0, binary 10/0, uss 64/0, auth 14/14, console 61/61 (isoliert).

https://claude.ai/code/session_019ibLZobVRy47xfNgEKxpS2