### PR TITLE
fix(dsapi): register the member-list file handle so recovery can close it

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1434,6 +1434,14 @@ int memberListHandler(Session *session)
 		goto quit;
 	}
 
+	/* The handle is held across the whole streaming loop, which on a large
+	   directory runs for seconds. If this handler abends in that window the
+	   quit: path below never runs, and an unregistered handle is one that
+	   session_cleanup() cannot find -- the data set then stays allocated to
+	   the address space for good, and the next DELETE of it waits on the
+	   SCRATCH enqueue forever, costing a worker permanently (#217). */
+	session_register_file(session, fp);
+
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc,200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
@@ -1513,7 +1521,7 @@ int memberListHandler(Session *session)
 
 quit:
 	if (fp) {
-		fclose(fp);
+		session_fclose(session, fp);
 	}
 
 	return rc;


### PR DESCRIPTION
Refs #217. One half of the root cause found tonight — the half that is mine.

## What was wrong

Every long-lived `fopen()` in this code base registers its handle with the session so `session_cleanup()` can close it if the handler abends — `dsapi.c:924`, `:1023`, `:1569`, `:1679`, `jobsapi.c:1389`. The member list did not. I introduced that with the streaming rewrite in #213.

The handle is held across the whole streaming loop, which on a large directory runs for seconds. The bare `fclose()` in the `quit:` path covers the error returns and nothing else; an abend in that window unwinds straight past it, and `session_cleanup()` walks `session->open_files[]`, where an unregistered handle does not appear.

## Why a leaked handle is so expensive

`datasetDeleteHandler` calls `remove()`, which SCRATCHes the data set. SCRATCH needs exclusive control, so against a still-allocated data set it **waits on the enqueue** — no timeout, no quiesce check, no CPU burn. The worker never comes back.

Observed live during a load run:

```
PID    ELAPSED  COMMAND
24435    09:13  curl -s -X DELETE .../zosmf/restfiles/ds/IBMUSER.CURL.TESTSEQ
```

Nine minutes outstanding while `/zosmf/info` still answered in 40 ms. Reproduced in isolation: `HTTP 000 in 45.003s`. Shortly after, the server was gone — nine workers `RUNNING`, `Active: 15`, `P HTTPD` reporting success while recovering nothing, and only CANCEL clearing it.

That is the shape #217 has had all day: healthy right up to the moment the last worker goes, because workers are lost one at a time and nothing reports it.

## The fix

The contract the neighbouring handlers already follow: `session_register_file()` after the open, `session_fclose()` on the way out.

## What this does not fix

There are two ways a handle survives a failure, and this addresses one:

1. **never registered** — `session_cleanup()` cannot find it. Fixed here.
2. **registered, and recovery abended inside its own `fclose`** — that is #101, and it leaves the allocation in place with an identical outcome.

The hang that exposed this was on a *sequential* data set, which the member-list handler never opens (it is gated behind `require_pds()`). So case 2 produced that particular one. I have commented on #101 accordingly and raised it to priority:high; it is not a curiosity, it is the other half.

The two remaining bare `fopen()`s in this file (`:1009`, `:2378`) are existence probes that open, test and close with nothing in between — a few instructions rather than seconds. Left as they are.

## Verification status — read before merging

**This is not verified on a live system.** The server is currently down: after the reproduction it needed repeated CANCELs and there are now two `HTTPD` address spaces in `D A,L` with port 8080 unresponsive. I stopped escalating rather than issuing `FORCE` on a system I can only see through a keyhole while its owner is asleep.

The change compiles clean and follows an established pattern in the same file, but it has not been exercised. Worth running `tests/curl-datasets.sh` against it before this lands.
