### PR TITLE
dsapi: return member names without the directory's blank padding

### DIFF
--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -20,8 +20,8 @@ or with explicit volume:
 - `start` (optional): Starting member name for pagination. The listing begins at
   this member — **inclusive**, as in z/OSMF — and runs to the end of the
   directory. The name is folded to upper case and trailing blanks are trimmed,
-  so a name echoed back from a previous listing (which is still padded to eight
-  characters, issue #154) works unchanged.
+  so a name padded to the directory's eight characters — by an older client, or
+  by one that kept a list from before issue #154 — works unchanged.
 - `pattern` (optional): Member name filter. `*` matches any run of characters
   including none, `%` matches exactly one; everything else matches literally,
   and the value is folded to upper case. A pattern without wildcards is an
@@ -77,8 +77,17 @@ in a JSON string is emitted as a `\uXXXX` escape naming its ASCII value, so the
 response parses whatever the directory contains. Ordinary names (`A-Z 0-9 @ # $`)
 are unaffected.
 
-Names are returned padded to 8 characters, as they are held in the directory
-(issue #154).
+## Name padding
+
+The directory holds every name blank padded to eight bytes. Those blanks are
+**not** part of the name and are trimmed before the name is emitted, matching
+z/OSMF — `"member": "CR"`, not `"member": "CR      "`. The endpoint used to
+return the padded form (issue #154), which left a client building
+`{dsn}({member})` from the listing asking for a member whose name ends in a
+blank.
+
+`start=` still accepts a padded name, so a client holding a list from before the
+fix keeps working.
 
 ## Error Responses
 - HTTP 400 (Bad Request)

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -664,10 +664,11 @@ jday_to_md(unsigned short year, unsigned short jday,
    The list endpoints page with z/OSMF's start= parameter (the listing begins at
    that name, inclusive, and runs to the end) and filter with pattern=.  Query
    values reach a CGI already in EBCDIC, so no translation is involved; they do
-   arrive exactly as the client typed them, and a client that feeds a name back
-   from a member listing still carries the blank padding of #154.  Trim that,
-   fold to upper case (both catalog and directory names are upper case), and
-   truncate to what the key can hold.
+   arrive exactly as the client typed them.  The member list no longer pads the
+   names it emits (#154), but a client feeding back a name it kept from before
+   that fix -- or padded itself out of the directory -- still sends the blanks.
+   Trim them, fold to upper case (both catalog and directory names are upper
+   case), and truncate to what the key can hold.
 
    Returns 1 when there is a key to work with, 0 when the parameter was absent
    or empty -- list everything. */
@@ -1648,6 +1649,7 @@ int memberListHandler(Session *session)
 		   at +11 can be read */
 		for (pos = 2; pos + PDS_DIR_ENT_FIXED <= used; ) {
 			int	size;
+			size_t	nlen;
 			char	member[MEMBER_ESC_SIZE];
 
 			if (memcmp(&blk[pos],
@@ -1658,6 +1660,22 @@ int memberListHandler(Session *session)
 
 			size = PDS_DIR_ENT_FIXED
 			     + ((blk[pos + 11] & PDS_DIR_UDATA_MASK) * 2);
+
+			/* The directory holds the name blank padded to eight
+			   bytes; z/OSMF reports it without the padding, and a
+			   client that builds "dsn(member)" from what it was
+			   given otherwise asks for a member with a trailing
+			   blank in its name (#154).  The trimmed length serves
+			   the pattern match as well -- a name is what the
+			   client sees, so both have to agree on where it ends.
+			   A directory may hold arbitrary bytes rather than a
+			   name, and one of those ending in 0x40 is trimmed
+			   too; such an entry is \uXXXX escaped and no client
+			   can address it either way. */
+			nlen = MAX_MEMBER_NAME;
+			while (nlen > 0 && blk[pos + nlen - 1] == ' ') {
+				nlen--;
+			}
 
 			/* Skip up to the start member.  This has to happen before
 			   the maxitems check: otherwise the skipped entries eat the
@@ -1681,12 +1699,6 @@ int memberListHandler(Session *session)
 			   also means moreRows counts matches, not directory
 			   entries. */
 			if (have_pattern) {
-				size_t	nlen = MAX_MEMBER_NAME;
-
-				while (nlen > 0 && blk[pos + nlen - 1] == ' ') {
-					nlen--;
-				}
-
 				if (!member_match(&blk[pos], nlen, pattern_key)) {
 					pos += size;
 					continue;
@@ -1699,7 +1711,8 @@ int memberListHandler(Session *session)
 				break;
 			}
 
-			json_escape_member((const unsigned char *) &blk[pos], 8,
+			json_escape_member((const unsigned char *) &blk[pos],
+				(unsigned) nlen,
 				httpx->xlate_cp037->etoa, member, sizeof(member));
 
 			if (first) {

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -524,6 +524,18 @@ assert_http_status "200" "$HTTP_CODE" "list PDS members"
 assert_json_field_exists "$CONTENT" '.items[0].member' "member list has member field"
 assert_json_field "$CONTENT" '.moreRows' "false" "member list: moreRows false when complete"
 
+# Names come back as z/OSMF reports them, without the directory's blank padding
+# (#154). A padded name makes a client build "dsn(member )" for the follow-up
+# request. Every other member assertion below compares the exact string, so this
+# is checked once here for the directory as a whole.
+if echo "$CONTENT" | jq -e '[.items[].member] | length > 0 and all(test("^[^ ]+$"))' \
+	>/dev/null 2>&1; then
+	pass "member names are returned unpadded"
+else
+	fail "member names are returned unpadded" \
+		"got: $(echo "$CONTENT" | jq -c '[.items[].member]' 2>/dev/null)"
+fi
+
 # --- List PDS members (start=) ---
 #
 # start= was accepted and ignored, so Zowe Explorer could never page past the
@@ -546,10 +558,9 @@ for M in MBRA MBRB MBRC MBRF1 MBR03; do
 		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(${M})"
 done
 
-# member names still come back padded to eight bytes (#154) -- trim to compare
 LIST=$(curl -s -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRC" |
-	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+	jq -r '.items[].member' 2>/dev/null)
 
 if [ "$(echo "$LIST" | head -1)" = "MBRC" ] &&
    ! echo "$LIST" | grep -qxE 'MBRA|MBRB'; then
@@ -561,7 +572,7 @@ fi
 
 LIST=$(curl -s -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBR03" |
-	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+	jq -r '.items[].member' 2>/dev/null)
 
 if [ "$(echo "$LIST" | head -1)" = "MBR03" ] && ! echo "$LIST" | grep -qx 'MBRF1'; then
 	pass "start=MBR03 skips MBRF1 (EBCDIC collating order)"
@@ -576,7 +587,7 @@ BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" -H 'X-IBM-Max-Items: 2' \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRC")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
-LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null)
 
 if [ "$HTTP_CODE" = "200" ] &&
    [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "2" ] &&
@@ -589,10 +600,12 @@ else
 		"got HTTP $HTTP_CODE rows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) items='$(echo "$LIST" | tr '\n' ' ')' moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
 fi
 
-# a client echoing a name back from a listing still sends the #154 padding
+# the listing no longer pads the names it returns (#154), but a client holding
+# an older list -- or padding a name itself -- still sends the blanks, and
+# start= has to keep tolerating them
 LIST=$(curl -s -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRC%20%20%20%20" |
-	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//')
+	jq -r '.items[].member' 2>/dev/null)
 
 if [ "$(echo "$LIST" | head -1)" = "MBRC" ]; then
 	pass "start= tolerates a blank-padded member name"
@@ -625,7 +638,7 @@ echo "--- List PDS Members (pattern=, issue #236) ---"
 pattern_list() {
 	curl -s -u "$AUTH" \
 		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?pattern=$1" |
-		jq -r '.items[].member' 2>/dev/null | sed 's/ *$//' | tr '\n' ' ' |
+		jq -r '.items[].member' 2>/dev/null | tr '\n' ' ' |
 		sed 's/ *$//'
 }
 
@@ -650,7 +663,7 @@ BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" -H 'X-IBM-Max-Items: 2' \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?pattern=MBR%25")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
-LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null | sed 's/ *$//' |
+LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null |
 	tr '\n' ' ' | sed 's/ *$//')
 
 if [ "$HTTP_CODE" = "200" ] && [ "$LIST" = "MBRA MBRB" ] &&
@@ -675,7 +688,7 @@ assert_json_field "$(cat /tmp/curl_ds_pat.json)" '.reason' "9" \
 # pattern= and start= have to compose -- Zowe pages a filtered list
 LIST=$(curl -s -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRB&pattern=MBR%25" |
-	jq -r '.items[].member' 2>/dev/null | sed 's/ *$//' | tr '\n' ' ' | sed 's/ *$//')
+	jq -r '.items[].member' 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
 
 if [ "$LIST" = "MBRB MBRC" ]; then
 	pass "start= and pattern= compose"

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -360,6 +360,17 @@ if [ "$MEMBER_WRITE_OK" -eq 1 ]; then
 	else
 		fail "member list returned results" "expected >0 items"
 	fi
+
+	# names arrive without the directory's blank padding (#154) -- Zowe hands
+	# them straight to the next request, so a padded name asks for a member
+	# whose name ends in a blank
+	NAMES=$(echo "$OUTPUT" |
+		jq -c '[.data.apiResponse.items[].member]' 2>/dev/null)
+	if echo "$NAMES" | jq -e 'all(test("^[^ ]+$"))' >/dev/null 2>&1; then
+		pass "member names are returned unpadded"
+	else
+		fail "member names are returned unpadded" "got: $NAMES"
+	fi
 fi
 
 # --- Read PDS member ---


### PR DESCRIPTION
Fixes #154

`GET /zosmf/restfiles/ds/{dsn}/member` emitted all eight bytes of the PDS
directory name, blanks included:

```json
{ "items": [ { "member": "CR      " }, { "member": "TSTDSB2 " } ] }
```

Real z/OSMF returns `"member": "CR"`. A client that builds `{dsn}({member})`
from the listing therefore asks for a member whose name ends in a blank —
the Desktop dataset browser hit this and trims client-side (#151).

## Change

`memberListHandler` trims the trailing blanks once per directory entry and
uses that length for **both** the `pattern=` match and the emitted name, so
the name a member is matched against is the name the client is given. The
trim already existed inside the `pattern=` branch; it is now hoisted out.

`start=` keeps accepting a padded name (`make_query_key` trims it), so a
client holding a list from before this change still pages correctly.

A directory entry holding arbitrary bytes rather than a name (the SMP/E keys
in `SYS1.SMPCDS`) is trimmed the same way if it happens to end in 0x40. Such
an entry is `\uXXXX` escaped and not addressable by any client either way —
and the `pattern=` path already made that call.

## Tests

- `tests/curl-datasets.sh`: new assertion that every returned name matches
  `^[^ ]+$`. The existing member assertions all piped through
  `sed 's/ *$//'`, so they passed either way — that laundering is removed
  and they now compare the exact string.
- `tests/zowe-datasets.sh`: same assertion on the Zowe member list.
- The `start=MBRC%20%20%20%20` case stays — it now tests server tolerance of
  client-sent padding, which is still correct behaviour.

## Verification

Deployed and activated into the live `HTTPD.LINKLIB`; `/zosmf/test?fn=version`
reports `a218d3d`, matching the branch HEAD that was built.

```
GET /SYS1.PROCLIB/member?pattern=JES2*
  -> ["JES2","JES2BLD","JES2JOB","JES2LNK","JES20098","JES20099"]
GET /SYS1.PROCLIB/member?start=JES2%20%20%20%20   (padded, old-client form)
  -> ["JES2","JES2BLD","JES2JOB"]
```

Both suites green against MVS:

- `tests/curl-datasets.sh` — 103 passed, 0 failed, 0 skipped
- `tests/zowe-datasets.sh` — 39 passed, 0 failed, 0 skipped

That includes the `SYS1.SMPCDS` cases (~23000 members, binary directory
keys): the response is still valid JSON and the server still serves requests
afterwards.