### PR TITLE
fix(ctx): pin the NT_STORE to subpool 0, not the ambient one

### DIFF
--- a/src/mvsmfctx.c
+++ b/src/mvsmfctx.c
@@ -1,6 +1,7 @@
 #include "mvsmfctx.h"
 #include "ntstore.h"
 #include "mvssupa.h"    /* __getm */
+#include "clibos.h"     /* __getmsp */
 #include "cliblock.h"   /* lock / unlock, LOCK_EXC */
 #include "httpcgi.h"    /* HTTPD, HTTPX, http_get_httpx, http_cgictx_get */
 
@@ -56,7 +57,14 @@ NT_STORE *mvsmf_kvstore(void *httpd)
 			ctx->ver = 1;
 		}
 		if (!ctx->kvstore) {
-			NT_STORE *store = (NT_STORE *)__getm(sizeof(NT_STORE));
+			/* Subpool 0 explicitly, not the ambient one. This block hangs off
+			 * MVSMF_CTX, which lives in httpd's cgictx[] for the life of the
+			 * address space -- so it must outlive the request. On a route with
+			 * RECLAIM=YES the ambient subpool is non-zero and gets FREEMAINed
+			 * when the module abends or the worker TCB ends, which would leave
+			 * a dangling pointer in an address-space-lifetime block. See #223;
+			 * this mirrors the pin httpd applied to its own registrar. */
+			NT_STORE *store = (NT_STORE *)__getmsp(sizeof(NT_STORE), 0);
 			if (store) {
 				nt_store_init(store);
 				ctx->kvstore = store;


### PR DESCRIPTION
Fixes #223. **This is the merge trigger for mvslovers/httpd#175**, which is deliberately held open until this lands — see the sequencing note at the bottom.

## The change

`src/mvsmfctx.c:59`

```diff
-NT_STORE *store = (NT_STORE *)__getm(sizeof(NT_STORE));
+NT_STORE *store = (NT_STORE *)__getmsp(sizeof(NT_STORE), 0);
```

plus `#include "clibos.h"` and a comment naming why.

The cursor store hangs off `MVSMF_CTX`, which lives in httpd's `cgictx[]` for the life of the address space. Since libc370#89 `__getm()` follows the *ambient* heap subpool, so under httpd's CGI storage reclaim the block lands in the module's subpool. httpd states the consequence more sharply than the issue did (`httpd.h:277`):

> The subpool is per-task, so MVS also releases it when the worker TCB ends — unpinned "persistent" storage does not merely risk the abend path, **it cannot survive at all**.

`__getmsp(size, 0)` (clibos.h, libc370#89) is `__getm()` with the subpool named explicitly, ignoring the ambient value — the same pin httpd applied to its own registrar.

## Audit: this is the only site

Re-checked rather than taken from the issue:

- `src/mvsmfctx.c:59` is the **only** `__getm` in `src/`.
- The four `malloc()` sites (`common.c:264`, `consapi.c:660`, `consapi.c:852`, `consapi.c:1121`, `jobsapi.c:1988`) are request buffers — precisely what the reclaim exists to collect.
- `MVSMF_CTX` carries one pointer field, `kvstore` (`include/mvsmfctx.h:21`), and no other TU writes to it; the `ctx->` hits elsewhere are unrelated local context structs (router's try-context, jobsapi's spool iteration).
- `NT_STORE` allocates nothing internally — fixed slots.
- The `MVSMF_CTX` block itself comes from httpd's `http_cgictx_get()`, already pinned server-side.

## Verification

Generated code goes from `L 15,=V(@@GETM)` to `L 15,=V(@@GETMSP)`. Clean build, no warnings; `make test-host` 32 PASS / 0 FAIL.

The symbol was checked in the archive, not just the header — mbt#22 (`mvslink final link should default to max_rc=0`) is open, so a successful `make` is not by itself evidence that autocall resolved it:

```
$ ar370 t ~/.local/cc370/lib/libc.a | grep GETMSP
  @@GETMSP                       (from @@getm.o)
$ ld370 ... -o build/MVSMF ; echo $?
0                               (no unresolved/undefined lines)
$ xxd -p build/MVSMF | grep -c 7c7cc7c5e3d4e2d7
1                               (EBCDIC '@@GETMSP' -- the member was pulled in)
```

**What is not verified: nothing exercises `mvsmfctx.c`.** TSTNTST drives `ntstore` through its own `__getm`, so the pin itself has no runtime coverage — the verification above is entirely "it compiled, it resolved, it emitted the right V-con". That is proportionate for a change with no behaviour delta on the current dependency, but it is not a test.

**No behaviour change on the current dependency.** The staged httpd 4.0.0-dev predates the reclaim — its header has no `HTTP_CGI_SUBPOOL` and its `httpd.a` carries no `SETSP`/`GETMSP` symbols at all, so `cgistart` never sets a subpool and the ambient value is 0. Explicit 0 and ambient 0 are the same allocation today. This lands *ahead* of the httpd bump, not after it.

## One correction to the issue text

#223 was written before httpd#174/#175, so its closing instruction — "until this lands, the `/zosmf/*` routes must not carry `RECLAIM=YES`" — no longer describes the risk. The keyword is retired and the reclaim is **unconditional**. The gate is therefore not a Parmlib keyword anyone can avoid, but the dependency itself: *do not rebuild mvsMF against post-#154 httpd until this is in*.

## Sequencing

httpd#175 is held open specifically so that `main` stays deployable against the running fleet — merged, a routine `make deploy` would put this unpinned store into the request subpool and produce a use-after-free in an address-space-lifetime block. With this merged, that ordering constraint is gone:

1. merge this
2. merge httpd#175
3. **cut a refreshed `4.0.0-dev` httpd release artifact** — `make deps` resolves against GitHub *Releases*, not `main`, so without this step step 4 silently restages the same pre-reclaim archive and nothing changes. (Alternative for a trial run: a gitignored `.mbt/deps.local.toml` `[override]`.) Worth agreeing which of the two before scheduling the window.
4. `make deps` in mvsMF → rebuild against the new httpd lib → deploy + activate both together

Since the pin has no test coverage, the acceptance drive at step 4 has to cover it explicitly: **populate the store and then read it back** — two console requests on the same connection (an issue/collect that writes a cursor, then a collect that reads it). That round trip is the only thing that tells a working pin apart from a dangling one under the new httpd; a single request cannot, because a fresh store is written before it is ever read.
