### PR TITLE
dsapi: implement pattern= filtering for the member list

### DIFF
--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -22,7 +22,11 @@ or with explicit volume:
   directory. The name is folded to upper case and trailing blanks are trimmed,
   so a name echoed back from a previous listing (which is still padded to eight
   characters, issue #154) works unchanged.
-- `pattern` (optional): Member name filter pattern
+- `pattern` (optional): Member name filter. `*` matches any run of characters
+  including none, `%` matches exactly one; everything else matches literally,
+  and the value is folded to upper case. A pattern without wildcards is an
+  exact name. Note that `%` has to be sent percent-encoded as `%25` —
+  unencoded it is consumed as a URL escape before the handler ever sees it.
 
 ## Request Headers
 - `X-IBM-Max-Items` (optional): Maximum number of members to return. Omitted or `0` returns all of them.
@@ -90,19 +94,29 @@ members".
 
 ## Pagination
 
-`X-IBM-Max-Items` caps a page, `start` picks up where the last one ended, and
-`moreRows` says whether anything is left. Members skipped by `start` are not
-charged against the page limit — a page is always `X-IBM-Max-Items` members
-long as long as the directory still holds that many.
+`X-IBM-Max-Items` caps a page, `start` picks up where the last one ended,
+`pattern` filters, and `moreRows` says whether anything is left. The three
+compose, and neither the members skipped by `start` nor the ones rejected by
+`pattern` are charged against the page limit — a page is always
+`X-IBM-Max-Items` members long as long as the directory still holds that many
+matches. `returnedRows` and `moreRows` therefore count matches, not directory
+entries.
 
 The directory is stored in **EBCDIC** order, and `start` is compared in that
 same order — `IEAVNPF1` precedes `IEAVNP03`, because `F` (0xC6) sorts before
 `0` (0xF0). An ASCII comparison would order the two the other way round and
 mis-skip every name mixing letters and digits (issue #232).
 
+```bash
+# the first ten IEFxxx members, then the next ten
+curl -H 'X-IBM-Max-Items: 10' \
+  'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=IEF*'
+curl -H 'X-IBM-Max-Items: 10' \
+  'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=IEF*&start=IEFPROC'
+```
+
 ## Limitations
 - No member statistics (TTR, size, dates) are returned yet
-- the `pattern` query parameter is accepted but not yet implemented
 
 ## Examples
 

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -108,11 +108,17 @@ same order — `IEAVNPF1` precedes `IEAVNP03`, because `F` (0xC6) sorts before
 mis-skip every name mixing letters and digits (issue #232).
 
 ```bash
-# the first ten IEFxxx members, then the next ten
-curl -H 'X-IBM-Max-Items: 10' \
-  'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=IEF*'
-curl -H 'X-IBM-Max-Items: 10' \
-  'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=IEF*&start=IEFPROC'
+# every JES2 member                -> JES2 JES2BLD JES2JOB JES2LNK JES20098 JES20099
+curl 'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=JES2*'
+
+# JES2 plus exactly four more       -> JES20098 JES20099   (%25 is '%')
+curl 'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=JES2%25%25%25%25'
+
+# the filtered list, two per page
+curl -H 'X-IBM-Max-Items: 2' \
+  'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=JES2*'
+curl -H 'X-IBM-Max-Items: 2' \
+  'http://mvs:1080/zosmf/restfiles/ds/SYS1.PROCLIB/member?pattern=JES2*&start=JES2JOB'
 ```
 
 ## Limitations

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -659,31 +659,31 @@ jday_to_md(unsigned short year, unsigned short jday,
 	*day_out = (unsigned char)d;
 }
 
-/* Normalise a "start=" query value into a comparison key.
+/* Normalise a query value -- start= or pattern= -- into a comparison key.
 
-   Both list endpoints page with z/OSMF's start= parameter: the listing begins
-   at that name -- inclusive -- and runs to the end of the list.  Query values
-   reach a CGI already in EBCDIC, so no translation is involved; they do arrive
-   exactly as the client typed them, and a client that feeds a name back from a
-   member listing still carries the blank padding of #154.  Trim that, fold to
-   upper case (both catalog and directory names are upper case), and truncate
-   to what the key can hold.
+   The list endpoints page with z/OSMF's start= parameter (the listing begins at
+   that name, inclusive, and runs to the end) and filter with pattern=.  Query
+   values reach a CGI already in EBCDIC, so no translation is involved; they do
+   arrive exactly as the client typed them, and a client that feeds a name back
+   from a member listing still carries the blank padding of #154.  Trim that,
+   fold to upper case (both catalog and directory names are upper case), and
+   truncate to what the key can hold.
 
-   Returns 1 when there is a key to compare against, 0 when start= was absent
+   Returns 1 when there is a key to work with, 0 when the parameter was absent
    or empty -- list everything. */
-__asm__("\n&FUNC    SETC 'make_start_key'");
+__asm__("\n&FUNC    SETC 'make_query_key'");
 static int
-make_start_key(const char *start, char *key, size_t keylen)
+make_query_key(const char *value, char *key, size_t keylen)
 {
 	size_t	n;
 	size_t	i;
 
-	if (!start) {
+	if (!value) {
 		return 0;
 	}
 
-	n = strlen(start);
-	while (n > 0 && start[n - 1] == ' ') n--;
+	n = strlen(value);
+	while (n > 0 && value[n - 1] == ' ') n--;
 
 	if (n == 0) {
 		return 0;
@@ -692,11 +692,55 @@ make_start_key(const char *start, char *key, size_t keylen)
 	if (n > keylen - 1) n = keylen - 1;
 
 	for (i = 0; i < n; i++) {
-		key[i] = (char) toupper((unsigned char) start[i]);
+		key[i] = (char) toupper((unsigned char) value[i]);
 	}
 	key[n] = '\0';
 
 	return 1;
+}
+
+/* Match a member name against a z/OSMF member pattern: '*' stands for any run
+   of characters including none, '%' for exactly one.  Everything else compares
+   literally, in EBCDIC on both sides -- the directory bytes are EBCDIC and so
+   is the pattern from the query string.
+
+   The loop backtracks to the last '*' instead of recursing.  A recursive
+   matcher is the textbook form, and its depth is driven by the input: on this
+   platform that is the wrong shape entirely.  Iterating costs two saved
+   positions and nothing else.
+
+   name is the raw directory name with its trailing blanks already trimmed off
+   by the caller; it is not NUL terminated, hence namelen. */
+__asm__("\n&FUNC    SETC 'member_match'");
+static int
+member_match(const char *name, size_t namelen, const char *pat)
+{
+	size_t	patlen	= strlen(pat);
+	size_t	n	= 0;
+	size_t	p	= 0;
+	size_t	star_p	= (size_t) -1;	/* pattern position after the last '*' */
+	size_t	star_n	= 0;		/* name position it was matched at */
+
+	while (n < namelen) {
+		if (p < patlen && (pat[p] == '%' || pat[p] == name[n])) {
+			p++;
+			n++;
+		} else if (p < patlen && pat[p] == '*') {
+			star_p = p++;
+			star_n = n;
+		} else if (star_p != (size_t) -1) {
+			/* mismatch: let the last '*' swallow one more character */
+			p = star_p + 1;
+			n = ++star_n;
+		} else {
+			return 0;
+		}
+	}
+
+	/* trailing stars may still match the empty rest */
+	while (p < patlen && pat[p] == '*') p++;
+
+	return p == patlen;
 }
 
 /* order two catalog entries by name, holes last */
@@ -855,7 +899,7 @@ int datasetListHandler(Session *session)
 		}
 	}
 
-	have_start = make_start_key(start, start_key, sizeof(start_key));
+	have_start = make_query_key(start, start_key, sizeof(start_key));
 
 	/* start= paging is only well defined on an ordered list: the client asks
 	** for the next page by name, so an entry that sits out of order is not
@@ -1419,6 +1463,11 @@ error:
 /* 8 name bytes, each worst case "\uXXXX", plus the terminator */
 #define MEMBER_ESC_SIZE		(8 * 6 + 1)
 
+/* A member pattern may be longer than the names it matches ("*A*B*C*D*"), so
+   it gets its own size rather than borrowing the eight-byte name length.
+   Anything longer is truncated, like an over-long start= value. */
+#define MEMBER_PATTERN_SIZE	45
+
 /* Render a directory member name as the body of a JSON string.
 
    Member names are normally A-Z 0-9 @ # $, but nothing enforces that: a PDS
@@ -1485,6 +1534,11 @@ int memberListHandler(Session *session)
 	char		start_key[MAX_MEMBER_NAME];	/* EBCDIC, blank padded */
 	int		skipping	= 0;
 
+	/* a pattern is not a name: "*A*B*C*D*" is longer than any member it can
+	   match, so the buffer is sized for the pattern, not for eight bytes */
+	char		pattern_key[MEMBER_PATTERN_SIZE];
+	int		have_pattern	= 0;
+
 
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
 	if (!dsname){
@@ -1512,12 +1566,14 @@ int memberListHandler(Session *session)
 	{
 		char	start_buf[MAX_MEMBER_NAME + 1];
 
-		if (make_start_key(start, start_buf, sizeof(start_buf))) {
+		if (make_query_key(start, start_buf, sizeof(start_buf))) {
 			memset(start_key, ' ', sizeof(start_key));
 			memcpy(start_key, start_buf, strlen(start_buf));
 			skipping = 1;
 		}
 	}
+
+	have_pattern = make_query_key(pattern, pattern_key, sizeof(pattern_key));
 
 	/* opening a non-partitioned data set this way abends S001 (#193) */
 	if (require_pds(session, dsname) != 0) {
@@ -1602,6 +1658,25 @@ int memberListHandler(Session *session)
 					continue;
 				}
 				skipping = 0;
+			}
+
+			/* Filter, then cap -- for the same reason the skip above
+			   comes first: a member the client did not ask for must not
+			   consume a slot of the page, or a narrow pattern answers
+			   with an empty items array and moreRows true.  Ordering
+			   also means moreRows counts matches, not directory
+			   entries. */
+			if (have_pattern) {
+				size_t	nlen = MAX_MEMBER_NAME;
+
+				while (nlen > 0 && blk[pos + nlen - 1] == ' ') {
+					nlen--;
+				}
+
+				if (!member_match(&blk[pos], nlen, pattern_key)) {
+					pos += size;
+					continue;
+				}
 			}
 
 			if (maxitems > 0 && emitted >= maxitems) {

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -611,6 +611,68 @@ else
 		"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
 fi
 
+# --- List PDS members (pattern=) ---
+#
+# pattern= was accepted and ignored, so a filtered member view silently showed
+# the whole directory (#236). '*' matches any run of characters, '%' exactly
+# one -- and '%' has to be sent percent-encoded as %25, or the URL parser eats
+# it as an escape.
+#
+# The directory at this point is MBRA, MBRB, MBRC, MBRF1, MBR03, TESTMBR.
+echo ""
+echo "--- List PDS Members (pattern=, issue #236) ---"
+
+pattern_list() {
+	curl -s -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?pattern=$1" |
+		jq -r '.items[].member' 2>/dev/null | sed 's/ *$//' | tr '\n' ' ' |
+		sed 's/ *$//'
+}
+
+assert_pattern() {
+	local got
+	got=$(pattern_list "$1")
+	if [ "$got" = "$2" ]; then
+		pass "pattern=$1 -> $2"
+	else
+		fail "pattern=$1 -> $2" "got '$got'"
+	fi
+}
+
+assert_pattern 'MBR*'  'MBRA MBRB MBRC MBRF1 MBR03'
+assert_pattern 'MBR%25' 'MBRA MBRB MBRC'
+assert_pattern '*MBR*' 'MBRA MBRB MBRC MBRF1 MBR03 TESTMBR'
+assert_pattern 'MBRC'  'MBRC'
+assert_pattern 'NOSUCH*' ''
+
+# a filtered-out member must not consume a slot of the page
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" -H 'X-IBM-Max-Items: 2' \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?pattern=MBR%25")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null | sed 's/ *$//' |
+	tr '\n' ' ' | sed 's/ *$//')
+
+if [ "$HTTP_CODE" = "200" ] && [ "$LIST" = "MBRA MBRB" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "2" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "true" ]; then
+	pass "pattern= with max-items=2 fills the page with matches only"
+else
+	fail "pattern= with max-items=2 fills the page with matches only" \
+		"got HTTP $HTTP_CODE items='$LIST' moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+fi
+
+# pattern= and start= have to compose -- Zowe pages a filtered list
+LIST=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRB&pattern=MBR%25" |
+	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//' | tr '\n' ' ' | sed 's/ *$//')
+
+if [ "$LIST" = "MBRB MBRC" ]; then
+	pass "start= and pattern= compose"
+else
+	fail "start= and pattern= compose" "got '$LIST' (expected 'MBRB MBRC')"
+fi
+
 for M in MBRA MBRB MBRC MBRF1 MBR03; do
 	curl -s -o /dev/null -X DELETE -u "$AUTH" \
 		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(${M})"


### PR DESCRIPTION
Fixes #236

## What was wrong

`memberListHandler` read `pattern=` into a local and never looked at it — the
same shape of defect as `start=` in #232, in the same handler. The whole
directory came back regardless, so a filtered member view in Zowe silently
showed everything.

## What changed

`*` matches any run of characters including none, `%` exactly one, everything
else literally; the value is folded to upper case, and a pattern without
wildcards is an exact name. Both sides of the comparison are EBCDIC — the
directory bytes are, and so is the query value by the time a CGI sees it.

The matcher **backtracks to the last `*` instead of recursing**. The recursive
form is the textbook one and its depth is driven by the input, which is the
wrong shape for this platform; iterating costs two saved positions and nothing
else.

The filter runs **before** the `X-IBM-Max-Items` check, for the same reason the
`start=` skip does: a member the client did not ask for must not consume a slot
of the page, or a narrow pattern answers with an empty `items` array and
`moreRows: true`. `returnedRows` and `moreRows` therefore count matches, not
directory entries.

`make_start_key()` is now `make_query_key()` — it normalises `start=` and
`pattern=` alike and the old name no longer said what it does.

## Verification

The matcher was exercised against 34 cases on the host first (nested stars,
`%` runs, leading/trailing stars, the classic `A*C` vs `ABAB` backtracking
traps) — all green — then built, deployed and activated on the dev stand (live
build `e5ae7c5`) and checked against a real directory:

```
pattern=JES2*             -> JES2 JES2BLD JES2JOB JES2LNK JES20098 JES20099
pattern=JES2%25%25%25%25  -> JES20098 JES20099
pattern=*2                -> DLBDELT2 JES2
pattern=R%25KF*           -> RAKF RAKFPROF RAKFPWUP RAKFUSER
pattern=TSO               -> TSO
pattern=JES2*&start=JES2JOB          -> JES2JOB JES2LNK JES20098 JES20099
pattern=JES2* + X-IBM-Max-Items: 2   -> JES2 JES2BLD, moreRows=true
```

- `tests/curl-datasets.sh` — 100 passed, 0 failed (7 new cases)
- `tests/zowe-datasets.sh` — 38 passed, 0 failed

## Notes

`%` must be sent percent-encoded as `%25`, or the URL parser consumes it as an
escape before the handler sees it. That bites in the tests and in the docs, so
it is called out in both.

The host check of the matcher was a throwaway: `member_match()` is file-static
in `dsapi.c`, and mvsMF's `[[test]]` modules cannot run on MVS anyway — mbt
links httpd's CGI `@@START` ahead of the C runtime, so every test module exits
CC 12 before `main()`. The curl suite is this project's real test surface.