### PR TITLE
dsapi: implement start= paging for the dataset and member lists

### DIFF
--- a/docs/endpoints/datasets/list.md
+++ b/docs/endpoints/datasets/list.md
@@ -11,7 +11,9 @@ GET
 ## Query Parameters
 - `dslevel` (required): Dataset name filter pattern. Supports exact names (`USER.TEST.DATA`), hierarchical prefixes (`USER.TEST`), and wildcard patterns (`USER.*`, `USER.**`, `USER.C*`). Internally, the longest concrete prefix is used for the catalog lookup and any wildcard or extra-qualifier filtering is applied afterwards.
 - `volser` (optional): Filter by volume serial
-- `start` (optional): Starting dataset name for pagination
+- `start` (optional): Starting dataset name for pagination. The listing begins
+  at this name — **inclusive**, as in z/OSMF — and runs to the end of the list.
+  The value is folded to upper case and trailing blanks are trimmed.
 
 ## Request Headers
 - `X-IBM-Max-Items` (optional): Maximum number of items to return. Value `0` means unlimited (default behavior). When the result set is truncated, `moreRows` is set to `true`.
@@ -52,10 +54,22 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
 - `cdate`: Creation date
 - `rdate`: Last referenced date
 
+## Pagination
+
+The result is sorted by dataset name in EBCDIC order before anything is
+emitted, and `start` is compared in that same order. Sorting is not cosmetic:
+`start` paging asks for the next page *by name*, so an entry out of order would
+be skipped for good once a page boundary passed it — LISTC returns a level's
+children in catalog order, and the exact-name entry (the `A.B` that `dslevel=A.B`
+returns alongside `A.B.C`) is found separately and would otherwise trail the
+list (issue #232).
+
+Entries skipped by `start` are not charged against `X-IBM-Max-Items`, and
+`moreRows` counts only what is still fetchable from `start` onwards.
+
 ## Limitations
 - Only NONVSAM datasets are listed
 - `*` and `**` wildcards are treated identically (both match any number of qualifiers)
-- `start` parameter is not yet implemented
 
 ## Examples
 

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -17,7 +17,11 @@ or with explicit volume:
 - `volume-serial` (optional): Volume serial number
 
 ## Query Parameters
-- `start` (optional): Starting member name for pagination
+- `start` (optional): Starting member name for pagination. The listing begins at
+  this member — **inclusive**, as in z/OSMF — and runs to the end of the
+  directory. The name is folded to upper case and trailing blanks are trimmed,
+  so a name echoed back from a previous listing (which is still padded to eight
+  characters, issue #154) works unchanged.
 - `pattern` (optional): Member name filter pattern
 
 ## Request Headers
@@ -84,9 +88,21 @@ has to happen first (issue #193). A dataset that was not cataloged used to be
 answered with an empty `items` list and 200, which reads as "this PDS has no
 members".
 
+## Pagination
+
+`X-IBM-Max-Items` caps a page, `start` picks up where the last one ended, and
+`moreRows` says whether anything is left. Members skipped by `start` are not
+charged against the page limit — a page is always `X-IBM-Max-Items` members
+long as long as the directory still holds that many.
+
+The directory is stored in **EBCDIC** order, and `start` is compared in that
+same order — `IEAVNPF1` precedes `IEAVNP03`, because `F` (0xC6) sorts before
+`0` (0xF0). An ASCII comparison would order the two the other way round and
+mis-skip every name mixing letters and digits (issue #232).
+
 ## Limitations
 - No member statistics (TTR, size, dates) are returned yet
-- `start` and `pattern` query parameters are accepted but not yet implemented
+- the `pattern` query parameter is accepted but not yet implemented
 
 ## Examples
 

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <clibary.h>
 #include <clibwto.h>
 #include <cliblist.h>
@@ -658,6 +659,62 @@ jday_to_md(unsigned short year, unsigned short jday,
 	*day_out = (unsigned char)d;
 }
 
+/* Normalise a "start=" query value into a comparison key.
+
+   Both list endpoints page with z/OSMF's start= parameter: the listing begins
+   at that name -- inclusive -- and runs to the end of the list.  Query values
+   reach a CGI already in EBCDIC, so no translation is involved; they do arrive
+   exactly as the client typed them, and a client that feeds a name back from a
+   member listing still carries the blank padding of #154.  Trim that, fold to
+   upper case (both catalog and directory names are upper case), and truncate
+   to what the key can hold.
+
+   Returns 1 when there is a key to compare against, 0 when start= was absent
+   or empty -- list everything. */
+__asm__("\n&FUNC    SETC 'make_start_key'");
+static int
+make_start_key(const char *start, char *key, size_t keylen)
+{
+	size_t	n;
+	size_t	i;
+
+	if (!start) {
+		return 0;
+	}
+
+	n = strlen(start);
+	while (n > 0 && start[n - 1] == ' ') n--;
+
+	if (n == 0) {
+		return 0;
+	}
+
+	if (n > keylen - 1) n = keylen - 1;
+
+	for (i = 0; i < n; i++) {
+		key[i] = (char) toupper((unsigned char) start[i]);
+	}
+	key[n] = '\0';
+
+	return 1;
+}
+
+/* order two catalog entries by name, holes last */
+__asm__("\n&FUNC    SETC 'dslist_cmp'");
+static int
+dslist_cmp(const void *a, const void *b)
+{
+	DSLIST *const *pa = (DSLIST *const *) a;
+	DSLIST *const *pb = (DSLIST *const *) b;
+
+	if (!*pa) return *pb ? 1 : 0;
+	if (!*pb) return -1;
+
+	/* both sides are EBCDIC and strcmp() compares as unsigned char, so this
+	   is the platform's own collating order */
+	return strcmp((*pa)->dsn, (*pb)->dsn);
+}
+
 int datasetListHandler(Session *session)
 {
 	unsigned	rc		= 0;
@@ -666,6 +723,7 @@ int datasetListHandler(Session *session)
 	unsigned	i		= 0;
 	unsigned	maxitems	= 0;
 	unsigned	emitted		= 0;
+	unsigned	eligible	= 0;
 
 	char		*method		= NULL;
 	char		*path		= NULL;
@@ -679,6 +737,8 @@ int datasetListHandler(Session *session)
 	char		*start		= NULL;
 	char		*filter		= NULL;
 	char		level_buf[45]	= {0};
+	char		start_key[MAX_DATASET_NAME + 1] = {0};
+	int		have_start	= 0;
 
 	method	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_METHOD");
 	path	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_PATH");
@@ -795,6 +855,24 @@ int datasetListHandler(Session *session)
 		}
 	}
 
+	have_start = make_start_key(start, start_key, sizeof(start_key));
+
+	/* start= paging is only well defined on an ordered list: the client asks
+	** for the next page by name, so an entry that sits out of order is not
+	** merely misplaced -- it is skipped for good once a page boundary passes
+	** it.  LISTC returns the level's children in catalog order and the
+	** exact-name entry above was appended last (A.B belongs in front of
+	** A.B.C, not behind it), so order the array before emitting.  z/OSMF
+	** returns its lists sorted too.  qsort() recurses only into the smaller
+	** partition, which bounds the depth at log2(n) -- about 15 frames for the
+	** largest catalog on this platform. */
+	if (dslist) {
+		count = array_count(&dslist);
+		if (count > 1) {
+			qsort(dslist, count, sizeof(DSLIST *), dslist_cmp);
+		}
+	}
+
 	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
 	if (maxitems_str) maxitems = (unsigned) atoi(maxitems_str);
 
@@ -818,7 +896,15 @@ int datasetListHandler(Session *session)
 
 		if (!ds) continue;
 
-		if (maxitems > 0 && emitted >= maxitems) break;
+		/* start= is inclusive: everything sorting before it belongs to a
+		** page the client already has */
+		if (have_start && strcmp(ds->dsn, start_key) < 0) continue;
+
+		/* keep counting past the page limit -- moreRows has to tell "page
+		** full" from "list exhausted", and only the entries at or after
+		** start= are still fetchable */
+		eligible++;
+		if (maxitems > 0 && emitted >= maxitems) continue;
 
 		if (first) {
 			/* first time we're printing this '{' so no ',' needed */
@@ -872,7 +958,7 @@ end:
 	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", emitted)) < 0) goto quit;
 	// TODO: add totalRows if X-IBM-Attributes has ',total'
 	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
-		(maxitems > 0 && emitted < count) ? "true" : "false")) < 0) goto quit;
+		(emitted < eligible) ? "true" : "false")) < 0) goto quit;
 
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;
@@ -1396,6 +1482,9 @@ int memberListHandler(Session *session)
 	char		*pattern	= NULL;
 	char		*maxitems_str	= NULL;
 
+	char		start_key[MAX_MEMBER_NAME];	/* EBCDIC, blank padded */
+	int		skipping	= 0;
+
 
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
 	if (!dsname){
@@ -1413,6 +1502,22 @@ int memberListHandler(Session *session)
 
 	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
 	if (maxitems_str) maxitems = (unsigned) atoi(maxitems_str);
+
+	/* The directory is stored in ascending EBCDIC order -- #232's own output
+	   shows IEAVNPF1 ahead of IEAVNP03, which holds only in EBCDIC ('F' 0xC6
+	   < '0' 0xF0).  So the key is compared against the raw eight name bytes,
+	   blank padded, with no translation at all: query values reach a CGI in
+	   EBCDIC already.  Comparing in ASCII would order those two names the
+	   other way round and mis-skip every name that mixes letters and digits. */
+	{
+		char	start_buf[MAX_MEMBER_NAME + 1];
+
+		if (make_start_key(start, start_buf, sizeof(start_buf))) {
+			memset(start_key, ' ', sizeof(start_key));
+			memcpy(start_key, start_buf, strlen(start_buf));
+			skipping = 1;
+		}
+	}
 
 	/* opening a non-partitioned data set this way abends S001 (#193) */
 	if (require_pds(session, dsname) != 0) {
@@ -1483,6 +1588,21 @@ int memberListHandler(Session *session)
 
 			size = PDS_DIR_ENT_FIXED
 			     + ((blk[pos + 11] & PDS_DIR_UDATA_MASK) * 2);
+
+			/* Skip up to the start member.  This has to happen before
+			   the maxitems check: otherwise the skipped entries eat the
+			   page budget and the response is an empty items array with
+			   moreRows true -- a different-looking bug.  The directory
+			   is sorted, so once we are past the key there is nothing
+			   left to compare and the flag stays off. */
+			if (skipping) {
+				if (memcmp(&blk[pos], start_key,
+					sizeof(start_key)) < 0) {
+					pos += size;
+					continue;
+				}
+				skipping = 0;
+			}
 
 			if (maxitems > 0 && emitted >= maxitems) {
 				more = 1;

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -410,6 +410,33 @@ else
 			"got HTTP $HTTP_CODE first='$FIRST' returnedRows=$RETURNED (expected first='$SECOND', $((COUNT - 1)) rows)"
 	fi
 
+	# The exact-name entry must sort in front of its own children. LISTC
+	# returns the children of a level and the handler looks the exact name up
+	# separately, so before #232 it was appended last -- with max-items=1 the
+	# first page was the CHILD and the parent was unreachable from any later
+	# start=.
+	BODY='{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":3120,"alcunit":"TRK","primary":1,"secondary":1}'
+	for D in "${MVSMF_USER}.CURL.EXACT" "${MVSMF_USER}.CURL.EXACT.CHILD"; do
+		curl -s -o /dev/null -X POST -u "$AUTH" \
+			-H "Content-Type: application/json" -d "$BODY" \
+			"${BASE_URL}/zosmf/restfiles/ds/${D}"
+	done
+
+	CONTENT=$(curl -s -u "$AUTH" -H "X-IBM-Max-Items: 1" \
+		"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL.EXACT")
+	if [ "$(echo "$CONTENT" | jq -r '.items[0].dsname' 2>/dev/null)" = "${MVSMF_USER}.CURL.EXACT" ] &&
+	   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "true" ]; then
+		pass "exact-name entry sorts before its children"
+	else
+		fail "exact-name entry sorts before its children" \
+			"first item is '$(echo "$CONTENT" | jq -r '.items[0].dsname' 2>/dev/null)'"
+	fi
+
+	for D in "${MVSMF_USER}.CURL.EXACT.CHILD" "${MVSMF_USER}.CURL.EXACT"; do
+		curl -s -o /dev/null -X DELETE -u "$AUTH" \
+			"${BASE_URL}/zosmf/restfiles/ds/${D}"
+	done
+
 	# past the last name is an empty page, not a full one -- and moreRows
 	# must not claim there is more to fetch
 	CONTENT=$(curl -s -u "$AUTH" \

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -377,6 +377,52 @@ else
 	fail "moreRows=true when truncated" "expected true, got $MORE_ROWS"
 fi
 
+# --- List datasets (start=) ---
+#
+# start= was read from the query string and then never used, so every page
+# began at the first entry and a client paging by name never advanced (#232).
+echo ""
+echo "--- List Datasets (start=) ---"
+
+ALL=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL" |
+	jq -r '.items[].dsname' 2>/dev/null)
+COUNT=$(echo "$ALL" | grep -c .)
+
+if [ "$COUNT" -lt 2 ]; then
+	skip "start= returns the tail of the list (need two datasets under ${MVSMF_USER}.CURL)"
+	skip "start= beyond the last dataset (need two datasets under ${MVSMF_USER}.CURL)"
+else
+	SECOND=$(echo "$ALL" | sed -n 2p)
+
+	BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL&start=${SECOND}")
+	HTTP_CODE=$(echo "$BODY" | tail -1)
+	CONTENT=$(echo "$BODY" | sed '$d')
+	FIRST=$(echo "$CONTENT" | jq -r '.items[0].dsname' 2>/dev/null)
+	RETURNED=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)
+
+	if [ "$HTTP_CODE" = "200" ] && [ "$FIRST" = "$SECOND" ] &&
+	   [ "$RETURNED" = "$((COUNT - 1))" ]; then
+		pass "start=${SECOND} returns the tail of the list (inclusive)"
+	else
+		fail "start=${SECOND} returns the tail of the list" \
+			"got HTTP $HTTP_CODE first='$FIRST' returnedRows=$RETURNED (expected first='$SECOND', $((COUNT - 1)) rows)"
+	fi
+
+	# past the last name is an empty page, not a full one -- and moreRows
+	# must not claim there is more to fetch
+	CONTENT=$(curl -s -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL&start=ZZZZZZZZ")
+	if [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "0" ] &&
+	   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
+		pass "start= beyond the last dataset returns an empty page"
+	else
+		fail "start= beyond the last dataset returns an empty page" \
+			"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+	fi
+fi
+
 # --- Read with volume prefix ---
 echo ""
 echo "--- Read Sequential Dataset with Volume Prefix ---"
@@ -450,6 +496,98 @@ CONTENT=$(echo "$BODY" | sed '$d')
 assert_http_status "200" "$HTTP_CODE" "list PDS members"
 assert_json_field_exists "$CONTENT" '.items[0].member' "member list has member field"
 assert_json_field "$CONTENT" '.moreRows' "false" "member list: moreRows false when complete"
+
+# --- List PDS members (start=) ---
+#
+# start= was accepted and ignored, so Zowe Explorer could never page past the
+# first X-IBM-Max-Items members of a directory (#232).
+#
+# The names below pin the collating order down. A PDS directory is stored in
+# EBCDIC order, where 'F' (0xC6) sorts BEFORE '0' (0xF0) -- in ASCII it is the
+# other way round. The directory therefore reads
+#
+#     MBRA, MBRB, MBRC, MBRF1, MBR03, TESTMBR
+#
+# and a start=MBR03 compared in ASCII would wrongly keep MBRF1 in the answer.
+echo ""
+echo "--- List PDS Members (start=, issue #232) ---"
+
+for M in MBRA MBRB MBRC MBRF1 MBR03; do
+	curl -s -o /dev/null -X PUT -u "$AUTH" \
+		-H "Content-Type: application/octet-stream" \
+		--data-binary "MEMBER ${M}" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(${M})"
+done
+
+# member names still come back padded to eight bytes (#154) -- trim to compare
+LIST=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRC" |
+	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+
+if [ "$(echo "$LIST" | head -1)" = "MBRC" ] &&
+   ! echo "$LIST" | grep -qxE 'MBRA|MBRB'; then
+	pass "start=MBRC begins at MBRC and drops the earlier members"
+else
+	fail "start=MBRC begins at MBRC and drops the earlier members" \
+		"got: $(echo "$LIST" | tr '\n' ' ')"
+fi
+
+LIST=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBR03" |
+	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+
+if [ "$(echo "$LIST" | head -1)" = "MBR03" ] && ! echo "$LIST" | grep -qx 'MBRF1'; then
+	pass "start=MBR03 skips MBRF1 (EBCDIC collating order)"
+else
+	fail "start=MBR03 skips MBRF1 (EBCDIC collating order)" \
+		"got: $(echo "$LIST" | tr '\n' ' ') -- an ASCII compare keeps MBRF1"
+fi
+
+# the skipped members must not eat the page budget: with the skip applied
+# after the cap this returns zero items and moreRows true
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" -H 'X-IBM-Max-Items: 2' \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRC")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+
+if [ "$HTTP_CODE" = "200" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "2" ] &&
+   [ "$(echo "$LIST" | head -1)" = "MBRC" ] &&
+   [ "$(echo "$LIST" | sed -n 2p)" = "MBRF1" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "true" ]; then
+	pass "start=MBRC with max-items=2 returns MBRC,MBRF1 and moreRows=true"
+else
+	fail "start=MBRC with max-items=2 returns MBRC,MBRF1 and moreRows=true" \
+		"got HTTP $HTTP_CODE rows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) items='$(echo "$LIST" | tr '\n' ' ')' moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+fi
+
+# a client echoing a name back from a listing still sends the #154 padding
+LIST=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRC%20%20%20%20" |
+	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+
+if [ "$(echo "$LIST" | head -1)" = "MBRC" ]; then
+	pass "start= tolerates a blank-padded member name"
+else
+	fail "start= tolerates a blank-padded member name" \
+		"got: $(echo "$LIST" | tr '\n' ' ')"
+fi
+
+CONTENT=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=ZZZZZZZZ")
+if [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "0" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
+	pass "start= beyond the last member returns an empty page"
+else
+	fail "start= beyond the last member returns an empty page" \
+		"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+fi
+
+for M in MBRA MBRB MBRC MBRF1 MBR03; do
+	curl -s -o /dev/null -X DELETE -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(${M})"
+done
 
 # --- List members: a large directory must not take the server down (#212) ---
 # memberListHandler used to build the whole member array in storage via


### PR DESCRIPTION
Fixes #232

## What was wrong

`memberListHandler` and `datasetListHandler` both read the z/OSMF `start=`
parameter into a local variable and then never looked at it again — the docs
admitted as much (`docs/endpoints/datasets/list.md`, `members-list.md`). Every
page therefore began at the first entry, so a client paging by name kept
getting the same first page back. Zowe Explorer sets `X-IBM-Max-Items: 101`
and pages with `start=`, which is why the members past 101 of a large PDS were
unreachable.

Reproduced against the live stand before the fix:

```
GET /zosmf/restfiles/ds/SYS1.SAMPLIB/member?start=ICKUSER1   ->  COBSAMP …
```

This is **not** related to #154 (the eight-byte padded member names). The two
touch only in one direction: a client that echoes a returned name straight back
as `start=` sends it padded, which the new code trims.

## What changed

`start=` is inclusive, as in z/OSMF: the listing begins at the named entry and
runs to the end. The value is right-trimmed and folded to upper case first, so
a padded name from a previous listing is accepted.

**Both comparisons run in EBCDIC**, and that is the substance of the fix rather
than a detail. A PDS directory is stored in EBCDIC order, where `F` (0xC6)
sorts before `0` (0xF0) — the listing in #232 shows `IEAVNPF1` ahead of
`IEAVNP03`, which holds in no other collating order. An ASCII comparison orders
those two the other way round and would mis-skip every name mixing letters and
digits. Query values reach a CGI in EBCDIC already, so nothing on this path is
translated.

`memberListHandler` applies the skip **before** the `X-IBM-Max-Items` check.
The other order is a concrete failure, not a style point: the skipped members
would eat the page budget and a deep `start=` would answer with an empty
`items` array and `moreRows: true`.

`datasetListHandler` sorts the catalog list by name before emitting. Ordering
is a precondition for paging by name, not cosmetics — LISTC returns a level's
children in catalog order and the exact-name entry (the `A.B` that
`dslevel=A.B` returns next to `A.B.C`) is looked up separately and appended
last, so it trailed its own children and any page boundary past it would have
dropped it for good. `qsort()` recurses only into the smaller partition, which
bounds the depth at about 15 frames here. Its `moreRows` now counts what is
still fetchable from `start=` onwards instead of comparing against the
unfiltered list length.

## Verification

Built, deployed and activated on the dev stand (live build `2ba9684`).

```
GET /zosmf/restfiles/ds/SYS1.SAMPLIB/member?start=ICKUSER1
  -> ICKUSER1, ICLSAV2, IEAIPL00, IEAVNIPM, IEAVNPF1, IEAVNP03, …
GET /zosmf/restfiles/ds?dslevel=SYS1&start=SYS1.AGENLIB&X-IBM-Max-Items: 2
  -> SYS1.AGENLIB, SYS1.AHELP, moreRows=true
```

`tests/curl-datasets.sh` gained seven cases covering both endpoints: inclusive
start, the EBCDIC ordering trap (`start=MBR03` must drop `MBRF1`), the
interaction with `X-IBM-Max-Items`, a blank-padded start value, and a start past
the last entry.

- `tests/curl-datasets.sh` — 92 passed, 0 failed
- `tests/zowe-datasets.sh` — 38 passed, 0 failed

The Zowe suite does not exercise `start=`: `zowe files list ds` / `list am`
expose no such option, Zowe Explorer drives the parameter through the API
directly.

## Not in this PR

`pattern=` on the member list is still read and ignored — it is what Zowe's
member filter uses. Tracked separately.