### PR TITLE
fix(dsapi): stop writing a console message for every dataset operation

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -2108,8 +2108,6 @@ int datasetCreateHandler(Session *session)
 		dsname, dsorg, recfm, lrecl, blksize,
 		alcunit, primary, secondary, dirblk);
 
-	wtof("MVSMF63I Dataset create: %s", opts);
-
 	/* Allocate the dataset */
 	rc = __dsalcf(ddname, "%s", opts);
 	if (rc != 0) {
@@ -2168,8 +2166,6 @@ int datasetDeleteHandler(Session *session)
 			ERR_MSG_DATASET_ALLOC_FAILED, NULL, 0);
 	}
 
-	wtof("MVSMF73I Dataset deleted: %s", dsname);
-
 	/* Send HTTP 204 No Content */
 	rc = sendDefaultHeaders(session, 204, "application/json", 0);
 
@@ -2221,8 +2217,6 @@ int memberDeleteHandler(Session *session)
 			CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_ALLOC_FAILED,
 			ERR_MSG_DATASET_ALLOC_FAILED, NULL, 0);
 	}
-
-	wtof("MVSMF77I Member deleted: %s", dataset);
 
 	/* Send HTTP 204 No Content */
 	rc = sendDefaultHeaders(session, 204, "application/json", 0);


### PR DESCRIPTION
Removes the three per-operation informational WTOs in `dsapi.c`:

| ID | Text |
|----|------|
| `MVSMF63I` | `Dataset create: %s` |
| `MVSMF73I` | `Dataset deleted: %s` |
| `MVSMF77I` | `Member deleted: %s` |

None of them is actionable for an operator — the client already gets the HTTP response. `MVSMF63I` additionally echoed the full `__dsalcf()` option string (`DSN=…;DISP=…;DSORG=…;RECFM=…;LRECL=…;BLKSIZE=…;SPACE=…`) and wrapped across two console lines.

They also polluted mvsMF's own console API: `consapi.c` reads the Master Trace Table, so every WTO mvsMF writes reappears in `/zosmf/restconsoles/.../solmsgs` and hardcopy-log responses.

Kept deliberately:

- the matching error messages `MVSMF64E`, `MVSMF72E`, `MVSMF76E` — those report real failures
- `MVSMF30I JOB %s(%s) SUBMITTED` (`jobsapi.c`) — a job submission is a system-wide event that belongs on the console

## Verification

`make` builds clean (`[cc370] src/dsapi.c` → `[ld370] MVSMF`). No behaviour change on the wire: no response path, status code or body is touched, so the existing `tests/curl-datasets.sh` / `tests/zowe-datasets.sh` coverage is unaffected. Confirming the quieter console needs a `make deploy` against a live system.

The broader message-catalog rework (colliding IDs, severity policy, uppercase literals) is tracked separately.

Fixes #199

https://claude.ai/code/session_019ibLZobVRy47xfNgEKxpS2