### PR TITLE
test(zowe): make the Zowe suites independent of ambient CLI profile state

### DIFF
--- a/tests/zowe-auth.sh
+++ b/tests/zowe-auth.sh
@@ -57,7 +57,7 @@ fail() {
 # Run a zowe command with JSON output; sets OUTPUT and RC.
 run_zowe_json() {
 	RC=0
-	OUTPUT=$(zowe "$@" --rfj 2>&1) || RC=$?
+	OUTPUT=$(zowe "$@" --rfj 2>&1 </dev/null) || RC=$?
 }
 
 assert_rc() {

--- a/tests/zowe-binary.sh
+++ b/tests/zowe-binary.sh
@@ -34,9 +34,34 @@ fi
 
 # Tell Zowe to use our local config
 export ZOWE_CLI_HOME="$CONFIG_DIR"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
 
-# Extract user from config for dataset naming
-MVS_USER=$(jq -r '.profiles.mvsmf.properties.user' "$CONFIG_FILE")
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+MVS_USER="${MVSMF_USER:-}"
+if [ -z "$MVS_USER" ]; then
+	echo "ERROR: MVSMF_USER is not set in ${ENV_FILE}."
+	echo "  Without it every data set name is built from an empty prefix and the"
+	echo "  suite silently works on the wrong HLQ. Refusing to run. See issue #204."
+	exit 1
+fi
+
+# Every connection option goes on every invocation. A Zowe base profile is
+# merged into each command and overrides host and credentials silently --
+# passing --user/--password alone is not enough, the request still goes to
+# the base profile's host and comes back 401. See issue #204.
+ZOWE_CONN=(--host "$MVSMF_HOST" --port "$MVSMF_PORT"
+	--protocol "${MVSMF_PROTOCOL:-http}"
+	--user "$MVS_USER" --password "$MVSMF_PASS"
+	--reject-unauthorized false)
 
 # Test dataset names
 TEST_SEQ="${MVS_USER}.ZOWE.TESTBIN"
@@ -81,7 +106,7 @@ skip() {
 run_zowe() {
 	local output
 	local rc=0
-	output=$(zowe "$@" 2>&1) || rc=$?
+	output=$(zowe "$@" "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
 }
@@ -102,8 +127,8 @@ assert_rc() {
 # =========================================================================
 
 cleanup_datasets() {
-	zowe files delete ds "$TEST_SEQ" -f >/dev/null 2>&1 || true
-	zowe files delete ds "$TEST_PDS" -f >/dev/null 2>&1 || true
+	run_zowe files delete ds "$TEST_SEQ" -f >/dev/null 2>&1 || true
+	run_zowe files delete ds "$TEST_PDS" -f >/dev/null 2>&1 || true
 }
 
 # =========================================================================

--- a/tests/zowe-console.sh
+++ b/tests/zowe-console.sh
@@ -16,6 +16,37 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+MVS_USER="${MVSMF_USER:-}"
+if [ -z "$MVS_USER" ]; then
+	echo "ERROR: MVSMF_USER is not set in ${ENV_FILE}."
+	echo "  Without it every data set name is built from an empty prefix and the"
+	echo "  suite silently works on the wrong HLQ. Refusing to run. See issue #204."
+	exit 1
+fi
+
+# Every connection option goes on every invocation. A Zowe base profile is
+# merged into each command and overrides host and credentials silently --
+# passing --user/--password alone is not enough, the request still goes to
+# the base profile's host and comes back 401. See issue #204.
+ZOWE_CONN=(--host "$MVSMF_HOST" --port "$MVSMF_PORT"
+	--protocol "${MVSMF_PROTOCOL:-http}"
+	--user "$MVS_USER" --password "$MVSMF_PASS"
+	--reject-unauthorized false)
+
+
 # --- state ---
 PASSED=0
 FAILED=0
@@ -31,7 +62,7 @@ fail() {
 # Run a zowe command with JSON output; sets OUTPUT and RC.
 run_zowe_json() {
 	RC=0
-	OUTPUT=$(zowe "$@" --rfj 2>&1) || RC=$?
+	OUTPUT=$(zowe "$@" --rfj "${ZOWE_CONN[@]}" 2>&1 </dev/null) || RC=$?
 }
 
 assert_rc() {

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -28,9 +28,34 @@ fi
 
 # Tell Zowe to use our local config
 export ZOWE_CLI_HOME="$CONFIG_DIR"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
 
-# Extract user from config for dataset naming
-MVS_USER=$(jq -r '.profiles.mvsmf.properties.user' "$CONFIG_FILE")
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+MVS_USER="${MVSMF_USER:-}"
+if [ -z "$MVS_USER" ]; then
+	echo "ERROR: MVSMF_USER is not set in ${ENV_FILE}."
+	echo "  Without it every data set name is built from an empty prefix and the"
+	echo "  suite silently works on the wrong HLQ. Refusing to run. See issue #204."
+	exit 1
+fi
+
+# Every connection option goes on every invocation. A Zowe base profile is
+# merged into each command and overrides host and credentials silently --
+# passing --user/--password alone is not enough, the request still goes to
+# the base profile's host and comes back 401. See issue #204.
+ZOWE_CONN=(--host "$MVSMF_HOST" --port "$MVSMF_PORT"
+	--protocol "${MVSMF_PROTOCOL:-http}"
+	--user "$MVS_USER" --password "$MVSMF_PASS"
+	--reject-unauthorized false)
 
 # Test dataset names
 TEST_SEQ="${MVS_USER}.ZOWE.TESTSEQ"
@@ -74,7 +99,7 @@ skip() {
 run_zowe() {
 	local output
 	local rc=0
-	output=$(zowe "$@" 2>&1) || rc=$?
+	output=$(zowe "$@" "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
 }
@@ -83,7 +108,7 @@ run_zowe() {
 run_zowe_json() {
 	local output
 	local rc=0
-	output=$(zowe "$@" --rfj 2>&1) || rc=$?
+	output=$(zowe "$@" --rfj "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
 }
@@ -131,9 +156,9 @@ assert_json_field_exists() {
 # =========================================================================
 
 cleanup_datasets() {
-	zowe files delete ds "$TEST_SEQ" -f >/dev/null 2>&1 || true
-	zowe files delete ds "$TEST_SEQ2" -f >/dev/null 2>&1 || true
-	zowe files delete ds "$TEST_PDS" -f >/dev/null 2>&1 || true
+	run_zowe files delete ds "$TEST_SEQ" -f >/dev/null 2>&1 || true
+	run_zowe files delete ds "$TEST_SEQ2" -f >/dev/null 2>&1 || true
+	run_zowe files delete ds "$TEST_PDS" -f >/dev/null 2>&1 || true
 }
 
 # =========================================================================

--- a/tests/zowe-jobs.sh
+++ b/tests/zowe-jobs.sh
@@ -37,9 +37,34 @@ fi
 
 # Tell Zowe to use our local config
 export ZOWE_CLI_HOME="$CONFIG_DIR"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
 
-# Extract user from config for dataset naming
-MVS_USER=$(jq -r '.profiles.mvsmf.properties.user' "$CONFIG_FILE")
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+MVS_USER="${MVSMF_USER:-}"
+if [ -z "$MVS_USER" ]; then
+	echo "ERROR: MVSMF_USER is not set in ${ENV_FILE}."
+	echo "  Without it every data set name is built from an empty prefix and the"
+	echo "  suite silently works on the wrong HLQ. Refusing to run. See issue #204."
+	exit 1
+fi
+
+# Every connection option goes on every invocation. A Zowe base profile is
+# merged into each command and overrides host and credentials silently --
+# passing --user/--password alone is not enough, the request still goes to
+# the base profile's host and comes back 401. See issue #204.
+ZOWE_CONN=(--host "$MVSMF_HOST" --port "$MVSMF_PORT"
+	--protocol "${MVSMF_PROTOCOL:-http}"
+	--user "$MVS_USER" --password "$MVSMF_PASS"
+	--reject-unauthorized false)
 TEST_PDS="${MVS_USER}.MVSMF.TESTJCL"
 
 # --- state ---
@@ -89,7 +114,7 @@ skip() {
 run_zowe() {
 	local output
 	local rc=0
-	output=$(zowe "$@" 2>&1) || rc=$?
+	output=$(zowe "$@" "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
 }
@@ -98,7 +123,7 @@ run_zowe() {
 run_zowe_json() {
 	local output
 	local rc=0
-	output=$(zowe "$@" --rfj 2>&1) || rc=$?
+	output=$(zowe "$@" --rfj "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
 }

--- a/tests/zowe-uss.sh
+++ b/tests/zowe-uss.sh
@@ -22,6 +22,35 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+MVS_USER="${MVSMF_USER:-}"
+if [ -z "$MVS_USER" ]; then
+	echo "ERROR: MVSMF_USER is not set in ${ENV_FILE}."
+	echo "  Without it every data set name is built from an empty prefix and the"
+	echo "  suite silently works on the wrong HLQ. Refusing to run. See issue #204."
+	exit 1
+fi
+
+# Every connection option goes on every invocation. A Zowe base profile is
+# merged into each command and overrides host and credentials silently --
+# passing --user/--password alone is not enough, the request still goes to
+# the base profile's host and comes back 401. See issue #204.
+ZOWE_CONN=(--host "$MVSMF_HOST" --port "$MVSMF_PORT"
+	--protocol "${MVSMF_PROTOCOL:-http}"
+	--user "$MVS_USER" --password "$MVSMF_PASS"
+	--reject-unauthorized false)
+
 # CONFIG_DIR="${SCRIPT_DIR}/.config"
 # CONFIG_FILE="${CONFIG_DIR}/zowe.config.json"
 #
@@ -73,7 +102,7 @@ skip() {
 run_zowe() {
 	local output
 	local rc=0
-	output=$(zowe "$@" 2>&1) || rc=$?
+	output=$(zowe "$@" "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
 }
@@ -82,7 +111,7 @@ run_zowe() {
 run_zowe_json() {
 	local output
 	local rc=0
-	output=$(zowe "$@" --rfj 2>&1) || rc=$?
+	output=$(zowe "$@" --rfj "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
 }
@@ -103,7 +132,7 @@ assert_rc() {
 # =========================================================================
 
 cleanup_uss() {
-	zowe files delete uss-file "${TEST_DIR}" -r -f >/dev/null 2>&1 || true
+	run_zowe files delete uss-file "${TEST_DIR}" -r -f >/dev/null 2>&1 || true
 }
 
 # =========================================================================


### PR DESCRIPTION
The Zowe suites inherited whatever profile happened to be configured on the machine, and when that profile was wrong they did not fail — they hung. All six now take their connection from `.env` and pass it explicitly.

Found while verifying #198 on a live system: `tests/curl-*.sh` ran fine against the same target with the same credentials, the Zowe suites did not.

## The three defects

**Wrong HLQ, silently.** The user id came out of the config JSON via `jq '.profiles.mvsmf.properties.user'`. A profile that keeps credentials in the OS store declares `"secure": ["user","password"]` and has no `user` key there at all, so `jq` yielded the string `null` — every data set name became `null.ZOWE.TESTSEQ`. One run spent 29 minutes on the `NULL` high-level qualifier and printed nothing but its banner.

**Five-minute hangs on an invisible prompt.** With no usable credentials the CLI falls back to interactive input (`Enter the user name for your service`). Nothing is attached to stdin in a suite run, so every command sat there until it timed out.

**A base profile overriding the connection.** `defaults.base` is merged into every command and silently replaces host and credentials. `--user`/`--password` alone did not help — the request still went to the base profile's host and returned 401. Confirmed by elimination: the same credentials give HTTP 200 over curl, and the Zowe command only succeeds when *all* connection options are overridden.

## The change

`.env` is already the single source of truth for the curl suites; the Zowe suites now use it the same way.

- connection resolved from `.env`, passed explicitly on every invocation via the central `run_zowe` / `run_zowe_json` helpers
- refuse to start when the user id cannot be resolved, rather than building names from `null`
- stdin redirected from `/dev/null` so a credential prompt fails immediately instead of hanging
- cleanup functions called `zowe` directly, bypassing the helpers — they go through them now, which is what let the old cleanup phase hang for ten minutes

## Verified on a live target

| Suite | Before | After |
|---|---|---|
| `zowe-datasets.sh` | never completed | **38/38** |
| `zowe-jobs.sh` | never completed | **34/34** (1 skip) |
| `zowe-uss.sh` | never completed | **23/23** |
| `zowe-binary.sh` | never completed | **10/10** |
| `zowe-console.sh` | never completed | **9/9** |

This also gives #198 its second client: the large-LRECL test in `zowe-datasets.sh` now actually runs, and passes.

## zowe-auth.sh is left almost untouched

It gets the stdin guard only. It passes credentials per command because authentication is what it tests, and it has **three pre-existing failures** unrelated to this work: `zowe auth login zosmf` rejects every connection flag with `Unknown arguments: host, port, reject-unauthorized, user, password, show-token, zosmf`. Reproduced identically by stashing this change and re-running, so it is not a regression. I did not add `--protocol` there — adding another flag to a command that demonstrably rejects flags is the wrong direction. Worth its own ticket.

No mvsMF code is touched; this is purely test harness.

Fixes #204

https://claude.ai/code/session_019ibLZobVRy47xfNgEKxpS2