### PR TITLE
fix(ntstore): pass last_access by value, around a cc370 -O1 miscompile

### DIFF
--- a/src/ntstore.c
+++ b/src/ntstore.c
@@ -39,10 +39,19 @@ static int name_free(const char *n)
 	return 1;
 }
 
-static int slot_expired(const NT_SLOT *sl, unsigned long long now)
+/* Takes last_access BY VALUE, not the slot pointer. Reading a 64-bit member
+ * through a pointer that is dead afterwards makes cc370 -O1 emit
+ *
+ *     L 2,16(2)  /  L 3,4+16(2)
+ *
+ * -- the first half overwrites its own base register and the second half then
+ * indexes off the loaded TOD value, which on a 24-bit machine is nowhere: S0C4.
+ * Passing the value keeps the caller's `s` live across its loop, so the load
+ * keeps a base register of its own. See issue #225. */
+static int slot_expired(unsigned long long last_access, unsigned long long now)
 {
 	unsigned now_hi = (unsigned)(now >> 32);
-	unsigned acc_hi = (unsigned)(sl->last_access >> 32);
+	unsigned acc_hi = (unsigned)(last_access >> 32);
 	return (now_hi - acc_hi) >= KVS_TTL_TICKS;
 }
 
@@ -88,7 +97,7 @@ int nt_set(NT_STORE *s, const char *name, const void *val, unsigned len)
 	if (!target) {
 		for (i = 0; i < s->nslots; i++) {
 			if (name_free(s->slot[i].name) ||
-			    slot_expired(&s->slot[i], now)) {
+			    slot_expired(s->slot[i].last_access, now)) {
 				target = &s->slot[i];
 				break;
 			}
@@ -138,7 +147,7 @@ int nt_get(NT_STORE *s, const char *name, void *buf, unsigned max,
 		if (name_free(s->slot[i].name)) {
 			continue;
 		}
-		if (slot_expired(&s->slot[i], now)) {
+		if (slot_expired(s->slot[i].last_access, now)) {
 			continue;                    /* expired -> treat as miss */
 		}
 		if (name_eq(s->slot[i].name, name)) {


### PR DESCRIPTION
Fixes #225.

`slot_expired()` read `sl->last_access` through a `NT_SLOT *`. cc370 at `-O1` (mbt's default) compiled that 64-bit load as:

```
L 2,0(11)      R2 = sl
L 2,16(2)      R2 = sl->last_access, high word   <- clobbers its own base
L 3,4+16(2)    R3 = word at [R2 + 20]            <- indexes off the loaded VALUE
```

The second half uses a TOD clock reading as an address. On a 24-bit machine that is nowhere — S0C4. The SYSUDUMP of TSTNTST carries exactly those bytes (`5822 0010` / `5832 0014`) with **R2 = `E31D3F68`** at abend, the same TOD signature as the ASCB `EWST` field.

## The change

`slot_expired` now takes `last_access` by value:

```c
static int slot_expired(unsigned long long last_access, unsigned long long now)
```

The defect needs three conditions together — a 64-bit load through a pointer with both halves live, a pointer that is **dead afterwards** (so the allocator reuses its register for the destination pair), and `-O1`. Passing the value removes the second: in both call sites `s` stays live across the loop. It also removes the dereference outright — the function now compiles to a subtract and a compare with no pointer at all:

```
L  2,8(11)
S  2,0(11)
LA 3,299(0,0)
CLR 2,3
```

## Verification

This is a register-allocation accident, so none of it is inferred from the source change:

**Generated code.** The regenerated `-O1` assembly for `slot_expired` contains no load whose destination is its own base register.

**Whole-project scan.** Scanning the `-O1` assembly of every `src/*.c` for the pattern (a load clobbering its base, immediately followed by the paired `L d+1,4+disp(base)`) now finds **zero** sites — it found this one before. Controlled against a reproducer holding three known-bad sites, which the same scanner still trips, so the zero is a real negative and not a broken instrument:

```
=== mvsMF after the fix ===
  (no hits)
=== control: reproducer must still trip ===
  repro.s   a_dead
  repro2.s  i_shift16
  repro2.s  j_off0
```

**Built modules.** The byte sequence `5822001058320014` is gone from `build/TSTNTST` **and** `build/MVSMF` — it was compiled into the production module too, not only the test:

```
TSTNTST  0
MVSMF    0
```

**On MVS.** `make test-mvs`, job MBTTEST JOB00922:

```
  TEST       BATCH          TSO
  ---------- -------------- --------------
  TSTJCLN    ok CC 0        ok CC 0
  TSTMTLN    ok CC 0        ok CC 0
  TSTNTST    ok CC 0        ok CC 0

  assertions (batch+tso): 96 PASS, 0 FAIL
```

Up from 64 PASS with TSTNTST abending S0C4 (JOB00920). TSTNTST reproduces the abend reliably, so it guards this change — but note it is not a targeted test of `slot_expired`: it reaches the function only as a side effect of the LRU/TTL steps, which happen to read occupied slots. If someone later moves `slot_expired` back to a pointer parameter, detection depends on some step incidentally hitting an occupied slot. A dedicated case would be a small, separate improvement.

## Scope

This is the local workaround only. The compiler defect is real and general (any `-O1` build in the ecosystem can hit it) and is reported separately against cc370 with a minimal reproducer; the workaround should not wait for a toolchain release.

Not included: whether this ever fired in production. `slot_expired` is reached from `nt_get` for every occupied slot and from `nt_set` while scanning for a free one, both short-circuited behind `name_free()` — so a fresh store survives and the next access after any slot is populated does not. Callers are `consapi.c` only. Establishing whether that explains any observed console S0C4 is a separate question, and deliberately not tested here, since a CGI abend leaks storage until the STC restarts (httpd#154).

## Not yet active

This is built and tested, not deployed. `make deploy` and the activation job were deliberately not run — the module on the stand still carries the `5822001058320014` sequence until someone deploys and activates it.
