### PR TITLE
feat(jobsapi): report job execution timestamps as ISO 8601 UTC

### DIFF
--- a/docs/endpoints/jobs/list.md
+++ b/docs/endpoints/jobs/list.md
@@ -14,6 +14,7 @@ GET
 - `jobid` (optional): Filter by specific job ID.
 - `status` (optional): Filter by job status (`INPUT`, `ACTIVE`, `OUTPUT`). Use `*` for all.
 - `max-jobs` (optional): Maximum number of jobs to return (1-1000). Default: 1000.
+- `exec-data` (optional): `Y` adds the execution timestamps to each job object. Any other value (or omitting the parameter) returns the object unchanged. The Zowe CLI sends `exec-data=Y` for `zowe jobs list jobs --exec-data`.
 
 ## Response
 On successful completion, this request returns HTTP status code 200 (OK) and a JSON array of job objects:
@@ -33,6 +34,49 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
         "retcode": "CC nnnn|ABEND Sxxx|ABEND Unnnn|JCL ERROR|null"
     }
 ]
+```
+
+With `exec-data=Y`, two further fields follow `retcode`:
+
+```json
+        "exec-started": "2026-08-07T18:57:10.000Z",
+        "exec-ended": "2026-08-07T18:57:10.000Z"
+```
+
+See [Execution timestamps](#execution-timestamps).
+
+## Execution timestamps
+
+`exec-started` and `exec-ended` are ISO 8601 instants in **UTC**, with a
+millisecond fraction and a literal `Z` — the format real z/OSMF uses. JES2
+records these with second resolution, so the fraction is always `.000`; z/OSMF
+itself reports `exec-submitted` the same way, so this is compatible rather than
+a compromise.
+
+A job that has not reached that stage yet returns `null` for the field, not a
+placeholder date. An active job therefore has `exec-started` set and
+`exec-ended` null.
+
+The timestamps are always UTC and never local time: the server cannot know the
+caller's timezone, so a local string would be unlabelled and the client could
+not tell which zone it received. Zowe and browsers localise the instant
+themselves.
+
+**`exec-submitted` is not implemented.** JES2 records it as `JCTRDRON` /
+`JCTRDTON` (time and date on the input processor), which libc370's `JESJOB`
+does not carry — tracked in mvslovers/libc370#79. The field is omitted rather
+than guessed.
+
+`exec-system` and `exec-member` are likewise not implemented (mvslovers/mvsmf#209).
+
+### Cross-check
+
+httpd's `/jes/status` reports the same instants in the same format, so the two
+APIs can be compared directly for a given job:
+
+```bash
+curl -s -u user:pass "http://host:8080/jes/status?jobname=IEFBR14" \
+  | grep -E 'start_display|end_display'
 ```
 
 ## Error Responses
@@ -59,12 +103,16 @@ curl "http://mvs:1080/zosmf/restjobs/jobs?prefix=TEST*"
 
 # List jobs by job ID
 curl "http://mvs:1080/zosmf/restjobs/jobs?jobid=JOB00123"
+
+# List jobs with execution timestamps
+curl "http://mvs:1080/zosmf/restjobs/jobs?prefix=TEST*&exec-data=Y"
 ```
 
 ### Using Zowe CLI
 ```bash
 zowe jobs list jobs
 zowe jobs list jobs --owner "*" --prefix "TEST*"
+zowe jobs list jobs --prefix "TEST*" --exec-data
 ```
 
 ### Success Response

--- a/docs/endpoints/jobs/status.md
+++ b/docs/endpoints/jobs/status.md
@@ -12,6 +12,9 @@ GET
 - `job-name`: Name of the job
 - `jobid`: ID of the job (e.g. JOB00123)
 
+## Query Parameters
+- `exec-data` (optional): `Y` adds `exec-started` and `exec-ended` to the job object, exactly as for [list](list.md#execution-timestamps). Any other value (or omitting the parameter) returns the object unchanged.
+
 ## Response
 On successful completion, this request returns HTTP status code 200 (OK) and a JSON object with the following properties:
 
@@ -29,6 +32,16 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
     "retcode": "CC nnnn|ABEND Sxxx|ABEND Unnnn|JCL ERROR|null"
 }
 ```
+
+With `exec-data=Y`, two further fields follow `retcode`:
+
+```json
+    "exec-started": "2026-08-07T18:57:10.000Z",
+    "exec-ended": "2026-08-07T18:57:10.000Z"
+```
+
+Format, `null` semantics and the missing `exec-submitted` are described under
+[Execution timestamps](list.md#execution-timestamps).
 
 ## Error Responses
 - HTTP 400 (Bad Request)

--- a/docs/endpoints/jobs/submit.md
+++ b/docs/endpoints/jobs/submit.md
@@ -36,6 +36,8 @@ The request body is a JSON object referencing a dataset containing JCL:
 ## Response
 On successful completion, this request returns HTTP status code 200 (OK) and the job status as a JSON object (same format as the [status](status.md) endpoint).
 
+`exec-data=Y` is honoured here too, since the response is built by the same code, but it is of little use: a job that has just been submitted has usually not started yet, so `exec-started` and `exec-ended` are typically `null`. A very short job can already have run by the time the response is built, in which case they carry real instants — do not rely on either outcome.
+
 ## Error Responses
 - HTTP 400 (Bad Request)
     - Invalid internal reader parameters

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -43,6 +43,13 @@
 #define MIN_USER_SYSOUT_DSID 	100
 #define MAX_USER_SYSOUT_DSID 	199
 
+/* an ISO 8601 instant with a millisecond fraction: 2018-11-03T09:05:18.010Z */
+#define EXEC_TIME_STR_SIZE	(24 + 1)
+
+/* libc370 ships __tzget() (src/clib/@@tzget.c) but declares it in no header;
+   httpd carries the same local declaration in src/httpjes2.c. */
+extern int __tzget(void);
+
 //
 // private functions prototypes
 //
@@ -53,7 +60,9 @@ static int  do_print_sysout(Session *session, JESJOB *job, unsigned dsid);
 // needed by jobListHandler
 static void process_job_list_filters(Session *session, const char **filter, JESFILT *jesfilt);
 static unsigned get_max_jobs(Session *session);
-static int  process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *host);
+static int  want_exec_data(Session *session);
+static const char* format_exec_time(const time64_t *t, int tzadjust, char *out, size_t outlen);
+static int  process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *host, int exec_data);
 static JESJOB* find_job_by_name_and_id(Session *session, const char *jobname, const char *jobid, JESJOB ***out_joblist);
 static int process_job_files(Session *session, JESJOB *job, const char *host, JsonBuilder *builder);
 static int validate_intrdr_headers(Session *session);
@@ -131,9 +140,11 @@ jobListHandler(Session *session)
 
 	startArray(builder);
 
+	const int exec_data = want_exec_data(session);
+
 	int ii = 0;
 	for (ii = 0; ii < MIN(max_jobs, array_count(&joblist)); ii++) {
-		rc = process_job(builder, joblist[ii], owner, host);
+		rc = process_job(builder, joblist[ii], owner, host, exec_data);
 		if (rc < 0) {
 			goto quit;
 		}
@@ -845,9 +856,75 @@ should_skip_job(const JESJOB *job, const char *owner)
 	return 0;
 }
 
+/* z/OSMF gates the exec-* fields on exec-data=Y; the Zowe CLI sends exactly
+   that (GET /zosmf/restjobs/jobs?prefix=...&exec-data=Y).  Without it the job
+   object keeps the shape it had before. */
+__asm__("\n&FUNC	SETC 'want_exec_data'");
+static int
+want_exec_data(Session *session)
+{
+	const char *exec_data = getQueryParam(session, "exec-data");
+
+	return (exec_data && (exec_data[0] == 'Y' || exec_data[0] == 'y'));
+}
+
+/* Render a JES2 job timestamp as an ISO 8601 instant in UTC -- the shape real
+   z/OSMF emits, "2018-11-03T09:05:18.010Z".  Returns NULL when the job has no
+   such time yet, so the caller emits JSON null rather than a bogus 1970 date.
+
+   Two things this must not do.  It must not use ctime64()/localtime64(): those
+   convert through crt->crttzoff, the calling task's timezone, which would apply
+   an offset a second time on top of tzadjust and report an instant that is
+   neither UTC nor anyone's local time (mvslovers/httpd#145).  And it must not
+   render local time at all -- the server cannot know the caller's zone, so a
+   local string would be unlabelled and the client could not tell what it got.
+   gmtime64_r() touches no timezone state, which is why the USS mtime timestamps
+   never had this class of bug.
+
+   JES2 keeps its checkpoint times in system local time, so tzadjust carries
+   them to UTC.  Resolution is seconds (time64_t), hence the fixed ".000" --
+   which is what z/OSMF itself reports for exec-submitted. */
+__asm__("\n&FUNC	SETC 'format_exec_time'");
+static const char *
+format_exec_time(const time64_t *t, int tzadjust, char *out, size_t outlen)
+{
+	struct tm	tm;
+	time64_t	utc;
+	int			written;
+
+	if (!t || !out || outlen == 0) {
+		return NULL;
+	}
+
+	/* a job that has not started (or has not ended) carries a zero time */
+	if (__64_cmp_u32((time64_t *)t, 0) == __64_EQUAL) {
+		return NULL;
+	}
+
+	__64_init(&utc);
+	__64_add_i32((time64_t *)t, tzadjust, &utc);
+
+	if (!gmtime64_r(&utc, &tm)) {
+		return NULL;
+	}
+
+	/* snprintf reports truncation with the would-be length, not a negative rc,
+	   so a short buffer would otherwise yield a silently clipped instant that
+	   still looks like a valid string to the caller. */
+	written = snprintf(out, outlen, "%04d-%02d-%02dT%02d:%02d:%02d.000Z",
+			tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+			tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+	if (written < 0 || written >= (int)outlen) {
+		return NULL;
+	}
+
+	return out;
+}
+
 __asm__("\n&FUNC	SETC 'process_job'");
-static int 
-process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *host) 
+static int
+process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *host, int exec_data)
 {
 	int rc = 0;
 
@@ -940,7 +1017,28 @@ process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *ho
 		}
 	}
 	rc = addJsonString(builder, "retcode", retcode);
-	
+
+	if (exec_data) {
+		/* crttzoff is seconds east of UTC (negative west) and UTC = local -
+		   offset, so the addend is the negated offset.  __tzget() reports the
+		   value tzset() resolved for this task from TZ or the system's CVTTZ --
+		   a fact about the machine, not a configured preference.  Kept on the
+		   stack: MVSMF is link-edited RENT, so caching it in a static would
+		   ABEND S0C4 on the write. */
+		int  tzadjust = __tzget() * -1;
+		char exec_time[EXEC_TIME_STR_SIZE];
+
+		/* exec-submitted is deliberately absent: JES2 records it as
+		   JCTRDRON/JCTRDTON (time/date on the input processor), which libc370's
+		   JESJOB does not carry -- see mvslovers/libc370#79. */
+		rc = addJsonString(builder, "exec-started",
+			format_exec_time(&job->start_time64, tzadjust,
+				exec_time, sizeof(exec_time)));
+		rc = addJsonString(builder, "exec-ended",
+			format_exec_time(&job->end_time64, tzadjust,
+				exec_time, sizeof(exec_time)));
+	}
+
 	rc = endJsonObject(builder);
 
 	return rc;
@@ -1489,7 +1587,7 @@ send_job_status_response(Session *session, JESJOB *job, const char *host)
         return -1;
     }
 
-    rc = process_job(builder, job, NULL, host);
+    rc = process_job(builder, job, NULL, host, want_exec_data(session));
     if (rc < 0) {
         freeJsonBuilder(builder);
         return rc;

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -538,6 +538,102 @@ test_list_jobs_with_max() {
 	fi
 }
 
+# An ISO 8601 instant in UTC with a millisecond fraction, the shape z/OSMF uses:
+# 2026-08-07T18:57:10.000Z.  JES2 has second resolution, so .000 is expected.
+assert_iso8601_utc() {
+	local value="$1"
+	local label="$2"
+
+	if [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z$ ]]; then
+		pass "$label ($value)"
+	else
+		fail "$label" "not an ISO 8601 UTC instant: '$value'"
+	fi
+}
+
+test_list_jobs_exec_data() {
+	echo ""
+	echo "--- List Jobs: exec-data ---"
+
+	local resp
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?owner=*&exec-data=Y")
+	split_response "$resp"
+
+	assert_http_status "200" "$HTTP_STATUS" "list jobs exec-data=Y"
+
+	# jq's `all` is true for an empty array, so every has()-assertion below would
+	# pass vacuously on an empty spool.  Anchor them on a non-empty result first.
+	assert_json_array_nonempty "$BODY" "exec-data=Y returned jobs"
+
+	# has_key, not a value test: a job that has not started carries null, which
+	# is a correct answer and must not be confused with the field being absent.
+	assert_json_field "$BODY" '[.[] | has("exec-started")] | all' "true" \
+		"exec-data=Y: every job has exec-started"
+	assert_json_field "$BODY" '[.[] | has("exec-ended")] | all' "true" \
+		"exec-data=Y: every job has exec-ended"
+
+	# any non-null exec-started must be a well-formed UTC instant
+	local started
+	started=$(echo "$BODY" | jq -r '[.[] | .["exec-started"] | select(. != null)] | first // ""' 2>/dev/null)
+	if [ -n "$started" ]; then
+		assert_iso8601_utc "$started" "exec-started format"
+	else
+		skip "exec-started format (no job has started)"
+	fi
+
+	# an ACTIVE job has started but not ended -- exec-ended must be null, not a
+	# placeholder date.
+	#
+	# Count first, and never funnel the value through jq's `//`: that operator
+	# fires on null as well as on absence, so `[null] | first // "none"` yields
+	# "none" and the check would skip itself in exactly the case it exists to
+	# verify.
+	local active_count
+	active_count=$(echo "$BODY" | jq '[.[] | select(.status == "ACTIVE")] | length' 2>/dev/null) || active_count=0
+
+	if [ "$active_count" -eq 0 ] 2>/dev/null; then
+		skip "exec-ended null while active (no ACTIVE job on the system)"
+	else
+		local all_null
+		all_null=$(echo "$BODY" | jq -r \
+			'[.[] | select(.status == "ACTIVE") | .["exec-ended"] == null] | all' 2>/dev/null)
+		if [ "$all_null" = "true" ]; then
+			pass "exec-ended is null for all $active_count ACTIVE job(s)"
+		else
+			fail "exec-ended null while active" \
+				"an ACTIVE job carries a non-null exec-ended"
+		fi
+
+		# the counterpart: an ACTIVE job has started, so exec-started must be set
+		local started_set
+		started_set=$(echo "$BODY" | jq -r \
+			'[.[] | select(.status == "ACTIVE") | .["exec-started"] != null] | all' 2>/dev/null)
+		if [ "$started_set" = "true" ]; then
+			pass "exec-started is set for all $active_count ACTIVE job(s)"
+		else
+			fail "exec-started set while active" \
+				"an ACTIVE job carries a null exec-started"
+		fi
+	fi
+}
+
+test_list_jobs_without_exec_data() {
+	echo ""
+	echo "--- List Jobs: exec-data absent ---"
+
+	local resp
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?owner=*")
+	split_response "$resp"
+
+	assert_http_status "200" "$HTTP_STATUS" "list jobs without exec-data"
+
+	# without the parameter the object keeps its previous shape
+	assert_json_field "$BODY" '[.[] | has("exec-started")] | any' "false" \
+		"no exec-started without exec-data"
+	assert_json_field "$BODY" '[.[] | has("exec-ended")] | any' "false" \
+		"no exec-ended without exec-data"
+}
+
 test_job_status() {
 	echo ""
 	echo "--- Job Status ---"
@@ -563,6 +659,49 @@ test_job_status() {
 	assert_json_field_exists "$BODY" '.url' "status has url"
 	assert_json_field_exists "$BODY" '.["files-url"]' "status has files-url"
 	assert_json_field_exists "$BODY" '.status' "status has status"
+}
+
+test_job_status_exec_data() {
+	echo ""
+	echo "--- Job Status: exec-data ---"
+
+	if [ -z "$SUBMIT_JOBNAME" ] || [ -z "$SUBMIT_JOBID" ]; then
+		skip "job status exec-data (no submitted job)"
+		return
+	fi
+
+	wait_for_output "$SUBMIT_JOBNAME" "$SUBMIT_JOBID" || true
+
+	local resp
+	resp=$(do_curl GET \
+		"${BASE_URL}/zosmf/restjobs/jobs/${SUBMIT_JOBNAME}/${SUBMIT_JOBID}?exec-data=Y")
+	split_response "$resp"
+
+	assert_http_status "200" "$HTTP_STATUS" "job status exec-data=Y"
+	assert_json_field "$BODY" 'has("exec-started")' "true" "status has exec-started"
+	assert_json_field "$BODY" 'has("exec-ended")' "true" "status has exec-ended"
+
+	# the job ran to completion, so both instants must be present and well-formed
+	local started ended
+	started=$(echo "$BODY" | jq -r '.["exec-started"] // ""' 2>/dev/null)
+	ended=$(echo "$BODY" | jq -r '.["exec-ended"] // ""' 2>/dev/null)
+
+	if [ -n "$started" ]; then
+		assert_iso8601_utc "$started" "status exec-started format"
+	else
+		fail "status exec-started" "null for a completed job"
+	fi
+
+	if [ -n "$ended" ]; then
+		assert_iso8601_utc "$ended" "status exec-ended format"
+	else
+		fail "status exec-ended" "null for a completed job"
+	fi
+
+	# exec-submitted is deliberately not implemented (libc370#79) -- assert it
+	# stays absent so the gap is visible if someone adds a placeholder
+	assert_json_field "$BODY" 'has("exec-submitted")' "false" \
+		"exec-submitted absent (libc370#79)"
 }
 
 test_job_status_not_found() {
@@ -904,9 +1043,12 @@ test_list_jobs_with_prefix
 test_list_jobs_with_jobid
 test_list_jobs_with_status
 test_list_jobs_with_max
+test_list_jobs_exec_data
+test_list_jobs_without_exec_data
 
 # Status tests
 test_job_status
+test_job_status_exec_data
 test_job_status_not_found
 
 # Spool file tests

--- a/tests/zowe-jobs.sh
+++ b/tests/zowe-jobs.sh
@@ -387,6 +387,41 @@ test_list_jobs_with_prefix() {
 	assert_rc 0 "$rc" "list jobs with prefix"
 }
 
+test_list_jobs_exec_data() {
+	echo ""
+	echo "--- List Jobs: --exec-data ---"
+
+	local output rc=0
+	output=$(run_zowe_json jobs list jobs --owner "*" --exec-data) || rc=$?
+
+	assert_rc 0 "$rc" "list jobs --exec-data"
+
+	if [ $rc -ne 0 ]; then
+		return
+	fi
+
+	# the CLI turns --exec-data into exec-data=Y on the wire; every job object
+	# must carry the keys, though the values may be null for a job that has not
+	# reached that stage
+	assert_json_field "$output" '[.data[] | has("exec-started")] | all' "true" \
+		"--exec-data: every job has exec-started"
+	assert_json_field "$output" '[.data[] | has("exec-ended")] | all' "true" \
+		"--exec-data: every job has exec-ended"
+
+	# what the user actually sees: the exec-started column must not be blank for
+	# a job that has run.  This is the regression #208 reported.
+	local started
+	started=$(echo "$output" | jq -r \
+		'[.data[] | .["exec-started"] | select(. != null)] | first // ""' 2>/dev/null)
+	if [ -z "$started" ]; then
+		skip "--exec-data: exec-started populated (no job has started)"
+	elif [[ "$started" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z$ ]]; then
+		pass "--exec-data: exec-started is an ISO 8601 UTC instant ($started)"
+	else
+		fail "--exec-data: exec-started format" "got '$started'"
+	fi
+}
+
 test_job_status() {
 	echo ""
 	echo "--- Job Status ---"
@@ -527,6 +562,7 @@ test_submit_from_dataset
 test_list_jobs_default
 test_list_jobs_all_owners
 test_list_jobs_with_prefix
+test_list_jobs_exec_data
 
 # Status test
 test_job_status


### PR DESCRIPTION
Fixes #208.

The jobs API emitted no timestamps at all — `zowe jobs ls js --exec-data` printed the `exec-submitted`, `exec-started` and `exec-ended` columns blank for every job, because none of those fields was ever produced.

## What ships

`exec-started` and `exec-ended`, from the `JESJOB` execution window, gated on `exec-data=Y`. `process_job()` is the single JSON emitter for the list, status and submit responses, so all three gain the fields together.

Gating on `exec-data=Y` is not a guess — traced with `tests/trace-zowe.sh`, the CLI sends exactly that:

```
Resource: /zosmf/restjobs/jobs?prefix=iefbr14&exec-data=Y
```

Format is z/OSMF's: an ISO 8601 instant in UTC with a millisecond fraction and a literal `Z`. JES2 has second resolution, so the fraction is always `.000` — which is what z/OSMF itself reports for `exec-submitted`, so this is compatible rather than a compromise. A job that has not reached a stage returns `null` for that field rather than a placeholder date, matching how `retcode` already behaves.

## The two conversion rules

Both are the reason `format_exec_time()` carries comments rather than being three lines.

JES2 keeps its checkpoint times in **system local time**, so they need the system's own offset — `__tzget()`, the value `tzset()` resolved from `TZ` or `CVTTZ` — to reach UTC. And the rendering goes through `gmtime64_r()`, never `ctime64()`/`localtime64()`: those convert through the calling task's `crt->crttzoff` and would apply an offset a second time, which is how httpd came to report a job that started at 17:25:18 UTC as 05:25:18 (mvslovers/httpd#145).

`tzadjust` is kept on the stack, not cached in a `static` — MVSMF is link-edited RENT.

## Verified on a live system

Deployed to `mvsdev.lan` and activated in `HTTPD.LINKLIB` before merging.

**Cross-check against httpd `/jes/status`** (the reference implementation, post-mvslovers/httpd#151) — same job, both APIs, matching to the second:

| jobid | `/jes/status` | mvsMF `exec-started` |
|---|---|---|
| JOB00559 | 2026-08-08T09:11:57.000Z | 2026-08-08T09:11:57.000Z |
| JOB00560 | 2026-08-08T09:13:38.000Z | 2026-08-08T09:13:38.000Z |

**Shape unchanged without the parameter** — key lists compared, not just field presence:

```
without : subsystem,jobname,jobid,owner,type,class,url,files-url,status,retcode
with    : subsystem,jobname,jobid,owner,type,class,url,files-url,status,retcode,exec-started,exec-ended
```

**Null semantics** — six ACTIVE jobs, all with `exec-started` set and `exec-ended` null.

Suites: `curl-jobs.sh` 87 passed / 0 failed / 1 skipped, `zowe-jobs.sh` 38 / 0 / 1.

### Coverage caveat

The test system runs at UTC−5, so `tzadjust` was **positive** — the same branch httpd exercises. The negative branch (a system east of UTC) is covered by reading `libc370/src/clib/@@64ai32.c:12-18`, which takes the absolute value and calls `__64_sub` for a negative addend, but was **not** exercised live.

## Deliberate gaps

- **`exec-submitted`** — JES2 records it as `JCTRDRON`/`JCTRDTON` and libc370's `JESJOB` does not carry it. Filed as mvslovers/libc370#79; the field is omitted rather than guessed.
- **`exec-system` / `exec-member`** — same class, filed as #209.

Both are documented in `docs/endpoints/jobs/list.md`, and `test_job_status_exec_data` asserts `exec-submitted` stays *absent* so the gap is visible if someone later adds a placeholder.

## Unrelated finding

The submit response returns `owner:""` (the value appears seconds later). Pre-existing, cause traced, filed separately as #210 — not touched here.