### PR TITLE
fix(consapi): correlate a MODIFY reply on the target's source, not the issuer's

### DIFF
--- a/docs/endpoints/console/issue-command.md
+++ b/docs/endpoints/console/issue-command.md
@@ -97,6 +97,31 @@ Console services use a `return-code`/`reason-code`/`reason` body (not `category`
 ## Implementation (MVS 3.8j)
 mvsMF has no EMCS consoles or TSO address spaces. The command is issued with **SVC 34 (MGCR)** under the authenticated user's ACEE (so RAKF evaluates command authority for that user); the response is read from the **Master Trace Table (MTT)** via `clibmtt`, correlating the command echo and its responses by jobid + command text + MLWTO number. EMCS OPERPARM fields (`auth`, `routcode`, `mscope`, `storage`, `auto`) are accepted but ignored.
 
+### How the response block is identified
+
+The newest MTT entry containing the command text is the **echo**. Its source
+field (`"STC  nnn"`) seeds the block, and following entries are kept while they
+carry that source, a blank source (an MLWTO header such as `IEE102I`), or a
+matching MLWTO continuation number. A differently attributed originator ends the
+block.
+
+**A command routed to another address space is the exception.** The echo carries
+the *issuer's* source — mvsMF's own worker — while the reply to `F <stc>,...` is
+written by the *target* started task under its own source. So while the block has
+produced no line yet, the first differently attributed originator is adopted as
+the block's source, once, provided it falls in the echo's own second. Without
+that, every `MODIFY` to anything but HTTPD itself returned an empty
+`cmd-response` (issue #174); `D T` and `F HTTPD,...` were unaffected only because
+there the issuer *is* the target.
+
+The same-second requirement is what keeps an unrelated message written between
+the echo and the reply from hijacking the block. MTT timestamps are
+second-granular, so that is as tight as correlation gets here.
+
+**Known limitation:** every mvsMF worker shares one source, so two console
+requests issued concurrently through the same server can pick up each other's
+lines. Tracked in #214.
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/jobs/list.md
+++ b/docs/endpoints/jobs/list.md
@@ -69,15 +69,16 @@ than guessed.
 
 `exec-system` and `exec-member` are likewise not implemented (mvslovers/mvsmf#209).
 
-### Cross-check
+### Provenance of the format
 
-httpd's `/jes/status` reports the same instants in the same format, so the two
-APIs can be compared directly for a given job:
+The conversion was validated against httpd's `/jes/status`, which emitted the
+same instants in the same format after mvslovers/httpd#151 — the two agreed to
+the second on the same job.
 
-```bash
-curl -s -u user:pass "http://host:8080/jes/status?jobname=IEFBR14" \
-  | grep -E 'start_display|end_display'
-```
+**Do not reach for that comparison again:** httpd retires `/jes/*` (and `/dsl/*`)
+in 4.0.0, since these endpoints are what mvsMF replaces. The reference is
+recorded here because it is how the timezone handling was verified, not as a
+check to re-run.
 
 ## Error Responses
 - HTTP 500 (Internal Server Error)

--- a/src/consapi.c
+++ b/src/consapi.c
@@ -59,6 +59,33 @@
 #define MTT_SRC_LEN    8
 #define MTT_MSG_OFF    24         /* message text start                       */
 
+/* An MTT entry is one console line; nothing in the record bounds it for us.  */
+#define MTT_ENTRY_MAX  256
+
+/* mtentlen is a signed halfword (ieezb806.h) over a flexible mtentdat[], so a
+ * bogus or over-read entry presents a negative or absurd length and any use of
+ * it as a scan bound walks off the record -- #176.
+ *
+ * That fix clamped the two consumers known at the time (the echo search and
+ * detect_count) and left the rest of this file reading the field raw. The
+ * MODIFY correlation in #174 then started processing entries that the source
+ * predicate had previously skipped, which turned one of those raw reads into a
+ * live S0C4. Every length goes through here now, so there is one place to be
+ * right rather than six. Callers still clamp to their own buffer on top. */
+__asm__("\n&FUNC	SETC 'mtt_len'");
+static int mtt_len(const MTENTRY *e)
+{
+	int len;
+
+	if (!e) return 0;
+
+	len = (int) e->mtentlen;
+	if (len < 0) return 0;
+	if (len > MTT_ENTRY_MAX) return MTT_ENTRY_MAX;
+
+	return len;
+}
+
 /* ------------------------------------------------------------------ */
 /* small helpers                                                       */
 /* ------------------------------------------------------------------ */
@@ -246,6 +273,8 @@ static void key_to_name(const char *key, char name[MVSMF_KVS_NAMELEN])
 /* of lines appended.  (session: array_count() routes through the      */
 /* httpd httpx vector, which needs session->httpd.)                    */
 /* ------------------------------------------------------------------ */
+static int mtt_secs_of_day(const char *dat, int len);
+
 __asm__("\n&FUNC	SETC 'correlate_once'");
 static int correlate_once(Session *session, const char *cmd_upper, char *out,
                           size_t outsz, unsigned skip, unsigned *total)
@@ -260,6 +289,8 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 	char src[MTT_SRC_LEN + 1];
 	char num[12];
 	int have_num = 0;
+	int echo_secs = -1;	/* hh.mm.ss of the echo, for the adoption below */
+	int adopted = 0;	/* the block's source was taken from the target  */
 
 	out[0] = '\0';
 
@@ -267,11 +298,9 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 	for (i = n; i > 0; i--) {
 		MTENTRY *e = arr[i - 1];
 		char tmp[160];
-		int len = e ? (int)e->mtentlen : 0;
+		int len = mtt_len(e);
 		if (!e) continue;
 		if (len > (int)sizeof(tmp) - 1) len = sizeof(tmp) - 1;
-		if (len < 0) len = 0;   /* mtentlen is a signed short: a bogus/over-read
-		                         * entry can sign-extend negative (#176) */
 		memcpy(tmp, e->mtentdat, len);
 		tmp[len] = '\0';
 		if (strstr(tmp, cmd_upper)) { ei = (int)(i - 1); break; }
@@ -279,15 +308,17 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 
 	if (ei >= 0) {
 		MTENTRY *ee = arr[ei];
-		int elen = (int)ee->mtentlen;
+		int elen = mtt_len(ee);
 		memset(src, ' ', MTT_SRC_LEN);
 		if (elen >= MTT_SRC_OFF + MTT_SRC_LEN)
 			memcpy(src, &ee->mtentdat[MTT_SRC_OFF], MTT_SRC_LEN);
 		src[MTT_SRC_LEN] = '\0';
 
+		echo_secs = mtt_secs_of_day(ee->mtentdat, elen);
+
 		for (i = (unsigned)ei + 1; i < n; i++) {
 			MTENTRY *e = arr[i];
-			int len = e ? (int)e->mtentlen : 0;
+			int len = mtt_len(e);
 			const char *dat = e ? e->mtentdat : "";
 			const char *msg;
 			int msglen, k;
@@ -310,6 +341,43 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 				if (len - k >= (int)strlen(num) &&
 				    memcmp(&dat[k], num, strlen(num)) == 0)
 					cont = 1;
+			}
+
+			/* A differently attributed originator normally ends our block --
+			   but the reply to a command routed to another address space is
+			   exactly that, and dropping it here is #174.
+
+			   The echo carries the ISSUER's source: MVSMF's own worker, e.g.
+			   "STC  631". A MODIFY reply is written by the TARGET started task
+			   under its own source, e.g. "STC  264" for UFSD, so it is neither
+			   has_src nor blank_src nor cont and fell through to the continue
+			   below -- leaving cmd-response empty for every F to anything but
+			   HTTPD itself. "D T" and "F HTTPD,D P" only ever worked because
+			   there the issuer IS the target; "D A,L" because IEE102I carries a
+			   blank source.
+
+			   So: while the block has produced no line yet, the first
+			   differently attributed originator is adopted as the block's
+			   source, once. Requiring it to fall in the echo's own second is
+			   what stops an unrelated message written between the echo and the
+			   reply from hijacking the block -- adjacency alone would not, and
+			   the MTT is second-granular, which is as tight as correlation gets
+			   here. */
+			if (!has_src && !blank_src && !cont &&
+			    line_idx == 0 && !adopted && echo_secs >= 0 &&
+			    len >= MTT_SRC_OFF + MTT_SRC_LEN) {
+				int s = mtt_secs_of_day(dat, len);
+
+				if (s >= 0) {
+					int d = s - echo_secs;
+					if (d < 0) d += 86400;	/* midnight roll */
+					if (d <= 1) {
+						memcpy(src, &dat[MTT_SRC_OFF], MTT_SRC_LEN);
+						src[MTT_SRC_LEN] = '\0';
+						adopted = 1;
+						has_src = 1;
+					}
+				}
 			}
 
 			/* a different, attributed originator ends our block */
@@ -413,12 +481,10 @@ static int detect_count(Session *session, const char *keyword_upper,
 	for (i = 0; i < n; i++) {
 		MTENTRY *e = arr[i];
 		char up[200];
-		int len = e ? (int)e->mtentlen : 0;
+		int len = mtt_len(e);
 		int k;
 		if (!e) continue;
 		if (len > (int)sizeof(up) - 1) len = sizeof(up) - 1;
-		if (len < 0) len = 0;   /* mtentlen is a signed short: a bogus/over-read
-		                         * entry can sign-extend negative (#176) */
 		for (k = 0; k < len; k++)
 			up[k] = (char)toupper((unsigned char)e->mtentdat[k]);
 		up[len] = '\0';
@@ -1064,7 +1130,7 @@ int consoleLogHandler(Session *session)
 	prev_hms  = base.tm_hour * 3600 + base.tm_min * 60 + base.tm_sec;
 	for (i = (int)n - 1; i >= 0; i--) {                /* newest -> oldest */
 		MTENTRY *e = arr[i];
-		int sod = e ? mtt_secs_of_day((const char *)e->mtentdat, (int)e->mtentlen) : -1;
+		int sod = e ? mtt_secs_of_day((const char *)e->mtentdat, mtt_len(e)) : -1;
 		struct tm etm;
 		if (sod < 0) { esecs[i] = (time_t)0; continue; }
 		if (sod > prev_hms + 43200) days_back++;       /* midnight crossing */
@@ -1102,7 +1168,7 @@ int consoleLogHandler(Session *session)
 		if (!e || esecs[i] == 0 || esecs[i] < lo || esecs[i] > hi) continue;
 
 		dat = (const char *)e->mtentdat;
-		len = (int)e->mtentlen;
+		len = mtt_len(e);
 
 		off = (len > MTT_MSG_OFF) ? MTT_MSG_OFF : 0;
 		while (off < len && dat[off] == ' ') off++;

--- a/tests/curl-console.sh
+++ b/tests/curl-console.sh
@@ -46,6 +46,8 @@ fail() {
 	FAILED=$((FAILED + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"
 	[ -n "${2:-}" ] && echo "        $2"
 }
+# SKIPPED was counted in the summary but had no way to be incremented
+skip() { SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1)); echo "  SKIP: $1"; }
 
 assert_http_status() {
 	if [ "$2" = "$1" ]; then pass "$3 (HTTP $2)"
@@ -111,6 +113,55 @@ assert_contains     "$BODY" '.["cmd-response"]' "IEE136I" "D T: response has IEE
 assert_json_exists  "$BODY" '.["cmd-response-key"]' "D T: key present"
 assert_json_exists  "$BODY" '.["cmd-response-url"]' "D T: url present"
 assert_json_exists  "$BODY" '.["cmd-response-uri"]' "D T: uri present"
+
+# =========================================================================
+# 1b. MODIFY to a started task OTHER than HTTPD (issue #174)
+#
+# correlate_once() anchors on the command echo and used to keep only entries
+# carrying THAT source -- the issuer, i.e. mvsMF's own worker. A MODIFY reply is
+# written by the target started task under its own source, so it was dropped and
+# cmd-response came back empty for every F to anything but HTTPD itself.
+#
+# "F HTTPD,..." cannot catch this: there the issuer IS the target, which is why
+# it worked all along. The test needs a different address space, so it is run
+# against a known-safe target and skipped where none is up. Even a rejection
+# ("unknown command") proves the point -- it is a reply from the target.
+# =========================================================================
+echo ""
+echo "--- sync: MODIFY to another started task (issue #174) ---"
+
+# which started tasks are up? D A,L lists them.
+ACTIVE_RESP=$(issue '{"cmd":"D A,L"}')
+ACTIVE_LIST=$(echo "$ACTIVE_RESP" | sed '$d' | jq -r '.["cmd-response"] // ""' 2>/dev/null | tr '\r' '\n')
+
+MODIFY_TARGET=""
+for cand in UFSD FTPD; do
+	if echo "$ACTIVE_LIST" | grep -q "$cand"; then MODIFY_TARGET="$cand"; break; fi
+done
+
+if [ -z "$MODIFY_TARGET" ]; then
+	skip "MODIFY to another STC (neither UFSD nor FTPD is active)"
+else
+	RESP=$(issue "{\"cmd\":\"F ${MODIFY_TARGET},STATUS\"}")
+	CODE=$(echo "$RESP" | tail -1); BODY=$(echo "$RESP" | sed '$d')
+	assert_http_status "200" "$CODE" "issue F ${MODIFY_TARGET},STATUS"
+
+	MLINES=$(echo "$BODY" | jq -r '.["cmd-response"] // ""' 2>/dev/null | tr '\r' '\n' | grep -c .)
+	if [ "${MLINES:-0}" -ge 1 ]; then
+		pass "F ${MODIFY_TARGET},STATUS: target's reply is correlated (${MLINES} lines)"
+	else
+		fail "F ${MODIFY_TARGET},STATUS: cmd-response is empty" \
+			"the target's reply was dropped -- #174 has regressed"
+	fi
+
+	# the reply must come from the target, not be an echo of our own command
+	if echo "$BODY" | jq -r '.["cmd-response"] // ""' 2>/dev/null | grep -q "$MODIFY_TARGET"; then
+		pass "F ${MODIFY_TARGET},STATUS: reply text names the target"
+	else
+		fail "F ${MODIFY_TARGET},STATUS: reply text does not name the target" \
+			"correlated the wrong block?"
+	fi
+fi
 
 # =========================================================================
 # 2. Synchronous, multi-line MLWTO response (D A,L -> IEE102I + continuations)


### PR DESCRIPTION
Fixes #174.

Every `MODIFY` to a started task other than HTTPD itself returned an empty `cmd-response`.

## Cause

`correlate_once()` anchors on the command echo and seeds the response block from **that entry's** source — which is the *issuer*, mvsMF's own worker. A `MODIFY` reply is written by the **target** started task under its own source, so it was neither `has_src` nor `blank_src` nor an MLWTO continuation, and the block-collection predicate dropped it.

Confirmed against the live MTT rather than inferred:

```
0000  6.08.14 STC  631  F UFSD,STATS            <- echo, the issuer
FFFF  6.08.14 STC  264  UFSD010I STATUS: ACTIVE <- reply, the target
```

`D T` and `F HTTPD,D P` only ever worked because there the issuer *is* the target; `D A,L` because `IEE102I` carries a blank source. That is the whole of the table in the ticket.

## Change

While the block has produced no line yet, the first differently attributed originator is adopted as the block's source, once — provided it falls in the echo's own second.

The same-second requirement is the load-bearing part. Adjacency alone would let an unrelated message written between the echo and the reply hijack the block; MTT timestamps are second-granular, so this is as tight as correlation gets here. Midnight rollover is handled.

`detect_count()` needed no change and is not affected: it scans the whole MTT for the keyword and never applies the source predicate. That closes the "shares the offsets but not this predicate, so it needs a separate look" note on the ticket.

## A regression this change caused, and the clamp that fixes it

The first test after the change abended **S0C4**.

`mtentlen` is a signed halfword over a flexible `mtentdat[]`, so a bogus entry presents a negative or absurd length, and using it as a scan bound walks off the record. #176 clamped the two consumers known at the time — the echo search and `detect_count` — and left **four** reads raw. Correlating a MODIFY reply processes entries the source predicate used to skip, which turned one of those raw reads into a live fault.

Every length now goes through `mtt_len()`. One place to be right beats six sites that have to remember; callers still bound to their own buffers on top. Three of the four repaired reads were latent before this PR and are unrelated to MODIFY — the hardcopy-log path had two of them.

## Verified on the live system

Idle server, all seven commands in 0-1 s:

| command | before | after |
|---|---|---|
| `F UFSD,STATS` | **empty** | 11 lines |
| `F UFSD,STATUS` | **empty** | 2 lines |
| `F FTPD,STATUS` | **empty** | 1 line |
| `F HTTPD,DISPLAY TIME` | very slow under load | 3 lines, 0 s |
| `D T` / `F HTTPD,D P` / `D A,L` | correct | unchanged |

`tests/curl-console.sh`: **64 passed, 0 failed**. The new case runs against a real second address space, because `F HTTPD` structurally cannot catch this defect, and skips itself where no suitable target is up. It also adds the `skip()` the suite counted in its summary but never actually had.

## Two findings filed, not fixed here

- **#214** — concurrent issue-command requests pick up each other's lines, because every worker shares one issuer source. **Pre-existing**: this PR only changes how a *differently* attributed source is treated, and the `has_src` path the defect lives on is untouched. It is also the likely cause of the slow `F HTTPD,DISPLAY TIME` observed under parallel load: `capture_response()` polls for a stable line count, and foreign lines keep it moving until the window expires.
- **#215** — `addJsonStringEsc()` escapes five characters rather than the control range. Found by reading the code; **no observed failure**. During verification I twice concluded the console API returned invalid JSON, and both times it was my own harness (`echo` in zsh expands the `\r` inside the JSON before `jq` sees it; the bash test suites do not). Recorded as a latent gap so it is not mis-prioritised.

## Also in this PR

One documentation commit, unrelated to the console: `docs/endpoints/jobs/list.md` told the reader to compare the exec timestamps against httpd's `/jes/status`. That comparison is how the conversion was verified, but it is not repeatable — httpd retires `/jes/*` and `/dsl/*` in 4.0.0, since mvsMF replaces them. The provenance stays, the runnable command goes, so the page does not hand out an instruction that silently stops working. That failure mode is the subject of #182.
