### PR TITLE
test: check in the console soak harness and rework its evidence capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ log-at-fail-*.json
 soak-triage-*.txt
 mtt-ring-*.json
 herc-at-fail-*.log
+worker-watch-*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ src/*.s
 # Build system
 .env
 *.jcl
+# ...except the test fixtures and operational jobs, which are source.
+# The ones already in tests/jcl/ predate the rule above and were force-added;
+# make the exception explicit so the next one does not hit the same wall.
+!tests/jcl/*.jcl
 .build-warnings
 .mbt/
 build/
@@ -84,3 +88,10 @@ dkms.conf
 
 # generated build-identity header
 include/buildid.h
+
+# soak / churn / loadtest artefacts (tests/*-176.sh write these to the cwd)
+churn-176-*.log
+soak-176-*.log
+loadtest-176-*.log
+mtt-at-fail-*.json
+log-at-fail-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ soak-176-*.log
 loadtest-176-*.log
 mtt-at-fail-*.json
 log-at-fail-*.json
+soak-triage-*.txt
+mtt-ring-*.json
+herc-at-fail-*.log

--- a/tests/churn-176.sh
+++ b/tests/churn-176.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# tests/churn-176.sh — concurrent unsol churn, every request reports
+set -u
+[ -f .env ] && . ./.env
+
+# The other suites in tests/ read MVSMF_*; deploy tooling sets MBT_MVS_*.
+# Accept either so this runs from the same .env as everything else.
+MVSMF_HOST="${MVSMF_HOST:-${MBT_MVS_HOST:-}}"
+MVSMF_PORT="${MVSMF_PORT:-${MBT_MVS_PORT:-}}"
+MVSMF_USER="${MVSMF_USER:-${MBT_MVS_USER:-}}"
+MVSMF_PASS="${MVSMF_PASS:-${MBT_MVS_PASS:-}}"
+
+B="http://${MVSMF_HOST}:${MVSMF_PORT}"
+A="${MVSMF_USER}:${MVSMF_PASS}"
+CT='Content-Type: application/json'
+CSRF='X-CSRF-ZOSMF-HEADER: true'
+CONS="$B/zosmf/restconsoles/consoles/defcn"
+LOG="churn-176-$(date +%H%M%S).log"
+THREADS="${THREADS:-4}"
+
+echo "start $(date) threads=$THREADS" | tee "$LOG"
+
+worker() { # $1 = id, $2 = mode
+	local n=0 c
+	while true; do
+		n=$((n + 1))
+		if [ "$2" = "unsol" ]; then
+			c=$(curl -s -o /dev/null -w '%{http_code}' --max-time 90 -X PUT "$CONS" -u "$A" \
+				-H "$CT" -H "$CSRF" \
+				-d '{"cmd":"D T","unsol-key":"ZZZNOMATCH","unsol-detect-sync":"Y","unsol-detect-timeout":"20"}')
+		else
+			c=$(curl -s -o /dev/null -w '%{http_code}' --max-time 90 -X PUT "$CONS" -u "$A" \
+				-H "$CT" -H "$CSRF" -d '{"cmd":"D T","async":"N"}')
+		fi
+		echo "$(date +%H:%M:%S) t$1 $n $c" >>"$LOG"
+		case "$c" in
+		200) ;;
+		000) ;; # client timeout / reset -- not a server error
+		*) echo "HIT t$1 n=$n code=$c $(date)" | tee -a "$LOG" ;;
+		esac
+		sleep 0.2
+	done
+}
+
+for i in $(seq 1 "$THREADS"); do worker "$i" unsol & done
+worker P plain &
+echo "running -- Ctrl-C to stop; watch for HIT lines in the log"
+wait

--- a/tests/jcl/mvsmfact.jcl
+++ b/tests/jcl/mvsmfact.jcl
@@ -1,0 +1,63 @@
+//MVSMFACT JOB (ACCT),'ACTIVATE MVSMF',CLASS=A,MSGCLASS=H,
+//         NOTIFY=&SYSUID
+//*
+//* Compress the httpd STEPLIB and copy a freshly deployed MVSMF
+//* into it.
+//*
+//* WHY THIS EXISTS
+//*   `make deploy` RECEIVEs the load module into the deploy
+//*   LINKLIB and stops there -- it does not touch the running
+//*   server. httpd loads the CGI fresh per request from its own
+//*   STEPLIB, so copying the member there activates a new build
+//*   with no httpd restart.
+//*
+//*   That STEPLIB fills up. Every replace-copy orphans the old
+//*   member's space, and once the data set is at its extent
+//*   limit the copy fails IEF450I ... ABEND SE37. That failure
+//*   is clean -- it abends before writing, so the existing
+//*   member and the running server are unharmed -- but nothing
+//*   is activated until the library is compressed.
+//*
+//* BEFORE YOU SUBMIT
+//*   Both steps use DISP=OLD, because IEBCOPY COMPRESS cannot
+//*   run against a library httpd holds SHR through its STEPLIB.
+//*   The job therefore WAITS in the enqueue until httpd releases
+//*   it. Either stop httpd first, or submit this and then stop
+//*   httpd -- it starts the moment the STC ends. Note that a
+//*   waiting job occupies an initiator.
+//*
+//*     P HTTPD          (3270 / console)
+//*     <this job runs>
+//*     S HTTPD
+//*
+//* CHECK THE NAMES
+//*   Both data sets below are installation-specific. The STEPLIB
+//*   name differs per stand -- it has been HTTPD.LINKLIB and
+//*   HTTPD.LINKLIBT on different systems, so confirm which one
+//*   holds the MVSMF member before submitting:
+//*
+//*     GET /zosmf/restfiles/ds?dslevel=HTTPD
+//*     GET /zosmf/restfiles/ds/<candidate>/member
+//*
+//*   The deploy library is the one `make deploy` reports as its
+//*   target, built from MBT_MVS_HLQ in .env.
+//*
+//* AFTERWARDS
+//*   GET /zosmf/test?fn=version returns the git hash the live
+//*   module was built from. IEBCOPY also prints IEB144I with the
+//*   tracks left, which is the early warning for the next SE37.
+//*
+//COMPRESS EXEC PGM=IEBCOPY
+//SYSPRINT DD SYSOUT=*
+//LIB      DD DSN=HTTPD.LINKLIB,DISP=OLD
+//SYSIN    DD *
+  COPY INDD=LIB,OUTDD=LIB
+/*
+//ACTIVATE EXEC PGM=IEBCOPY
+//SYSPRINT DD SYSOUT=*
+//IN       DD DSN=IBMUSER.MVSMF.V1R0M0D.LINKLIB,DISP=SHR
+//OUT      DD DSN=HTTPD.LINKLIB,DISP=OLD
+//SYSIN    DD *
+  COPY INDD=((IN,R)),OUTDD=OUT
+  SELECT MEMBER=MVSMF
+/*

--- a/tests/loadtest-176.sh
+++ b/tests/loadtest-176.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# tests/loadtest-176.sh — hunt the intermittent S0C4 in the console handler
+# Usage: ./tests/loadtest-176.sh <A|B|C> [iterations]
+#   A = full PUT      (MGCR + capture_response + correlate_once + nt_set)
+#   B = /test fn=cmd  (MGCR + MTT poll, no correlate_once, no nt_set)
+#   C = /v1/log       (MTT read only, no command)
+# Restart the HTTPD STC before every run.
+
+set -u
+[ -f .env ] && . ./.env
+
+# The other suites in tests/ read MVSMF_*; deploy tooling sets MBT_MVS_*.
+# Accept either so this runs from the same .env as everything else.
+MVSMF_HOST="${MVSMF_HOST:-${MBT_MVS_HOST:-}}"
+MVSMF_PORT="${MVSMF_PORT:-${MBT_MVS_PORT:-}}"
+MVSMF_USER="${MVSMF_USER:-${MBT_MVS_USER:-}}"
+MVSMF_PASS="${MVSMF_PASS:-${MBT_MVS_PASS:-}}"
+
+
+ARM="${1:?arm required: A, B or C}"
+N="${2:-500}"
+BASE="http://${MVSMF_HOST}:${MVSMF_PORT}"
+AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+LOG="loadtest-176-${ARM}-${STAMP}.log"
+
+echo "arm=$ARM iterations=$N base=$BASE" | tee "$LOG"
+
+for i in $(seq 1 "$N"); do
+	case "$ARM" in
+	A) code=$(curl -s -o /dev/null -w '%{http_code}' -X PUT \
+		"$BASE/zosmf/restconsoles/consoles/defcn" -u "$AUTH" \
+		-H 'Content-Type: application/json' \
+		-H 'X-CSRF-ZOSMF-HEADER: true' \
+		-d '{"cmd":"D T","async":"N"}') ;;
+	B) code=$(curl -s -o /dev/null -w '%{http_code}' \
+		"$BASE/zosmf/test?fn=cmd&cmd=D+T" -u "$AUTH") ;;
+	C) code=$(curl -s -o /dev/null -w '%{http_code}' \
+		"$BASE/zosmf/restconsoles/v1/log" -u "$AUTH") ;;
+	*)
+		echo "unknown arm: $ARM"
+		exit 2
+		;;
+	esac
+
+	echo "$i $code" >>"$LOG"
+	[ $((i % 25)) -eq 0 ] && echo "  ... $i ($code)"
+
+	if [ "$code" != "200" ]; then
+		echo "FAILED arm=$ARM N=$i code=$code" | tee -a "$LOG"
+		# snapshot while the address space is still alive
+		curl -s "$BASE/zosmf/test?fn=mtt&step=3" -u "$AUTH" \
+			>"mtt-at-fail-${ARM}-${STAMP}.json"
+		curl -s "$BASE/zosmf/restconsoles/v1/log" -u "$AUTH" \
+			>"log-at-fail-${ARM}-${STAMP}.json"
+		echo "snapshots written" | tee -a "$LOG"
+		exit 1
+	fi
+done
+
+echo "arm=$ARM survived $N iterations" | tee -a "$LOG"

--- a/tests/soak-176.sh
+++ b/tests/soak-176.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# tests/soak-176.sh — long-running mixed-load soak hunting the console S0C4
+# Usage: nohup ./tests/soak-176.sh > /dev/null 2>&1 &
+#        tail -f soak-176-*.log
+
+set -u
+[ -f .env ] && . ./.env
+
+# The other suites in tests/ read MVSMF_*; deploy tooling sets MBT_MVS_*.
+# Accept either so this runs from the same .env as everything else.
+MVSMF_HOST="${MVSMF_HOST:-${MBT_MVS_HOST:-}}"
+MVSMF_PORT="${MVSMF_PORT:-${MBT_MVS_PORT:-}}"
+MVSMF_USER="${MVSMF_USER:-${MBT_MVS_USER:-}}"
+MVSMF_PASS="${MVSMF_PASS:-${MBT_MVS_PASS:-}}"
+
+
+BASE="http://${MVSMF_HOST}:${MVSMF_PORT}"
+AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+LOG="soak-176-${STAMP}.log"
+DELAY="${DELAY:-0.5}"
+
+# Adjust to commands your system accepts. Variety of OUTPUT SHAPE is the
+# point: short vs. long, single- vs. multi-line, and -- since #174 -- replies
+# that come from a DIFFERENT address space than the issuer.
+#
+# The last one matters most now. Correlating a MODIFY reply makes the walk
+# process entries the source predicate used to skip, and that is exactly what
+# turned a raw mtentlen read into a live S0C4 while #174 was being tested. A
+# soak that only issues D-commands never touches that path.
+#
+# Note for anyone reading an older copy of this file: it used to recommend a
+# command producing '+' write-to-programmer WTOs, on the theory that the '+'
+# shifted the MTT column layout. That theory was REFUTED on #174 -- the source
+# field sits at the same offset either way. Do not spend time on it.
+COMMANDS=(
+	"D T"
+	"D A,L"
+	"D U,,,500,4"
+	"F UFSD,STATUS"
+)
+
+CONSOLE="$BASE/zosmf/restconsoles/consoles/defcn"
+CT='Content-Type: application/json'
+CSRF='X-CSRF-ZOSMF-HEADER: true'
+
+req() { # req <label> <curl args...>
+	local label="$1"
+	shift
+	local code
+	code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 90 "$@")
+	echo "$(date +%H:%M:%S) $N $label $code" >>"$LOG"
+	if [ "$code" != "200" ]; then
+		echo "FAILED n=$N label=$label code=$code at $(date)" | tee -a "$LOG"
+		curl -s "$BASE/zosmf/test?fn=mtt&step=3" -u "$AUTH" \
+			>"mtt-at-fail-${STAMP}.json"
+		curl -s "$BASE/zosmf/restconsoles/v1/log?timeRange=5m" -u "$AUTH" \
+			>"log-at-fail-${STAMP}.json"
+		exit 1
+	fi
+}
+
+echo "soak started $(date) base=$BASE" | tee "$LOG"
+N=0
+START=$(date +%s)
+
+while true; do
+	N=$((N + 1))
+	R=$((RANDOM % 100))
+
+	if [ "$R" -lt 50 ]; then
+		CMD="${COMMANDS[$((RANDOM % ${#COMMANDS[@]}))]}"
+		req "cmd[$CMD]" -X PUT "$CONSOLE" -u "$AUTH" \
+			-H "$CT" -H "$CSRF" \
+			-d "{\"cmd\":\"$CMD\",\"async\":\"N\"}"
+
+	elif [ "$R" -lt 80 ]; then
+		req "log45m" "$BASE/zosmf/restconsoles/v1/log?timeRange=45m" -u "$AUTH"
+
+	elif [ "$R" -lt 92 ]; then
+		for TR in 5m 15m 2h; do
+			req "log$TR" "$BASE/zosmf/restconsoles/v1/log?timeRange=$TR" -u "$AUTH"
+		done
+
+	else
+		# unsol_sync — holds a worker in the 581-588 poll loop.
+		# Dominant heap-churn driver: cmtt_new/cmtt_free per iteration.
+		req "unsol" -X PUT "$CONSOLE" -u "$AUTH" -H "$CT" -H "$CSRF" \
+			-d '{"cmd":"D T","unsol-key":"ZZZNOMATCH","unsol-detect-sync":"Y","unsol-detect-timeout":"10"}'
+	fi
+
+	if [ $((N % 100)) -eq 0 ]; then
+		ELAPSED=$(($(date +%s) - START))
+		echo "$(date +%H:%M:%S) --- n=$N elapsed=${ELAPSED}s" | tee -a "$LOG"
+	fi
+
+	sleep "$DELAY"
+done

--- a/tests/soak-176.sh
+++ b/tests/soak-176.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
-# tests/soak-176.sh — long-running mixed-load soak hunting the console S0C4
+# tests/soak-176.sh — long-running mixed console load.
+#
 # Usage: nohup ./tests/soak-176.sh > /dev/null 2>&1 &
 #        tail -f soak-176-*.log
+#
+# Tunables (env): DELAY SLOW_SECS MAXTIME RING_EVERY SOAK_HERC_LOG
+#
+# WHAT THIS IS FOR
+#   Originally written to hunt the intermittent console S0C4 (#176) and kept as
+#   the load-validation harness the release epic (#185) asks for. It has since
+#   found a second, different failure: the server HANGS under sustained load
+#   (#217) rather than faulting.
+#
+# WHY IT CAPTURES THE WAY IT DOES
+#   The first #217 run produced two 0-byte snapshots. It only reacted to a
+#   FAILED request, and by then the server was gone, so the capture requests
+#   failed too. Everything below follows from that:
+#
+#     - trip on a SLOW response, not a failed one, so the capture happens while
+#       the server may still be partly alive;
+#     - classify what is still answering (see triage()) instead of assuming;
+#     - keep a rolling pre-failure MTT snapshot, because the state that explains
+#       a hang is the state from BEFORE it.
 
 set -u
 [ -f .env ] && . ./.env
@@ -13,12 +33,23 @@ MVSMF_PORT="${MVSMF_PORT:-${MBT_MVS_PORT:-}}"
 MVSMF_USER="${MVSMF_USER:-${MBT_MVS_USER:-}}"
 MVSMF_PASS="${MVSMF_PASS:-${MBT_MVS_PASS:-}}"
 
-
 BASE="http://${MVSMF_HOST}:${MVSMF_PORT}"
 AUTH="${MVSMF_USER}:${MVSMF_PASS}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 LOG="soak-176-${STAMP}.log"
+TRIAGE="soak-triage-${STAMP}.txt"
+
 DELAY="${DELAY:-0.5}"
+# Trip the triage well below the hard timeout. The console sync capture polls
+# for ~3 s by design, so anything past ~15 s is already abnormal, and waiting
+# out a 90 s timeout is how the first run lost its evidence.
+SLOW_SECS="${SLOW_SECS:-15}"
+MAXTIME="${MAXTIME:-45}"
+RING_EVERY="${RING_EVERY:-50}"     # rolling MTT snapshot cadence, in iterations
+RING_KEEP=3
+# Optional: user@host:/path/to/hercules.log — the abend/console evidence lives
+# on the emulator host, not in any HTTP response.
+HERC_LOG="${SOAK_HERC_LOG:-}"
 
 # Adjust to commands your system accepts. Variety of OUTPUT SHAPE is the
 # point: short vs. long, single- vs. multi-line, and -- since #174 -- replies
@@ -44,23 +75,95 @@ CONSOLE="$BASE/zosmf/restconsoles/consoles/defcn"
 CT='Content-Type: application/json'
 CSRF='X-CSRF-ZOSMF-HEADER: true'
 
+# ---------------------------------------------------------------------------
+# triage — the point of the whole harness
+#
+# A hang looks the same from one endpoint no matter what caused it. This ladder
+# runs from "no mvsMF involved" to "the console path", each with a short
+# timeout, and the pattern of what still answers says which layer is stuck:
+#
+#   everything answers        -> the slow request was an outlier, not a wedge
+#   httpd yes, mvsMF no       -> the module cannot be loaded (the S80A shape,
+#                                i.e. storage — see #212 / httpd#154)
+#   mvsMF yes, console no     -> a console-specific hang; suspect shared state
+#                                (the ntstore latch in consapi/ntstore.c is one
+#                                candidate: held across an abend it is never
+#                                released)
+#   nothing answers           -> every worker is parked; whatever holds them is
+#                                upstream of the console handlers
+#
+# Read the STATUS CODE as "did something answer", not as "was it happy".
+# httpd-root answers 404 on a healthy system (no index document) and that is a
+# pass for this purpose: httpd took the connection and replied. What matters is
+# the boundary in the ladder where answers stop, and how long each one took.
+# ---------------------------------------------------------------------------
+triage() { # triage <why>
+	{
+		echo ""
+		echo "=== TRIAGE ($1) n=$N at $(date) ==="
+		while IFS='|' read -r name url; do
+			[ -z "$name" ] && continue
+			printf '  %-14s ' "$name"
+			curl -s -o /dev/null -m 10 -u "$AUTH" \
+				-w 'HTTP %{http_code}  %{time_total}s\n' "$url" \
+				|| echo "no answer within 10s"
+		done <<-PROBES
+			httpd-root|$BASE/
+			httpd-jes|$BASE/jes/status
+			mvsmf-info|$BASE/zosmf/info
+			mvsmf-version|$BASE/zosmf/test?fn=version
+			console-log|$BASE/zosmf/restconsoles/v1/log?timeRange=5m
+		PROBES
+	} 2>&1 | tee -a "$TRIAGE" | tee -a "$LOG"
+
+	if [ -n "$HERC_LOG" ]; then
+		local hhost="${HERC_LOG%%:*}"
+		local hpath="${HERC_LOG#*:}"
+		echo "  capturing hercules log tail from $hhost" | tee -a "$LOG"
+		ssh -o ConnectTimeout=10 "$hhost" "tail -300 '$hpath'" \
+			> "herc-at-fail-${STAMP}.log" 2>/dev/null \
+			&& echo "  -> herc-at-fail-${STAMP}.log" | tee -a "$LOG"
+	fi
+}
+
+# Rolling MTT snapshot. A hang is explained by the state BEFORE it, which is
+# exactly the state a post-mortem capture can no longer reach.
+ring_snapshot() {
+	local f="mtt-ring-${STAMP}-$((N / RING_EVERY % RING_KEEP)).json"
+	curl -s -m 20 -u "$AUTH" "$BASE/zosmf/test?fn=mtt&step=3" > "$f" 2>/dev/null
+}
+
 req() { # req <label> <curl args...>
 	local label="$1"
 	shift
-	local code
-	code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 90 "$@")
-	echo "$(date +%H:%M:%S) $N $label $code" >>"$LOG"
+	local out code secs
+
+	out=$(curl -s -o /dev/null -m "$MAXTIME" \
+		-w '%{http_code} %{time_total}' "$@")
+	code="${out%% *}"
+	secs="${out##* }"
+
+	echo "$(date +%H:%M:%S) $N $label $code ${secs}s" >>"$LOG"
+
+	# slow but still answering: capture NOW, while there is something to ask
+	if [ "$code" = "200" ] &&
+	   [ "$(printf '%.0f' "${secs:-0}" 2>/dev/null || echo 0)" -ge "$SLOW_SECS" ]; then
+		echo "SLOW n=$N label=$label ${secs}s at $(date)" | tee -a "$LOG"
+		triage "slow response: $label took ${secs}s"
+		return 0
+	fi
+
 	if [ "$code" != "200" ]; then
 		echo "FAILED n=$N label=$label code=$code at $(date)" | tee -a "$LOG"
-		curl -s "$BASE/zosmf/test?fn=mtt&step=3" -u "$AUTH" \
-			>"mtt-at-fail-${STAMP}.json"
-		curl -s "$BASE/zosmf/restconsoles/v1/log?timeRange=5m" -u "$AUTH" \
-			>"log-at-fail-${STAMP}.json"
+		triage "request failed: $label code=$code"
+		echo "evidence: $LOG $TRIAGE mtt-ring-${STAMP}-*.json" | tee -a "$LOG"
 		exit 1
 	fi
 }
 
 echo "soak started $(date) base=$BASE" | tee "$LOG"
+echo "  slow>=${SLOW_SECS}s  maxtime=${MAXTIME}s  ring every ${RING_EVERY}" | tee -a "$LOG"
+[ -n "$HERC_LOG" ] && echo "  hercules log: $HERC_LOG" | tee -a "$LOG"
 N=0
 START=$(date +%s)
 
@@ -83,11 +186,13 @@ while true; do
 		done
 
 	else
-		# unsol_sync — holds a worker in the 581-588 poll loop.
+		# unsol_sync — holds a worker in the poll loop.
 		# Dominant heap-churn driver: cmtt_new/cmtt_free per iteration.
 		req "unsol" -X PUT "$CONSOLE" -u "$AUTH" -H "$CT" -H "$CSRF" \
 			-d '{"cmd":"D T","unsol-key":"ZZZNOMATCH","unsol-detect-sync":"Y","unsol-detect-timeout":"10"}'
 	fi
+
+	[ $((N % RING_EVERY)) -eq 0 ] && ring_snapshot
 
 	if [ $((N % 100)) -eq 0 ]; then
 		ELAPSED=$(($(date +%s) - START))

--- a/tests/watch-workers.sh
+++ b/tests/watch-workers.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# tests/watch-workers.sh — catch the FIRST httpd worker that wedges, and record
+# the exact instruction it is sitting on.
+#
+# Usage:  ./tests/watch-workers.sh &            # alongside a soak run
+#         SOAKLOG=soak-176-*.log ./tests/watch-workers.sh &
+#
+# Tunables (env): INTERVAL SOAKLOG HERC_HOST HERC_PORT SSH_HOST HERC_LOG
+#
+# WHY
+#   Under sustained console load, workers stop dispatching one at a time while
+#   still reporting STATE RUNNING (#217). The server keeps serving on the ones
+#   that are left, so nothing is visible until the last one goes -- by which
+#   point the server answers nothing and cannot be interrogated at all.
+#
+#   The window between the first wedge and the last is long (half an hour or
+#   more was observed). This watches for the first one, while the server is
+#   still healthy enough to answer questions about itself.
+#
+# HOW IT READS THE WEDGED TASK
+#   Through httpd's own .dm CGI, NOT through the Hercules storage display.
+#   Hercules resolves addresses in whatever address space is currently
+#   dispatched, and TCBs live in private storage -- reading a worker TCB that
+#   way returns unrelated bytes (it looks like plausible code, which makes the
+#   mistake easy to miss). .dm runs inside httpd, so the addresses mean what
+#   they say.
+#
+#   The chain, verified against a healthy worker:
+#       TCB +00       -> RBP, the current request block
+#       RB  +10       -> RBOPSW: mask, then the instruction address
+#       RB  +1C       -> links back to the TCB (use this to confirm)
+#
+#   Sampling that address several times says whether the task is looping and
+#   over what span -- which is what distinguishes a loop from a long operation,
+#   and what no amount of system-wide PSW sampling can tell you.
+#
+# NOTE ON BASH
+#   /bin/bash on macOS is 3.2: no associative arrays. Per-round state is kept
+#   in a temp file deliberately, not as a style choice.
+
+set -u
+[ -f .env ] && . ./.env
+
+# The other suites in tests/ read MVSMF_*; deploy tooling sets MBT_MVS_*.
+MVSMF_HOST="${MVSMF_HOST:-${MBT_MVS_HOST:-}}"
+MVSMF_PORT="${MVSMF_PORT:-${MBT_MVS_PORT:-}}"
+MVSMF_USER="${MVSMF_USER:-${MBT_MVS_USER:-}}"
+MVSMF_PASS="${MVSMF_PASS:-${MBT_MVS_PASS:-}}"
+
+BASE_HTTP="http://${MVSMF_HOST}:${MVSMF_PORT}"
+AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+
+# Hercules' own HTTP server, used only to issue MVS console commands.
+HERC_HOST="${HERC_HOST:-$MVSMF_HOST}"
+HERC_PORT="${HERC_PORT:-8181}"
+HERC="http://${HERC_HOST}:${HERC_PORT}/cgi-bin/api/v1/syslog"
+
+# The emulator host's log, where httpd's replies land. Optional: without ssh
+# access the thread display cannot be read back and this script cannot work.
+SSH_HOST="${SSH_HOST:-$MVSMF_HOST}"
+HERC_LOG="${HERC_LOG:-/home/mike/MVSCE/hercules.log}"
+
+INTERVAL="${INTERVAL:-90}"
+SOAKLOG="${SOAKLOG:-}"
+OUT="worker-watch-$(date +%Y%m%d-%H%M%S).txt"
+
+herc() { curl -s -m 20 -G --data-urlencode "command=$1" "$HERC" >/dev/null; }
+
+dm() { # dm <addr> [len] -> "+00000 wwwwwwww wwwwwwww ..."
+	curl -s -m 30 -u "$AUTH" "$BASE_HTTP/.dm?memory=$1&length=${2:-48}&chunk=16" \
+		| LC_ALL=C sed -e 's/<[^>]*>/ /g' | LC_ALL=C tr -s ' \n' ' \n' | grep -aE '^\+'
+}
+
+resume_psw() { # resume_psw <tcb>
+	local rb psw back
+	rb=$(dm "$1" 16 | head -1 | awk '{print $2}')
+	if [ -z "$rb" ]; then echo "  TCB $1: unreadable"; return; fi
+	psw=$(dm "$rb" 32 | awk '$1=="+00010" {print $2, $3}')
+	back=$(dm "$rb" 32 | awk '$1=="+00010" {print $5}')
+	echo "  TCB $1  RB $rb  RBOPSW $psw  (RB+1C=$back)"
+}
+
+# One "tcb disp state" line per worker, newest state only: the log tail can
+# span more than one D THREADS block and a round must never mix two dumps.
+snap() {
+	herc "/F HTTPD,D THREADS"
+	sleep 6
+	ssh -o ConnectTimeout=10 "$SSH_HOST" "tail -220 '$HERC_LOG'" 2>/dev/null | awk '
+		/HTTPD104I/ { for(i=1;i<=NF;i++) if($i ~ /TCB$/ && $i !~ /OWNTCB/) tcb=$(i+1) }
+		/HTTPD114I/ { st=$NF }
+		/HTTPD117I/ { d=""
+		              for(i=1;i<=NF;i++) if($i ~ /^[0-9A-F]{16}$/) d=$i
+		              if (tcb != "" && d != "") print tcb, d, st
+		              tcb=""; d=""; st="" }' \
+		| awk '{ last[$1] = $0 } END { for (k in last) print last[k] }'
+}
+
+echo "watching every ${INTERVAL}s -> $OUT" | tee "$OUT"
+PREV=$(mktemp)
+trap 'rm -f "$PREV"' EXIT
+round=0
+
+while true; do
+	round=$((round + 1))
+	now=$(snap)
+	if [ -z "$now" ]; then
+		echo "$(date +%H:%M:%S) round $round: no thread data (server gone?)" | tee -a "$OUT"
+		sleep "$INTERVAL"; continue
+	fi
+
+	stuck=""
+	while read -r tcb disp state; do
+		[ -z "${tcb:-}" ] && continue
+		# RUNNING with an unchanged dispatch stamp across a whole interval:
+		# it is not serving a slow request, it has stopped coming back.
+		if [ "$state" = "RUNNING" ] && grep -q "^$tcb $disp\$" "$PREV" 2>/dev/null; then
+			stuck="$stuck $tcb"
+		fi
+	done <<< "$now"
+	echo "$now" | awk '{print $1, $2}' > "$PREV"
+
+	{
+		echo "$(date +%H:%M:%S) round $round:"
+		echo "$now" | sed 's/^/    /'
+	} | tee -a "$OUT"
+
+	if [ -n "$stuck" ]; then
+		{
+			echo ""
+			echo "*** WEDGED (RUNNING, dispatch frozen across ${INTERVAL}s):$stuck"
+			echo ""
+			echo "--- resume PSW, 5 samples 4s apart ---"
+			echo "    a fixed or narrowly ranging address is the loop"
+		} | tee -a "$OUT"
+
+		for pass in 1 2 3 4 5; do
+			echo "  pass $pass:" | tee -a "$OUT"
+			for t in $stuck; do resume_psw "$t" | tee -a "$OUT"; done
+			sleep 4
+		done
+
+		echo "--- httpd stats ---" | tee -a "$OUT"
+		herc "/F HTTPD,D STATS"; sleep 5
+		ssh "$SSH_HOST" "tail -12 '$HERC_LOG'" 2>/dev/null | grep -E "HTTPD41[12]I" | tee -a "$OUT"
+
+		echo "--- hercules tail ---" | tee -a "$OUT"
+		ssh "$SSH_HOST" "tail -60 '$HERC_LOG'" >> "$OUT" 2>/dev/null
+
+		if [ -n "$SOAKLOG" ] && [ -f "$SOAKLOG" ]; then
+			echo "--- soak requests in flight (last 25) ---" | tee -a "$OUT"
+			tail -25 "$SOAKLOG" | tee -a "$OUT"
+		fi
+
+		echo "*** evidence in $OUT" | tee -a "$OUT"
+		exit 0
+	fi
+
+	sleep "$INTERVAL"
+done


### PR DESCRIPTION
Checks in the console soak harness that has lived untracked since July, and reworks its evidence capture after it lost the evidence on its first real find.

Relates to #185 (the clamp load-validation item), #176, #217.

## The scripts

```
churn-176.sh     concurrent unsolicited-detect churn, every request logged
loadtest-176.sh  three arms isolating which layer faults (A/B/C)
soak-176.sh      long-running mixed load
```

They were the harness for hunting the intermittent console S0C4. The release epic still carries a load-validation item for the `mtentlen` clamp, and this is the harness that item means — it belongs in the tree, not in one working copy.

## Not committed as found

**Environment.** They read `MBT_MVS_*` while every other suite in `tests/` reads `MVSMF_*`. Both now work, preferring `MVSMF_*`, so one `.env` drives everything.

**Artefacts.** Their logs and snapshots landed untracked in the working tree; the names are now gitignored.

**A refuted lead removed.** `soak-176.sh` recommended adding a command that emits `+` write-to-programmer WTOs, on the theory that the `+` shifted the MTT column layout. That was refuted while fixing #174 — the source field sits at the same offset either way. The note now says so, instead of sending the next reader down it.

**A command added.** `F UFSD,STATUS`. Since #174 the walk processes entries the source predicate used to skip, and that is precisely what turned a raw `mtentlen` read into a live S0C4 during that work. A soak issuing only `D`-commands never reaches the path the clamp exists to protect.

## The capture rework

The first instrumented run found something real — the server hangs under sustained load (#217) — and then **produced two 0-byte snapshots**. The harness only reacted to a *failed* request, and by the time a request fails the server is gone, so the capture requests fail too. A run that cost a server restart yielded a log full of 200s and nothing about the hang.

Three changes follow from that:

**Trip on slow, not failed.** The console sync capture polls ~3 s by design, so past ~15 s is already abnormal. Waiting out the old 90 s timeout was how the evidence was lost. Hard timeout drops to 45 s.

**`triage()` — a probe ladder.** A hang looks identical from any one endpoint. Five probes with short timeouts, from "no mvsMF involved" to "the console path":

```
httpd-root -> httpd-jes -> mvsmf-info -> mvsmf-version -> console-log
```

The boundary where answers stop is the discriminator:

| pattern | reading |
|---|---|
| all answer | the slow request was an outlier, not a wedge |
| httpd yes, mvsMF no | module cannot be loaded — the S80A shape (#212, httpd#154) |
| mvsMF yes, console no | console-specific; shared state |
| nothing answers | every worker parked, upstream of the console handlers |

Status codes are read as "did something answer", not "was it happy" — `httpd-root` returns 404 on a healthy system and that is a pass here.

It optionally pulls the hercules log tail over ssh (`SOAK_HERC_LOG=user@host:/path`), because the abend evidence lives on the emulator host and never appears in an HTTP response.

**A rolling MTT snapshot**, three deep, every 50 iterations. The state that explains a hang is the state from *before* it — exactly what a post-mortem capture can no longer reach.

## tests/jcl/mvsmfact.jcl

The compress-then-copy job for activating a build on the running httpd. `HTTPD.LINKLIB` hit its extent limit three times in one session; the `SE37` that follows is clean — it abends before writing, so the existing member and the running server are unharmed — but nothing is activated until the library is compressed, and compress needs the server stopped.

The header records that, the enqueue behaviour of `DISP=OLD`, that the STEPLIB name differs per stand (`HTTPD.LINKLIB` here, `HTTPD.LINKLIBT` elsewhere) with how to check which one holds the member, and how to confirm the result afterwards.

The blanket `*.jcl` ignore hid the file. The three fixtures already in `tests/jcl/` predate that rule and were force-added, so the exception is now explicit rather than folklore.

## Verification

Shell syntax checked. The triage ladder was dry-run against the live server and all five probes answer — that is the healthy baseline the next run is compared against. No production code is touched by this PR.
