### PR TITLE
fix(jobsapi): take the callback stop from JESPRST, not jesprint()'s rc

### DIFF
--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -567,8 +567,10 @@ __asm__("\n&FUNC	SETC 'do_print_sysout_why'");
 static const char *
 do_print_sysout_why(int prc, const JESPRST *st, unsigned records)
 {
-	/* jesprint() rejected the request before the walk started; a completed
-	   walk returns 0 or the callback's negative rc, never a positive one */
+	/* jesprint() rejected the request before the walk started: since libc370
+	   #26 its rc is a status and nothing else - 0 when the walk ran, 404 for
+	   an unknown dsid, 503 when JES2 is unusable.  Why a walk that DID run
+	   ended is st->reason, below.                                          */
 	if (prc > 0) {
 		return "JES2 checkpoint or spool data set not available";
 	}
@@ -713,13 +715,20 @@ do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 
 		prc = jesprint(jes, job, dd->dsid, do_print_sysout_line, &ctx, &st);
 
-		if (prc == RC_SPOOL_CAP) {
-			prc = 0;	/* cap reached - normal end of dataset */
+		/* Since libc370 #26 prc is a status (0/404/503) and no longer carries
+		   the print callback's rc: a callback that stopped the walk arrives as
+		   JESPR_STOPPED with its own rc in st.prtrc.  RC_SPOOL_CAP is our
+		   sentinel for "capped at the PDDB record count", which is a normal
+		   end of the data set - anything else means the callback gave up.
+		   Reading st also works against a pre-#26 libc370, which additionally
+		   returned that rc in prc.                                          */
+		if (st.reason == JESPR_STOPPED && st.prtrc != RC_SPOOL_CAP) {
+			/* the callback gave up: the socket is gone, nothing to answer */
+			rc = st.prtrc;
+			goto quit;
 		}
 		if (prc < 0) {
-			/* the callback gave up: the socket is gone, nothing to answer */
-			rc = prc;
-			goto quit;
+			prc = 0;	/* pre-#26 libc370: the callback's rc, handled above */
 		}
 
 		/* remember the first abnormal outcome; it decides the status only if


### PR DESCRIPTION
Adapts the SYSOUT endpoint to **libc370 #26**, which makes `jesprint()`'s return value a status and nothing else (`0` / `404` / `503`). It no longer carries the print callback's rc.

Two things here read that rc and would have stopped working **silently** — the signature is unchanged, so this compiles either way:

| what | before | now |
|------|--------|-----|
| `RC_SPOOL_CAP` (our sentinel for "SYSIN capped at the PDDB record count") | came back in `prc` | `st.reason == JESPR_STOPPED && st.prtrc == RC_SPOOL_CAP` |
| callback gave up, socket gone | `prc < 0` | `st.reason == JESPR_STOPPED`, rc in `st.prtrc` |

Without this, a capped SYSIN data set would print the JES2 deletion line it is supposed to hide, and a dead socket would no longer abort the walk — with green CI in both cases.

### Merge order

**This can merge first.** `JESPRST` has carried `reason`/`prtrc` since libc370 PR #31, so reading `st` is correct against today's libc370 *and* against #26. Not a flag day.

Upstream: mvslovers/libc370#26 (PR mvslovers/libc370#40).

### Verified

`make` green against both the pre-#26 libc370 in the sysroot and the #26 build. Behaviour itself is on-target only — `jesprint()` reaches the JES2 spool through BDAM.