### PR TITLE
fix(jobsapi): grow the JCL line table without tearing it apart

### DIFF
--- a/include/jclines.h
+++ b/include/jclines.h
@@ -1,0 +1,40 @@
+#ifndef JCLINES_H
+#define JCLINES_H
+
+/**
+ * @file jclines.h
+ * @brief Growth of the JCL line table used by the job-submission paths.
+ *
+ * The submit paths in jobsapi.c hold a JCL deck as two allocations:
+ *
+ *   - `lines_buf` — one contiguous block of `capacity` fixed 81-byte slots
+ *     (an 80-byte card image plus its NUL terminator), and
+ *   - `lines` — an array of `capacity` pointers, where `lines[i]` always
+ *     addresses `lines_buf + i * 81`.
+ *
+ * The pair is a single logical object: the pointer array is only meaningful
+ * while every entry addresses the live buffer at the recorded capacity.
+ * grow_lines_arrays() is the only place that resizes it, and it is therefore
+ * the only place that can tear it apart.
+ *
+ * See issue #220.
+ */
+
+/**
+ * Grow the line table so it holds at least `required` lines.
+ *
+ * On success returns 0 with all three out-params updated in step.
+ *
+ * On failure returns -1 leaving the caller's view of the table exactly as it
+ * was: `*capacity_p` and `*lines_buf_p` are untouched, and entries
+ * [0, *capacity_p) of `*lines_p` still address that same live buffer. The
+ * caller may keep using the table at its old capacity, and frees `*lines_p`
+ * and `*lines_buf_p` as usual. (`*lines_p` may have been replaced by a larger
+ * -- harmlessly over-allocated -- array; see the ordering note in jclines.c.)
+ *
+ * A no-op returning 0 when `required` already fits.
+ */
+int grow_lines_arrays(char ***lines_p, char **lines_buf_p,
+                      int *capacity_p, int required)          asm("MFJCLGRW");
+
+#endif /* JCLINES_H */

--- a/project.toml
+++ b/project.toml
@@ -40,5 +40,14 @@ name = "TSTMTLN"
 sources = ["test/host/tstmtln.c"]
 norent = true
 
+# TSTJCLN: #220 — a failed realloc while growing the JCL line table must leave
+# the lines[] array and the line buffer consistent. Portable C (test-host); the
+# TU #includes src/jclines.c with a fault-injecting realloc, so it exercises the
+# real grow_lines_arrays() rather than a copy — do not list jclines.c here.
+[[test]]
+name = "TSTJCLN"
+sources = ["test/host/tstjcln.c"]
+norent = true
+
 [release]
 version_files = ["VERSION"]

--- a/src/jclines.c
+++ b/src/jclines.c
@@ -1,0 +1,85 @@
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jclines.h"
+
+/*
+ * JCL line table growth. See jclines.h for the shape of the table and the
+ * failure contract; issue #220 for why the failure contract matters.
+ *
+ * Lives in its own translation unit so test/host/tstjcln.c can pull in this
+ * source with a fault-injecting realloc and exercise the real function --
+ * jobsapi.c itself cannot compile on the host.
+ */
+
+/* Bytes per line slot: an 80-byte card image plus its NUL terminator. The
+ * callers in jobsapi.c size their initial calloc() with the same stride. */
+#define LINE_STRIDE 81
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'grow_lines_arrays'");
+#endif
+int
+grow_lines_arrays(char ***lines_p, char **lines_buf_p, int *capacity_p, int required)
+{
+	int    old_cap;
+	int    new_cap;
+	char  *new_buf;
+	char **new_lines;
+	int    i;
+
+	old_cap = *capacity_p;
+	if (required <= old_cap) {
+		return 0;
+	}
+
+	new_cap = old_cap;
+	while (new_cap < required) {
+		if (new_cap > INT_MAX / 2) {
+			return -1;      /* doubling would overflow the int capacity */
+		}
+		new_cap *= 2;
+	}
+
+	/*
+	 * Order matters, and it is the fix for #220.
+	 *
+	 * The pointer array is grown FIRST because that realloc cannot invalidate
+	 * lines_buf: if it fails, nothing has been touched and every out-param is
+	 * still exactly what the caller passed in.
+	 *
+	 * The buffer is grown SECOND. A failing realloc leaves its original block
+	 * intact, so entries [0, old_cap) of new_lines -- copied over by the
+	 * successful realloc above -- still address live storage. new_lines must
+	 * nevertheless be handed back, because the old array was freed by that
+	 * realloc; but *capacity_p and *lines_buf_p stay untouched, so the caller
+	 * still sees the same capacity over the same buffer. The only residue is
+	 * an over-allocated pointer array, released by the caller's normal free().
+	 *
+	 * Growing the buffer first (as this did before) cannot offer that: by the
+	 * time the second realloc fails the old buffer is already gone, and every
+	 * entry in the caller's pointer array dangles.
+	 */
+	new_lines = (char **)realloc(*lines_p, (size_t)new_cap * sizeof(char *));
+	if (!new_lines) {
+		return -1;
+	}
+
+	new_buf = (char *)realloc(*lines_buf_p, (size_t)new_cap * LINE_STRIDE);
+	if (!new_buf) {
+		*lines_p = new_lines;
+		return -1;
+	}
+	memset(new_buf + (size_t)old_cap * LINE_STRIDE, 0,
+		   (size_t)(new_cap - old_cap) * LINE_STRIDE);
+
+	for (i = 0; i < new_cap; i++) {
+		new_lines[i] = new_buf + (i * LINE_STRIDE);
+	}
+
+	*lines_buf_p = new_buf;
+	*lines_p     = new_lines;
+	*capacity_p  = new_cap;
+	return 0;
+}

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -17,6 +17,7 @@
 
 #include "common.h"
 #include "httpcgi.h"
+#include "jclines.h"
 #include "jobsapi.h"
 #include "jobsapi_msg.h"
 #include "json.h"
@@ -1297,47 +1298,6 @@ extract_file_value(char *json, size_t len)
 	*val_end = '\0';
 
 	return val_start;
-}
-
-__asm__("\n&FUNC	SETC 'grow_lines_arrays'");
-static int
-grow_lines_arrays(char ***lines_p, char **lines_buf_p, int *capacity_p, int required)
-{
-	int new_cap;
-	char *new_buf;
-	char **new_lines;
-	int i;
-
-	if (required <= *capacity_p) {
-		return 0;
-	}
-
-	new_cap = *capacity_p;
-	while (new_cap < required) {
-		new_cap *= 2;
-	}
-
-	new_buf = (char *)realloc(*lines_buf_p, (size_t)new_cap * 81);
-	if (!new_buf) {
-		return -1;
-	}
-	memset(new_buf + (size_t)(*capacity_p) * 81, 0,
-		   (size_t)(new_cap - *capacity_p) * 81);
-
-	new_lines = (char **)realloc(*lines_p, (size_t)new_cap * sizeof(char *));
-	if (!new_lines) {
-		*lines_buf_p = new_buf;
-		return -1;
-	}
-
-	for (i = 0; i < new_cap; i++) {
-		new_lines[i] = new_buf + (i * 81);
-	}
-
-	*lines_buf_p = new_buf;
-	*lines_p = new_lines;
-	*capacity_p = new_cap;
-	return 0;
 }
 
 __asm__("\n&FUNC	SETC 'submit_file'");

--- a/test/host/tstjcln.c
+++ b/test/host/tstjcln.c
@@ -1,0 +1,198 @@
+/*
+ * tstjcln.c - #220 regression: growing the JCL line table must never leave the
+ * pointer array and the line buffer out of sync.
+ *
+ * Root: grow_lines_arrays() resized lines_buf first and the lines[] pointer
+ * array second. When the second realloc failed it stored the already-grown
+ * buffer back into *lines_buf_p and returned -1 without updating *capacity_p
+ * or *lines_p -- so the caller was left holding a NEW buffer described by an
+ * OLD pointer array, every entry of which addressed the block realloc had just
+ * released. Both submit paths (jobsapi.c submit_file / submit_jcl_content)
+ * bail on -1 and only free(), so the torn state was never dereferenced; but
+ * since libc370#81 (fixed by libc370#82) realloc can genuinely fail, so the
+ * state became reachable rather than theoretical.
+ *
+ * Fix: grow the pointer array first, the buffer second. A failure then leaves
+ * the caller's view of the table byte-for-byte as it was.
+ *
+ * ====================================================================
+ * This test drives the REAL function. src/jclines.c is #included below
+ * with realloc macro-substituted for a fault injector, so the code under
+ * test is the shipping code, not a mirror of it -- a later refactor of
+ * grow_lines_arrays() stays covered. jobsapi.c itself cannot compile on
+ * the host (file-scope HLASM asm labels + MVS intrinsics), which is why
+ * the function lives in its own TU.
+ * ====================================================================
+ *
+ * The assertions are deliberately written against the INVARIANT rather than
+ * the call order, so they are a red->green gate: they fail on the old
+ * buffer-first code and pass on the fixed pointer-array-first code.
+ * Runs on host via `make test-host`.
+ */
+#include <stdio.h>
+#include <stdlib.h>   /* LOAD-BEARING: must precede the realloc macro below, so
+                       * that the macro rewrites call sites in the source under
+                       * test and never the declaration itself. Do not remove or
+                       * reorder when tidying these includes. */
+#include <string.h>
+#include <limits.h>
+
+#include <mbtcheck.h>
+
+/* ---- fault-injecting allocator -------------------------------------------
+ * fail_at is the 0-based ordinal of the realloc call to fail (-1 = never).
+ * The real headers are already included above, so the macro below rewrites
+ * only the call sites inside the source under test. */
+static int tst_fail_at = -1;
+static int tst_calls   = 0;
+
+static void *tst_realloc(void *p, size_t n)
+{
+	int seq = tst_calls++;
+
+	if (seq == tst_fail_at) {
+		return NULL;
+	}
+	return realloc(p, n);
+}
+
+#define realloc tst_realloc
+#include "../../src/jclines.c"
+#undef realloc
+
+/* ---- table helpers (mirror how jobsapi.c builds the pair) ----------------- */
+
+#define TST_CAP     8            /* small enough to keep the test cheap       */
+#define TST_STRIDE  81
+
+static char **g_lines;
+static char  *g_buf;
+static int    g_cap;
+
+static void table_new(void)
+{
+	int i;
+
+	g_cap   = TST_CAP;
+	g_lines = (char **)calloc(g_cap, sizeof(char *));
+	g_buf   = (char *)calloc(g_cap, TST_STRIDE);
+	for (i = 0; i < g_cap; i++) {
+		g_lines[i] = g_buf + (i * TST_STRIDE);
+	}
+	/* content the caller would still expect to read back after a failed grow */
+	strcpy(g_lines[0], "//TSTJCLN JOB (ACCT),'MVSMF',CLASS=A");
+	strcpy(g_lines[TST_CAP - 1], "//SYSIN DD *");
+}
+
+static void table_free(void)
+{
+	free(g_lines);
+	free(g_buf);
+	g_lines = NULL;
+	g_buf   = NULL;
+}
+
+/* Every entry below the recorded capacity addresses the live buffer. */
+static int table_consistent(void)
+{
+	int i;
+
+	for (i = 0; i < g_cap; i++) {
+		if (g_lines[i] != g_buf + (i * TST_STRIDE)) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+/* Run one grow with the Nth realloc forced to fail (-1 = let them all pass). */
+static int grow_with_failure_at(int nth, int required)
+{
+	tst_calls   = 0;
+	tst_fail_at = nth;
+	return grow_lines_arrays(&g_lines, &g_buf, &g_cap, required);
+}
+
+int main(void)
+{
+	int   rc;
+	char *saved_buf;
+	int   saved_cap;
+
+	printf("=== TSTJCLN: #220 atomic JCL line table growth ===\n");
+
+	/* 1. baseline -- an uninterrupted grow commits all three out-params */
+	table_new();
+	rc = grow_with_failure_at(-1, TST_CAP + 1);
+	CHECK_EQ(rc, 0, "success: grow returns 0");
+	CHECK_EQ(g_cap, TST_CAP * 2, "success: capacity doubled");
+	CHECK(table_consistent(), "success: every entry addresses the live buffer");
+	CHECK(strcmp(g_lines[0], "//TSTJCLN JOB (ACCT),'MVSMF',CLASS=A") == 0,
+		  "success: existing line content preserved");
+	CHECK(g_lines[TST_CAP * 2 - 1][0] == '\0', "success: new tail slots zeroed");
+	table_free();
+
+	/* 2. required already fits -- no-op, no allocation at all */
+	table_new();
+	rc = grow_with_failure_at(-1, TST_CAP);
+	CHECK_EQ(rc, 0, "no-op: grow returns 0 when capacity suffices");
+	CHECK_EQ(tst_calls, 0, "no-op: no realloc issued");
+	CHECK_EQ(g_cap, TST_CAP, "no-op: capacity unchanged");
+	CHECK(table_consistent(), "no-op: table still consistent");
+	table_free();
+
+	/* 3. FIRST realloc fails -- caller's table must be completely untouched */
+	table_new();
+	saved_buf = g_buf;
+	saved_cap = g_cap;
+	rc = grow_with_failure_at(0, TST_CAP + 1);
+	CHECK_EQ(rc, -1, "fail#1: grow reports failure");
+	CHECK_EQ(g_cap, saved_cap, "fail#1: capacity unchanged");
+	CHECK(g_buf == saved_buf, "fail#1: buffer pointer unchanged");
+	CHECK(table_consistent(), "fail#1: table still consistent");
+	table_free();
+
+	/* 4. SECOND realloc fails -- the #220 case. One of the two allocations has
+	 *    already succeeded, so this is where the pair could tear apart. The
+	 *    contract is the same as above: capacity and buffer unchanged, and
+	 *    every entry still addressing that buffer.
+	 *
+	 *    The buffer identity is checked BEFORE any content read: on the old
+	 *    code g_buf has been swapped for the grown block while g_lines[] still
+	 *    points into the released one, and reading through it is undefined.
+	 *    Checking the pointer first turns that into a clean FAIL. */
+	table_new();
+	saved_buf = g_buf;
+	saved_cap = g_cap;
+	rc = grow_with_failure_at(1, TST_CAP + 1);
+	CHECK_EQ(rc, -1, "fail#2: grow reports failure");
+	CHECK_EQ(g_cap, saved_cap, "fail#2: capacity unchanged");
+	CHECK(g_buf == saved_buf, "fail#2: buffer pointer unchanged");
+
+	if (g_buf == saved_buf && table_consistent()) {
+		CHECK(1, "fail#2: table still consistent");
+		CHECK(strcmp(g_lines[0], "//TSTJCLN JOB (ACCT),'MVSMF',CLASS=A") == 0,
+			  "fail#2: line content still readable through lines[]");
+		CHECK(strcmp(g_lines[TST_CAP - 1], "//SYSIN DD *") == 0,
+			  "fail#2: last line still readable through lines[]");
+	} else {
+		CHECK(0, "fail#2: table still consistent");
+		CHECK(0, "fail#2: line content still readable through lines[] (skipped)");
+		CHECK(0, "fail#2: last line still readable through lines[] (skipped)");
+	}
+	table_free();
+
+	/* 5. capacity doubling must not overflow int before any allocation runs */
+	table_new();
+	saved_buf = g_buf;
+	saved_cap = g_cap;
+	rc = grow_with_failure_at(-1, INT_MAX);
+	CHECK_EQ(rc, -1, "overflow: grow refuses an unrepresentable capacity");
+	CHECK_EQ(tst_calls, 0, "overflow: refused before allocating anything");
+	CHECK_EQ(g_cap, saved_cap, "overflow: capacity unchanged");
+	CHECK(g_buf == saved_buf, "overflow: buffer pointer unchanged");
+	CHECK(table_consistent(), "overflow: table still consistent");
+	table_free();
+
+	return mbt_test_summary("TSTJCLN");
+}


### PR DESCRIPTION
Fixes #220

## The defect

`grow_lines_arrays()` resized `lines_buf` first and the `lines[]` pointer array second. When the second `realloc` failed it stored the already-grown buffer back into `*lines_buf_p` and returned -1 **without** updating `*capacity_p` or `*lines_p` — leaving the caller holding a *new* buffer described by an *old* pointer array, every entry of which addressed the block `realloc` had just released.

Both submit paths (`submit_file`, `submit_jcl_content`) bail on -1 and only `free()` the two allocations, so the torn state was never dereferenced and there is no double free. Verified for both callers. But since libc370#81 (fixed by libc370#82, in the sysroot as of 2026-08-09) `realloc` can genuinely fail, so the state is reachable rather than theoretical.

## The fix

Grow the **pointer array first**, the **buffer second**.

- That first `realloc` cannot invalidate `lines_buf`, so if it fails nothing has been touched at all.
- If the *buffer* `realloc` then fails, `realloc` leaves its original block intact, so the entries copied into `new_lines` still address live storage. `new_lines` is handed back (the old array was freed by the successful `realloc`), but `*capacity_p` and `*lines_buf_p` stay untouched — the caller still sees the same capacity over the same buffer. The only residue is a harmlessly over-allocated pointer array, released by the caller's normal `free()`.

### Deviation from the issue's wording

The issue asks to "grow into locals, assign all three out-params only on full success." That is not achievable for the *first* `realloc` — it cannot be rolled back. The alternative that would satisfy it literally, `malloc` + `memcpy` + `free`, doubles peak storage during the copy, which is the wrong trade on a 16 MB machine (root `CLAUDE.md` makes memory priority #1). Ordering achieves the *effect* the issue wants — no observable state changes on failure — at zero extra storage.

### Also in scope

The doubling loop `new_cap *= 2` was unbounded `int` arithmetic. Overflow needs >2^30 lines (~87 GB of buffer) so it is unreachable in practice, but the guard is three lines and this change is about allocation safety. It refuses before allocating anything.

## Testing

`grow_lines_arrays()` moves into its own translation unit (`src/jclines.c` + `include/jclines.h`) so `test/host/tstjcln.c` can `#include` the source with a fault-injecting `realloc` and drive the **real** function — `jobsapi.c` cannot compile on the host (file-scope HLASM asm labels + MVS intrinsics). This is stronger than the mirror-test approach used for TSTMTLN: a later refactor of `grow_lines_arrays()` stays covered.

The assertions are written against the **invariant**, not the call order, which makes the test a genuine red→green gate.

**Red** (old buffer-first ordering restored temporarily) — 20/24, and the four failures are exactly the #220 symptom:

```
  FAIL: fail#2: buffer pointer unchanged
  FAIL: fail#2: table still consistent
  FAIL: fail#2: line content still readable through lines[] (skipped)
  FAIL: fail#2: last line still readable through lines[] (skipped)
=== TSTJCLN: 20/24 passed (4 FAILED) ===
```

**Green** (this branch):

```
  TSTJCLN    ok  rc=0     24 pass / 0 fail
```

Cases covered: successful grow, no-op when capacity suffices, first `realloc` fails, second `realloc` fails (the #220 case), and the overflow guard.

## Verification status

- `make test-host` — **TSTJCLN 24/24 pass.** Note the suite as a whole reports one failure: `TSTNTST FAIL COMPILE`. That is **pre-existing on `main`** (TSTNTST is MVS-only — `__getclk`/`cliblock`) and confirmed unrelated to this branch by running the suite from a clean stash.
- `make` — MVSMF cross-compiles and links clean under `-Wall -Werror`.
- `make test-mvs ARGS="--only TSTJCLN"` — **48 PASS / 0 FAIL** (24 assertions × batch + TSO step), *when the module is linked correctly*. See below.

### On-target run needs a relink until mbt#58 lands

Out of the box `make test-mvs` returns `CC 12` with no output for **every** mvsmf test, including ones merged long before this branch. Root cause is in mbt, not here: its link rules place the staged dependency archives before `-lc`, and httpd's `httpd.a` exports `@@START` (from its CGI launcher `cgistart.o`). Every mvsmf test module is therefore built as a CGI rather than a batch program — it never opens SYSPRINT and exits before `main()`. `EXIT_FAILURE` is 12 on MVS, hence the `CC 12`.

Filed as **mvslovers/mbt#58** with the full evidence. Only mvsmf, httprexx and httplua are affected — they are the only projects whose dependencies export `@@START`.

Relinking the same object with `-lc` ahead of the dependency archives is enough to make it run:

```
ld370 -L$SYSROOT/lib -e @@CRT0 $SYSROOT/lib/crt0.o build/tstjcln.o \
      -lc .mbt/deps/httpd/lib/httpd.a .mbt/deps/ufsd/lib/libufs.a \
      --norent -iebcopy -o build/TSTJCLN
```

```
  TEST       BATCH          TSO
  ---------- -------------- --------------
  TSTJCLN    ok CC 0        ok CC 0

  job MBTTEST JOB00718  | assertions (batch+tso): 48 PASS, 0 FAIL
```

So the fix in this PR is verified on real MVS, in both batch and TSO. Once mbt#58 is fixed, plain `make test-mvs` will run it with no manual step.
