### PR TITLE
dsapi: reject an over-long member pattern instead of truncating it

### DIFF
--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -27,6 +27,9 @@ or with explicit volume:
   and the value is folded to upper case. A pattern without wildcards is an
   exact name. Note that `%` has to be sent percent-encoded as `%25` —
   unencoded it is consumed as a URL escape before the handler ever sees it.
+  A pattern of 45 characters or more is rejected with HTTP 400 (`reason` 9)
+  rather than truncated, since a shortened pattern would select a different set
+  of members and the 200 would be a wrong answer instead of an error.
 
 ## Request Headers
 - `X-IBM-Max-Items` (optional): Maximum number of members to return. Omitted or `0` returns all of them.
@@ -80,6 +83,7 @@ Names are returned padded to 8 characters, as they are held in the directory
 ## Error Responses
 - HTTP 400 (Bad Request)
     - The dataset is not partitioned (use the dataset endpoint instead)
+    - `pattern` is 45 characters or longer (`reason` 9)
 - HTTP 404 (Not Found)
     - Dataset not cataloged (`reason` 4)
 - HTTP 500 (Internal Server Error)

--- a/include/dsapi_err.h
+++ b/include/dsapi_err.h
@@ -19,6 +19,7 @@
 #define REASON_INVALID_RENAME_REQUEST	6	// Unsupported or malformed control request
 #define REASON_RENAME_TARGET_EXISTS		7	// Rename target already exists
 #define REASON_RENAME_FAILED			8	// Rename operation failed
+#define REASON_PATTERN_TOO_LONG			9	// Member pattern longer than the handler accepts
 
 // Error messages for Category 6
 #define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
@@ -29,5 +30,6 @@
 #define ERR_MSG_INVALID_RENAME_REQUEST	"Unsupported request; only 'rename' is supported"
 #define ERR_MSG_RENAME_TARGET_EXISTS	"Rename target already exists"
 #define ERR_MSG_RENAME_FAILED		"Rename operation failed"
+#define ERR_MSG_PATTERN_TOO_LONG	"Member pattern is too long"
 
 #endif // DSAPI_ERR_H

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1465,7 +1465,9 @@ error:
 
 /* A member pattern may be longer than the names it matches ("*A*B*C*D*"), so
    it gets its own size rather than borrowing the eight-byte name length.
-   Anything longer is truncated, like an over-long start= value. */
+   A longer one is rejected rather than truncated: cutting a pattern changes
+   which members it selects, and the client would get a plain 200 carrying a
+   list that does not answer what it asked. */
 #define MEMBER_PATTERN_SIZE	45
 
 /* Render a directory member name as the body of a JSON string.
@@ -1571,6 +1573,18 @@ int memberListHandler(Session *session)
 			memcpy(start_key, start_buf, strlen(start_buf));
 			skipping = 1;
 		}
+	}
+
+	/* make_query_key() truncates, which is harmless for start= -- a key longer
+	   than a name simply sorts past every entry -- but not for a pattern: a
+	   cut pattern selects a different set of members, and the client would be
+	   answered 200 with a list that does not match what it asked for.  Say so
+	   instead. */
+	if (pattern && strlen(pattern) >= sizeof(pattern_key)) {
+		rc = sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_PATTERN_TOO_LONG,
+				ERR_MSG_PATTERN_TOO_LONG, NULL, 0);
+		goto quit;
 	}
 
 	have_pattern = make_query_key(pattern, pattern_key, sizeof(pattern_key));

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -662,6 +662,16 @@ else
 		"got HTTP $HTTP_CODE items='$LIST' moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
 fi
 
+# an over-long pattern is rejected, not quietly cut down to size: a truncated
+# pattern selects a different set of members, and answering 200 with that list
+# is a wrong answer rather than an error
+LONG_PATTERN=$(printf 'A%.0s' $(seq 1 60))
+HTTP_CODE=$(curl -s -o /tmp/curl_ds_pat.json -w '%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?pattern=${LONG_PATTERN}")
+assert_http_status "400" "$HTTP_CODE" "over-long pattern is rejected"
+assert_json_field "$(cat /tmp/curl_ds_pat.json)" '.reason' "9" \
+	"over-long pattern: reason 9 (pattern too long)"
+
 # pattern= and start= have to compose -- Zowe pages a filtered list
 LIST=$(curl -s -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRB&pattern=MBR%25" |


### PR DESCRIPTION
Follow-up to #237 (#236), fixing a defect it introduced.

## What was wrong

`make_query_key()` truncates to the key buffer. For `start=` that is harmless —
a key longer than any name simply sorts past every entry — but a **cut pattern
selects a different set of members**. A 60-character `pattern=` was silently
shortened to 44, the filter then ran on something the client never sent, and the
answer was a plain `200` carrying a member list that does not match the request.
Wrong data, no error, nothing in the response to notice it by.

## What changed

A `pattern` of `MEMBER_PATTERN_SIZE` (45) characters or more is now rejected
with `400` and the new `reason` 9. The check reads the raw query value before
normalisation, so it sees the length the client actually sent, and it runs
before any response byte is written.

`start=` keeps truncating, deliberately — the comment now says why the two
differ rather than leaving it to be re-derived.

## Verification

Deployed and activated on the dev stand (live build `798b1ad`):

```
pattern=<60 chars>  -> 400 {"rc":8,"category":6,"reason":9,"message":"Member pattern is too long"}
pattern=<44 chars>  -> 200   (the boundary still passes)
pattern=JES2*       -> JES2 JES2BLD JES2JOB JES2LNK JES20098 JES20099
```

`tests/curl-datasets.sh` — 102 passed, 0 failed (two new cases: the status and
the reason code).

## Note on CI

`build / build` is red on `main` and on every branch for a reason outside this
repo: CI builds cc370 from source on a cold toolchain cache and
`xmit370/src/xmit370.c:559` fails `-Werror=format-overflow=` on the runner's
GCC. Same failure mode as the open cc370#33, new site, introduced by cc370
51bdf5b. See #237 for the detail.