### PR TITLE
fix(dsapi): stream the PDS member list instead of building it in storage

### DIFF
--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -20,6 +20,9 @@ or with explicit volume:
 - `start` (optional): Starting member name for pagination
 - `pattern` (optional): Member name filter pattern
 
+## Request Headers
+- `X-IBM-Max-Items` (optional): Maximum number of members to return. Omitted or `0` returns all of them.
+
 ## Response
 On successful completion, this request returns HTTP status code 200 (OK) and a JSON object:
 
@@ -31,9 +34,40 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
         }
     ],
     "returnedRows": 0,
+    "moreRows": false,
     "JSONversion": 1
 }
 ```
+
+`moreRows` is `true` only when the list was cut short by `X-IBM-Max-Items`.
+
+## Large directories
+
+The directory is walked and each member emitted as it is read, so the handler's
+storage footprint is one 256-byte block regardless of how many members the data
+set has. `SYS1.SMPCDS` (22982 members) returns in about 3 s and 850 KB.
+
+This matters more than it sounds. The handler used to call `__listpd()`, which
+builds the complete member array in storage before anything is emitted. On a
+data set that size the region is exhausted, the request abends **S878**, and
+because the abend unwinds before the handler's `__freepd()` the storage is never
+returned — after which httpd can no longer load MVSMF at all and *every*
+endpoint answers `S80A` until the server is restarted (issue #212). A single
+ordinary request, such as opening a large PDS in Zowe Explorer, was enough.
+
+Use `X-IBM-Max-Items` if a bounded response is wanted; it is no longer needed to
+keep the server alive.
+
+## Non-printable member names
+
+Nothing requires a directory entry to hold a printable name, and some do not —
+the SMP/E keys in `SYS1.SMPCDS` are binary. Any byte that cannot appear literally
+in a JSON string is emitted as a `\uXXXX` escape naming its ASCII value, so the
+response parses whatever the directory contains. Ordinary names (`A-Z 0-9 @ # $`)
+are unaffected.
+
+Names are returned padded to 8 characters, as they are held in the directory
+(issue #154).
 
 ## Error Responses
 - HTTP 400 (Bad Request)
@@ -66,6 +100,12 @@ curl http://mvs:1080/zosmf/restfiles/ds/MIKE.TEST.JCL/member
 zowe files list all-members "MIKE.TEST.JCL"
 ```
 
+```bash
+# bounded
+curl -H 'X-IBM-Max-Items: 100' \
+  http://mvs:1080/zosmf/restfiles/ds/SYS1.MACLIB/member
+```
+
 ### Success Response
 ```json
 {
@@ -75,6 +115,7 @@ zowe files list all-members "MIKE.TEST.JCL"
         { "member": "LINKJOB" }
     ],
     "returnedRows": 3,
+    "moreRows": false,
     "JSONversion": 1
 }
 ```

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1313,23 +1313,88 @@ error:
     return rc;
 }
 
+/* PDS directory block, as delivered by fopen(dataset, "r,record") -- one block
+   per record, 256 bytes:
+
+       0..1    halfword: bytes used in this block, including these two
+       2..     packed entries, each
+                 0..7   member name, blank padded
+                 8..10  TTR
+                 11     0x80 alias, 0x60 TTR count, 0x1F user data halfwords
+                 12..   user data
+       a name of eight 0xFF bytes marks the logical end of the directory
+
+   This mirrors the walk in libc370's __listpd() (libc370/src/clib/@@listpd.c).
+   There are now two parsers for this format -- keep them in step. */
+#define PDS_DIR_BLKSIZE		256
+#define PDS_DIR_ENT_FIXED	12	/* name + TTR + indicator */
+#define PDS_DIR_UDATA_MASK	0x1F	/* user data size, in halfwords */
+
+/* 8 name bytes, each worst case "\uXXXX", plus the terminator */
+#define MEMBER_ESC_SIZE		(8 * 6 + 1)
+
+/* Render a directory member name as the body of a JSON string.
+
+   Member names are normally A-Z 0-9 @ # $, but nothing enforces that: a PDS
+   directory can hold arbitrary bytes, and the SMP/E keys in SYS1.SMPCDS are
+   binary. Emitting those raw produces a response that is not JSON -- jq and
+   every other parser reject the unescaped control characters.
+
+   The printability test has to be applied to the ASCII byte, not the EBCDIC
+   one, because http_printf() translates everything we emit on the way out.
+   So each name byte is run through the same table httpd will use, and the
+   result decides: pass the EBCDIC byte through and let the translation do its
+   work, or emit a \uXXXX escape naming the ASCII value.
+
+   This is the one place where comparing against numeric ASCII values is
+   correct rather than the mistake the root CLAUDE.md warns about: `a` is
+   already post-translation, so 0x22 and 0x5C really are the quote and the
+   backslash the parser will see. */
+__asm__("\n&FUNC    SETC 'json_escape_member'");
+static void
+json_escape_member(const unsigned char *raw, unsigned rawlen,
+                   const unsigned char *etoa, char *out, size_t outlen)
+{
+	size_t		o = 0;
+	unsigned	i;
+
+	for (i = 0; i < rawlen; i++) {
+		unsigned char a = etoa[raw[i]];
+
+		/* room for the longest escape plus the terminator */
+		if (o + 6 >= outlen) break;
+
+		if (a < 0x20 || a > 0x7E || a == 0x22 /* " */ || a == 0x5C /* \ */) {
+			o += (size_t) snprintf(&out[o], outlen - o, "\\u%04X", a);
+		} else {
+			out[o++] = (char) raw[i];
+		}
+	}
+
+	out[o] = '\0';
+}
+
 int memberListHandler(Session *session)
 {
 	unsigned	rc		= 0;
-	unsigned	count		= 0;
+	unsigned	emitted		= 0;
 	unsigned	first		= 1;
-	unsigned	i		= 0;
+	unsigned	maxitems	= 0;
+	int		more		= 0;
+	int		at_end		= 0;
 
 	char		*method		= NULL;
 	char		*path		= NULL;
 	char		*verb		= NULL;
 
-	PDSLIST		**pdslist	= NULL;
+	FILE		*fp		= NULL;
+	char		blk[PDS_DIR_BLKSIZE];
 
 	char 		*dsname		= NULL;
 
 	char		*start		= NULL;
 	char		*pattern	= NULL;
+	char		*maxitems_str	= NULL;
 
 
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
@@ -1346,12 +1411,28 @@ int memberListHandler(Session *session)
 	start 	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_START"); 
 	pattern = (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_PATTERN"); 
 
-	/* __listpd() abends S001 on a data set that is not partitioned (#193) */
+	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
+	if (maxitems_str) maxitems = (unsigned) atoi(maxitems_str);
+
+	/* opening a non-partitioned data set this way abends S001 (#193) */
 	if (require_pds(session, dsname) != 0) {
 		goto quit;
 	}
 
-	pdslist = __listpd(dsname, NULL);
+	/* Walk the directory and emit as we go.  This used to call __listpd(),
+	   which builds the complete member array in storage first: on a data set
+	   like SYS1.SMPCDS (~23000 members) that exhausts the region, abends S878,
+	   and -- because the abend unwinds before the handler's __freepd() -- leaves
+	   the storage lost, after which httpd can no longer LINK MVSMF at all and
+	   every endpoint answers S80A until the server is restarted (#212).
+	   Streaming keeps the footprint at one 256-byte block. */
+	fp = fopen(dsname, "r,record");
+	if (!fp) {
+		rc = sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+				CATEGORY_UNEXPECTED, RC_ERROR, REASON_DATASET_NOT_FOUND,
+				ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
+		goto quit;
+	}
 
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc,200)) < 0) goto quit;
@@ -1361,44 +1442,78 @@ int memberListHandler(Session *session)
 	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
-	count = array_count(&pdslist);
-
 	if ((rc = http_printf(session->httpc, "{\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"items\": [\n")) < 0) goto quit;
 
-	if (!pdslist) {
-		goto end;
-	} 
+	while (!at_end) {
+		int	len;
+		int	used;
+		int	pos;
 
-	for(i=0; i < count; i++) {
-		PDSLIST *pds = pdslist[i];
-		
-		if (!pds) continue;
-		
-		if (first) {
-			/* first time we're printing this '{' so no ',' needed */
-			if ((rc = http_printf(session->httpc, "    {\n")) < 0) goto quit;
-			first = 0;
-		} else {
-			/* all other times we need a ',' before the '{' */
-			if ((rc = http_printf(session->httpc, "   ,{\n")) < 0) goto quit;
+		len = fread(blk, 1, sizeof(blk), fp);
+		if (len <= 0) break;
+
+		used = (int) *(unsigned short *) blk;
+
+		/* the block says how much of it is in use -- never take that at face
+		   value.  A short read or a damaged block would otherwise walk us off
+		   the end of blk[], the same class of defect as the MTT length in
+		   #176.  Clamp to what we actually read. */
+		if (used > len) used = len;
+
+		/* PDS_DIR_ENT_FIXED bytes must be present before the indicator byte
+		   at +11 can be read */
+		for (pos = 2; pos + PDS_DIR_ENT_FIXED <= used; ) {
+			int	size;
+			char	member[MEMBER_ESC_SIZE];
+
+			if (memcmp(&blk[pos],
+			           "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8) == 0) {
+				at_end = 1;
+				break;
+			}
+
+			size = PDS_DIR_ENT_FIXED
+			     + ((blk[pos + 11] & PDS_DIR_UDATA_MASK) * 2);
+
+			if (maxitems > 0 && emitted >= maxitems) {
+				more = 1;
+				at_end = 1;
+				break;
+			}
+
+			json_escape_member((const unsigned char *) &blk[pos], 8,
+				httpx->xlate_cp037->etoa, member, sizeof(member));
+
+			if (first) {
+				/* first time we're printing this '{' so no ',' needed */
+				if ((rc = http_printf(session->httpc, "    {\n")) < 0) goto quit;
+				first = 0;
+			} else {
+				/* all other times we need a ',' before the '{' */
+				if ((rc = http_printf(session->httpc, "   ,{\n")) < 0) goto quit;
+			}
+
+			// TODO: extract user data from the entry, if X-IBM-Attributes == base
+			if ((rc = http_printf(session->httpc, "      \"member\": \"%s\"\n", member)) < 0) goto quit;
+			if ((rc = http_printf(session->httpc, "    }\n")) < 0) goto quit;
+
+			emitted++;
+			pos += size;
 		}
-
-		// TODO: extract user data from pds->udata, if X-IBM-Attributes == base 
-		if ((rc = http_printf(session->httpc, "      \"member\": \"%.8s\"\n", pds->name)) < 0) goto quit;
-		if ((rc = http_printf(session->httpc, "    }\n")) < 0) goto quit;
 	}
 
-end:
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", count)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", emitted)) < 0) goto quit;
 	// TODO: add totalRows if X-IBM-Attributes has ',total'
+	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
+		more ? "true" : "false")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;
 
 quit:
-	if (pdslist) {
-		__freepd(&pdslist);
+	if (fp) {
+		fclose(fp);
 	}
 
 	return rc;

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -449,6 +449,76 @@ HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
 assert_http_status "200" "$HTTP_CODE" "list PDS members"
 assert_json_field_exists "$CONTENT" '.items[0].member' "member list has member field"
+assert_json_field "$CONTENT" '.moreRows' "false" "member list: moreRows false when complete"
+
+# --- List members: a large directory must not take the server down (#212) ---
+# memberListHandler used to build the whole member array in storage via
+# __listpd(). On SYS1.SMPCDS (~23000 members) that exhausts the region and
+# abends S878, and because the abend unwinds before __freepd() the storage is
+# never returned -- httpd can then no longer load MVSMF and EVERY endpoint
+# answers S80A until it is restarted. One request was enough.
+#
+# So this case asserts two things: the request itself succeeds, and the server
+# is still alive afterwards. The second assertion is the one that matters.
+echo ""
+echo "--- List PDS Members: large directory (issue #212) ---"
+
+BIG_PDS="${BIG_PDS:-SYS1.SMPCDS}"
+
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 180 -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${BIG_PDS}/member")
+
+if [ "$HTTP_CODE" = "404" ]; then
+	skip "large member list (${BIG_PDS} not on this system)"
+	skip "large member list: X-IBM-Max-Items (${BIG_PDS} not on this system)"
+	skip "server survives a large member list (${BIG_PDS} not on this system)"
+else
+	assert_http_status "200" "$HTTP_CODE" "list members of ${BIG_PDS}"
+
+	# Member names are not guaranteed to be printable -- the SMP/E keys in
+	# SYS1.SMPCDS are binary. Emitted raw they produce control characters
+	# inside a JSON string, which no parser accepts, so the response has to
+	# survive an actual parse and not merely arrive with status 200.
+	if curl -s -m 180 -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${BIG_PDS}/member" | jq -e . >/dev/null 2>&1; then
+		pass "${BIG_PDS} member list is valid JSON (binary names escaped)"
+	else
+		fail "${BIG_PDS} member list is valid JSON" \
+			"jq rejected the response -- unescaped bytes in a member name"
+	fi
+
+	# The cap is asserted here rather than against TEST_PDS: that one holds a
+	# single member, so max-items=1 and no cap at all produce byte-identical
+	# output and the assertion would pass either way. Against a directory with
+	# thousands of entries the cap is the only thing that can produce 10 rows,
+	# and moreRows must then be true.
+	BODY=$(curl -s -w '\n%{http_code}' -m 180 -u "$AUTH" -H 'X-IBM-Max-Items: 10' \
+		"${BASE_URL}/zosmf/restfiles/ds/${BIG_PDS}/member")
+	HTTP_CODE=$(echo "$BODY" | tail -1)
+	CONTENT=$(echo "$BODY" | sed '$d')
+
+	if [ "$HTTP_CODE" = "200" ] &&
+	   [ "$(echo "$CONTENT" | jq -r '.returnedRows')" = "10" ] &&
+	   [ "$(echo "$CONTENT" | jq -r '.items | length')" = "10" ] &&
+	   [ "$(echo "$CONTENT" | jq -r '.moreRows')" = "true" ]; then
+		pass "max-items=10 on ${BIG_PDS}: 10 rows and moreRows=true"
+	else
+		fail "max-items=10 on ${BIG_PDS}" \
+			"got HTTP $HTTP_CODE returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows') moreRows=$(echo "$CONTENT" | jq -r '.moreRows')"
+	fi
+
+	# the regression: is MVSMF still loadable at all?
+	AFTER=$(curl -s -m 20 -u "$AUTH" "${BASE_URL}/zosmf/info")
+	case "$AFTER" in
+		*S80A*|"")
+			fail "server survives a large member list" \
+				"MVSMF no longer loads after ${BIG_PDS} -- httpd needs a restart"
+			;;
+		*)
+			pass "server still serves requests after listing ${BIG_PDS}"
+			;;
+	esac
+fi
 
 # --- List members: the target must actually be a PDS (issue #193) ---
 # __listpd() reads the directory with BPAM and abends S001 on a sequential


### PR DESCRIPTION
Fixes #212.

A single `GET /zosmf/restfiles/ds/<large-pds>/member` took the whole server down — not the request, the server. Reachable by opening a large PDS in Zowe Explorer.

## What was happening

`memberListHandler` called `__listpd()`, which walks the directory and `calloc`s a record per member into an array before anything is emitted. `SYS1.SMPCDS` has **22982** members; building that array exhausts the region and abends.

The damage outlived the request. The abend unwinds out of `__listpd()` before the handler reaches its `__freepd()`, so the partial array is never returned. httpd survives and keeps serving, but can no longer LINK MVSMF — every endpoint, including unauthenticated `/zosmf/info`, then answers `S80A` until restart:

```
11:56:14 / HTTPD001I Server is READY
11:58:57 / MVSMF99E Handler abend S878 U0000 for GET /zosmf/restfiles/ds/SYS1.SMPCDS/member
```

Server **2 min 43 s old**, no other traffic — which rules out this being exhaustion after sustained use. Reproduced twice.

## The change

Walk the directory and emit each member as it is read. The handler already streams its JSON through `http_printf`, so the array was pure overhead: the footprint is now one 256-byte block regardless of member count. `X-IBM-Max-Items` and `moreRows` come along, matching what the data set list in the same file already does.

Two things the old path got away with only because it never returned:

- **The block length is clamped** to the bytes actually read before it is used as a loop bound. `__listpd()` takes that halfword at face value, so a short or damaged block walks it off the end of its buffer — the same class as the MTT length in #176.
- **Member names are escaped.** Nothing requires a directory entry to be printable, and the SMP/E keys in `SYS1.SMPCDS` are binary: emitted raw they put control characters inside a JSON string and `jq` rejects the response. Bytes that cannot appear literally become `\uXXXX`. The printability test runs on the *translated* byte, since `http_printf` converts output on the way out — which makes this the one place where comparing against numeric ASCII values is correct rather than the mistake the root CLAUDE.md warns about. Reasoned out at the call site.

  This defect was invisible before: the request never got far enough to produce output. Found by the new test, not by inspection.

## Verified against the data set that caused the outage

| | |
|---|---|
| members | 22982 |
| response | valid JSON (`jq -e` accepts it) |
| size / time | 1.4 MB / ~5.5 s |
| consecutive runs | 5, all HTTP 200, identical |
| server afterwards | healthy, no abend in the Hercules log |

`SYS1.MACLIB` and `HTTPD.LINKLIB` return unchanged, ordinary names. `tests/curl-datasets.sh`: **85 passed, 0 failed, 0 skipped**.

The new test asserts three things, the last being the one that matters: the request succeeds, the body parses, and **MVSMF still loads afterwards**. The cap assertion runs against the large PDS rather than the suite`&#39;`s own test PDS — that one holds a single member, so `max-items=1` and no cap produce identical output and the check would pass either way.

## Notes for review

- **A second parser for the PDS directory format now exists**, next to libc370`&#39;`s in `@@listpd.c`. The layout is documented at the call site; the two have to be kept in step. libc370#80 proposes a bounded `__listpd()` that would let this copy go away.
- **`moreRows` is computed differently here** than in the data set list (`dsapi.c:875`): that one reports `true` whenever a cap was set and fewer rows came back, even if the list was complete; this one only when the cap actually cut the walk short. Deliberate, not an oversight — related to #54.
- **The other `__listpd()` caller is unaffected** (`dsapi.c:369`, the member existence probe): it passes a member name and `__patmat()` filters before the allocation.
- Member names stay padded to 8 characters (#154 unchanged) — deliberately out of scope for a stability fix.

## This is a point fix

It removes one trigger, not the class. Two follow-ups filed with today`&#39;`s evidence:

- **mvslovers/httpd#154** — httpd does not reclaim a CGI`&#39;`s storage after an abend (`httppcgi.c:20-55` has no FREEMAIN on that path). That is why one bad request disables the server permanently instead of failing one request. httpd has an unbounded `__listpd(dsn, NULL)` of its own at `httpdslp.c:38`, so `/dsl/` on a large PDS should reproduce this without mvsMF involved.
- **mvslovers/libc370#80** — `__listpd()`: unbounded allocation, unchecked block length, and a silently truncated list when `calloc` returns NULL (reachable — `getmain` is conditional).

#185 was updated: it had recorded this S878 as "no longer chasing a live abend", which is superseded.

## Deploy note

`HTTPD.LINKLIB` is at 16 extents, so a replace-copy of `MVSMF` needs a compress first or it fails `SE37`.