### PR TITLE
test: revive the test suite — mbt link-order bump + TSTNTST marked MVS-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ src/*.s
 
 # Build system
 .env
+# Per-stand connection files (.env.mvsdev, .env.drnmig3a, ...) carry
+# MBT_MVS_PASS just like .env does -- a bare '.env' pattern does not match a
+# suffixed name, so name them explicitly. .env.example is the committed
+# template and stays tracked.
+.env.*
+!.env.example
 *.jcl
 # ...except the test fixtures and operational jobs, which are source.
 # The ones already in tests/jcl/ predate the rule above and were force-added;

--- a/project.toml
+++ b/project.toml
@@ -27,8 +27,12 @@ exclude = ["src/cgxstart.c"]
 # Unit test for the persistent name/value store (MVS-only: __getm/lock/STCK).
 # norent: mbtcheck.h keeps file-static counters; a standalone test needs them
 # in writable storage, so drop the module's RENT attribute.
+# host = false: both TUs include mvssupa.h and ntstore.c calls __getm/__getclk
+# plus cliblock.h -- libc370 services with no host equivalent, so the native
+# compile can only ever fail.  test-mvs still runs it.
 [[test]]
 name = "TSTNTST"
+host = false
 sources = ["test/mvs/tstntst.c", "src/ntstore.c"]
 norent = true
 


### PR DESCRIPTION
Refs #222 — revives the test suite. #222 stays open: one test still fails, for a reason that turns out to be unrelated to either half of that ticket (see below).

## 1. `test-mvs` was dark — mbt submodule bump

Every test module resolved `@@START` from `httpd.a`'s CGI launcher (`cgistart.o`) instead of libc370's, so it started as a CGI, found no HTTP response stream and exited CC 12 before `main()`. Fixed upstream in mvslovers/mbt#58 → mbt `86e1013`, which adds `$(LIBC_FIRST)` to the four `LINK_*` helpers — empty for modules, `-lc` as a target-specific variable on `TEST_IMGS`. The resulting test link:

```
ld370 ... -e @@CRT0 crt0.o build/tstntst.o build/ntstore.o \
      -lc .mbt/deps/httpd/lib/httpd.a .mbt/deps/ufsd/lib/libufs.a -lc --norent ...
```

Verified against the acceptance check from #222 — the EBCDIC literal `cgistart` (`838789A2A38199A3`):

| module | before | after | |
|---|---|---|---|
| TSTNTST | 1 | **0** | |
| TSTMTLN | 1 | **0** | |
| TSTJCLN | 1 | **0** | |
| MVSMF | 1 | **1** | CGI — must keep httpd's `@@START` |

That also settles the `PRINTF` question raised on #222: `cgistart.o` exports a printf-over-httpx wrapper and mbtcheck writes its whole PASS/FAIL output through `printf`. With libc370 scanned first the member is not pulled in at all — one defect, not two.

**The production module is untouched, measured not assumed.** Rebuilding MVSMF against the previous mbt (`bf0e081`) and against `86e1013` yields the same load module:

```
d0c2d6e1d057ced73d32b47b3f81554f4980edd158599e9a7777c5ae1a76bfcd  build/MVSMF
```

mbt `86e1013` also adds the `//SYSTERM DD` libc370 expects to both runner legs.

## 2. TSTNTST was listed host-runnable but cannot compile natively

Both its TUs include `mvssupa.h`, and `src/ntstore.c` calls `__getm`/`__getclk` and includes `cliblock.h` — libc370 services the host `cc` has neither headers nor an implementation for. `make test-host` reported `FAIL COMPILE` on every run. Marked `host = false` (mbt's opt-out for pure-C tests using MVS-only runtime services).

## Verification

`make test-host`:

```
TSTJCLN    ok  rc=0     24 pass / 0 fail
TSTMTLN    ok  rc=0     8 pass / 0 fail
skipped (MVS-only): TSTNTST (host = false)
2 host test(s) | assertions: 32 PASS, 0 FAIL
```

`make test-mvs` against mvsdev, job MBTTEST JOB00920 — **from 0 assertions to 64**:

```
  TEST       BATCH          TSO
  ---------- -------------- --------------
  TSTJCLN    ok CC 0        ok CC 0
  TSTMTLN    ok CC 0        ok CC 0
  TSTNTST    FAIL ABEND S0C4 FAIL CC 12

  assertions (batch+tso): 64 PASS, 0 FAIL
```

## What the remaining S0C4 actually is — a cc370 miscompile, and it ships in production

TSTNTST reaches `main()` for the first time since it was written and abends. It is **not** a bug in the test, **not** the RENT problem `norent = true` guards against, and **not** an effect of the `-lc`-first relink. It is a cc370 code generation defect in `src/ntstore.c`, and it is compiled into the deployed MVSMF module too.

Attribution, from the SYSUDUMP (`TSTNTST EPA 000957D8`, abend `PSW 00096D30`) — the failing routine's name literal is in the module storage right after its code, so it can be read directly: `@@F6`, which `cc370 -S` identifies as `slot_expired`.

`cc370 -std=gnu99 -O1` (mbt's default, `mk/mbt.mk:40`) emits, for `sl->last_access`:

```
L     2,0(11)        R2 = sl
L     2,16(2)        R2 = sl->last_access, high word   <- clobbers the base register
L     3,4+16(2)      R3 = word at [R2 + 20]            <- reads through data as an address
SRDL  2,32
```

The doubleword load destroys its own base register in the first half, then indexes off the loaded *value*. The dump matches instruction for instruction (`5822 0010`, `5832 0014`), and at abend **R2 = `E31D3F68`** — a TOD clock high word (the same value appears in the ASCB's `EWST`), being used as an address. Hence the S0C4.

`-O2` does not generate this sequence; `-O1` does.

The same eight bytes are present in the production module:

```
$ for m in TSTNTST MVSMF; do xxd -p build/$m | tr -d '\n' | grep -c 5822001058320014; done
1
1
```

`slot_expired` is reached from `nt_set`/`nt_get` whenever a slot is occupied (it is short-circuited behind `name_free()`, so a fresh store does not hit it) — i.e. from the console cursor/detection store on any request after the first that populates a slot.

Filing this separately; it needs a cc370 issue and a decision on the mvsmf-side workaround. Not in scope for this PR, which only makes the suite capable of finding it.