### PR TITLE
dsapi: an over-long start= must not readmit the truncated prefix

### DIFF
--- a/docs/endpoints/datasets/list.md
+++ b/docs/endpoints/datasets/list.md
@@ -13,7 +13,10 @@ GET
 - `volser` (optional): Filter by volume serial
 - `start` (optional): Starting dataset name for pagination. The listing begins
   at this name — **inclusive**, as in z/OSMF — and runs to the end of the list.
-  The value is folded to upper case and trailing blanks are trimmed.
+  The value is folded to upper case and trailing blanks are trimmed. A value
+  longer than the 44 characters a dataset name can hold is cut to 44, and the
+  page then begins *after* that prefix: no cataloged name can be the value
+  itself, and one equal to the prefix sorts before it (issue #240).
 
 ## Request Headers
 - `X-IBM-Max-Items` (optional): Maximum number of items to return. Value `0` means unlimited (default behavior). When the result set is truncated, `moreRows` is set to `true`.

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -21,7 +21,10 @@ or with explicit volume:
   this member — **inclusive**, as in z/OSMF — and runs to the end of the
   directory. The name is folded to upper case and trailing blanks are trimmed,
   so a name padded to the directory's eight characters — by an older client, or
-  by one that kept a list from before issue #154 — works unchanged.
+  by one that kept a list from before issue #154 — works unchanged. A value
+  longer than eight characters cannot name a member: it is cut to eight and the
+  page then begins *after* that prefix, since a member named exactly the prefix
+  sorts before the value that was sent (issue #240).
 - `pattern` (optional): Member name filter. `*` matches any run of characters
   including none, `%` matches exactly one; everything else matches literally,
   and the value is folded to upper case. A pattern without wildcards is an

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -671,13 +671,21 @@ jday_to_md(unsigned short year, unsigned short jday,
    case), and truncate to what the key can hold.
 
    Returns 1 when there is a key to work with, 0 when the parameter was absent
-   or empty -- list everything. */
+   or empty -- list everything.  *truncated, when a pointer is passed, says
+   whether the value did not fit.  The key is then a prefix of what the client
+   asked for rather than the value itself, and the caller has to know: no name
+   can equal the value, and a name equal to the prefix sorts before it, so the
+   start of the page moves from inclusive to exclusive (#240). */
 __asm__("\n&FUNC    SETC 'make_query_key'");
 static int
-make_query_key(const char *value, char *key, size_t keylen)
+make_query_key(const char *value, char *key, size_t keylen, int *truncated)
 {
 	size_t	n;
 	size_t	i;
+
+	if (truncated) {
+		*truncated = 0;
+	}
 
 	if (!value) {
 		return 0;
@@ -690,7 +698,12 @@ make_query_key(const char *value, char *key, size_t keylen)
 		return 0;
 	}
 
-	if (n > keylen - 1) n = keylen - 1;
+	if (n > keylen - 1) {
+		n = keylen - 1;
+		if (truncated) {
+			*truncated = 1;
+		}
+	}
 
 	for (i = 0; i < n; i++) {
 		key[i] = (char) toupper((unsigned char) value[i]);
@@ -784,6 +797,7 @@ int datasetListHandler(Session *session)
 	char		level_buf[45]	= {0};
 	char		start_key[MAX_DATASET_NAME + 1] = {0};
 	int		have_start	= 0;
+	int		start_after	= 0;
 
 	method	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_METHOD");
 	path	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_PATH");
@@ -900,7 +914,8 @@ int datasetListHandler(Session *session)
 		}
 	}
 
-	have_start = make_query_key(start, start_key, sizeof(start_key));
+	have_start = make_query_key(start, start_key, sizeof(start_key),
+			&start_after);
 
 	/* start= paging is only well defined on an ordered list: the client asks
 	** for the next page by name, so an entry that sits out of order is not
@@ -942,8 +957,16 @@ int datasetListHandler(Session *session)
 		if (!ds) continue;
 
 		/* start= is inclusive: everything sorting before it belongs to a
-		** page the client already has */
-		if (have_start && strcmp(ds->dsn, start_key) < 0) continue;
+		** page the client already has.  Unless the value did not fit --
+		** then start_key is its first 44 characters, no cataloged name
+		** can be the value itself, and strcmp() puts a name equal to the
+		** prefix before it (the prefix ends in NUL, which sorts below the
+		** character the value continues with).  Drop it too (#240). */
+		if (have_start) {
+			int cmp = strcmp(ds->dsn, start_key);
+
+			if (cmp < 0 || (start_after && cmp == 0)) continue;
+		}
 
 		/* keep counting past the page limit -- moreRows has to tell "page
 		** full" from "list exhausted", and only the entries at or after
@@ -1536,6 +1559,7 @@ int memberListHandler(Session *session)
 
 	char		start_key[MAX_MEMBER_NAME];	/* EBCDIC, blank padded */
 	int		skipping	= 0;
+	int		start_after	= 0;
 
 	/* a pattern is not a name: "*A*B*C*D*" is longer than any member it can
 	   match, so the buffer is sized for the pattern, not for eight bytes */
@@ -1569,18 +1593,19 @@ int memberListHandler(Session *session)
 	{
 		char	start_buf[MAX_MEMBER_NAME + 1];
 
-		if (make_query_key(start, start_buf, sizeof(start_buf))) {
+		if (make_query_key(start, start_buf, sizeof(start_buf),
+				&start_after)) {
 			memset(start_key, ' ', sizeof(start_key));
 			memcpy(start_key, start_buf, strlen(start_buf));
 			skipping = 1;
 		}
 	}
 
-	/* make_query_key() truncates, which is harmless for start= -- a key longer
-	   than a name simply sorts past every entry -- but not for a pattern: a
-	   cut pattern selects a different set of members, and the client would be
-	   answered 200 with a list that does not match what it asked for.  Say so
-	   instead. */
+	/* A truncated pattern is answered rather than obeyed: a cut pattern
+	   selects a different set of members, and the client would be given a
+	   plain 200 carrying a list that does not match what it asked for.  Say so
+	   instead.  start= is cut to size too, but there the prefix still locates
+	   the page -- see the skip in the loop below (#240). */
 	if (pattern && strlen(pattern) >= sizeof(pattern_key)) {
 		rc = sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
 				CATEGORY_SERVICE, RC_ERROR, REASON_PATTERN_TOO_LONG,
@@ -1588,7 +1613,8 @@ int memberListHandler(Session *session)
 		goto quit;
 	}
 
-	have_pattern = make_query_key(pattern, pattern_key, sizeof(pattern_key));
+	have_pattern = make_query_key(pattern, pattern_key, sizeof(pattern_key),
+			NULL);
 
 	/* opening a non-partitioned data set this way abends S001 (#193) */
 	if (require_pds(session, dsname) != 0) {
@@ -1682,10 +1708,23 @@ int memberListHandler(Session *session)
 			   page budget and the response is an empty items array with
 			   moreRows true -- a different-looking bug.  The directory
 			   is sorted, so once we are past the key there is nothing
-			   left to compare and the flag stays off. */
+			   left to compare and the flag stays off.
+
+			   start= names the first member of the page, so the match
+			   is kept -- unless the value was too long for a member
+			   name and start_key is only its first eight characters.
+			   No member can then be the value itself, and the one
+			   equal to the prefix sorts before it: the eight name
+			   bytes run out and the value carries on, and every
+			   character a client can put there sorts above the blank
+			   the name is padded with.  So that one goes as well, and
+			   the page starts after the prefix rather than at it
+			   (#240). */
 			if (skipping) {
-				if (memcmp(&blk[pos], start_key,
-					sizeof(start_key)) < 0) {
+				int cmp = memcmp(&blk[pos], start_key,
+						sizeof(start_key));
+
+				if (cmp < 0 || (start_after && cmp == 0)) {
 					pos += size;
 					continue;
 				}

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -448,6 +448,57 @@ else
 		fail "start= beyond the last dataset returns an empty page" \
 			"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
 	fi
+
+	# --- over-long start= (issue #240) ---
+	#
+	# The dataset list cuts start= to 44 characters, the longest a cataloged
+	# name can be. A 45-character value was then applied as if the client had
+	# asked for its 44-character prefix, so a data set named exactly that
+	# prefix -- which sorts BEFORE the value that was sent -- stayed in the
+	# page. Only a 44-character name can collide, so one is built here.
+	LONG_DSN="${MVSMF_USER}.CURL"
+	while [ "${#LONG_DSN}" -lt 44 ]; do
+		QLEN=$((44 - ${#LONG_DSN} - 1))
+		[ "$QLEN" -le 0 ] && break
+		[ "$QLEN" -gt 8 ] && QLEN=8
+		LONG_DSN="${LONG_DSN}.$(printf 'Q%.0s' $(seq 1 $QLEN))"
+	done
+
+	if [ "${#LONG_DSN}" -ne 44 ]; then
+		skip "over-long start= (no 44-character name fits under ${MVSMF_USER}.CURL)"
+	else
+		curl -s -o /dev/null -X POST -u "$AUTH" \
+			-H "Content-Type: application/json" \
+			-d '{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":3120,"alcunit":"TRK","primary":1,"secondary":1}' \
+			"${BASE_URL}/zosmf/restfiles/ds/${LONG_DSN}"
+
+		# 44 characters fit, so start= still names the first row
+		LIST=$(curl -s -u "$AUTH" \
+			"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL&start=${LONG_DSN}" |
+			jq -r '.items[].dsname' 2>/dev/null)
+
+		if echo "$LIST" | grep -qx "$LONG_DSN"; then
+			pass "start= at 44 characters is inclusive"
+		else
+			fail "start= at 44 characters is inclusive" \
+				"got: $(echo "$LIST" | tr '\n' ' ')"
+		fi
+
+		# 45 do not, and the prefix must not readmit the name
+		LIST=$(curl -s -u "$AUTH" \
+			"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL&start=${LONG_DSN}X" |
+			jq -r '.items[].dsname' 2>/dev/null)
+
+		if ! echo "$LIST" | grep -qx "$LONG_DSN"; then
+			pass "start= at 45 characters starts after the truncated prefix"
+		else
+			fail "start= at 45 characters starts after the truncated prefix" \
+				"got: $(echo "$LIST" | tr '\n' ' ') -- a truncated start= must not readmit the prefix"
+		fi
+
+		curl -s -o /dev/null -X DELETE -u "$AUTH" \
+			"${BASE_URL}/zosmf/restfiles/ds/${LONG_DSN}"
+	fi
 fi
 
 # --- Read with volume prefix ---
@@ -695,6 +746,51 @@ if [ "$LIST" = "MBRB MBRC" ]; then
 else
 	fail "start= and pattern= compose" "got '$LIST' (expected 'MBRB MBRC')"
 fi
+
+# --- List PDS members (over-long start=, issue #240) ---
+#
+# A start= value longer than eight characters is cut to eight. It used to be
+# applied as if the client had asked for that prefix, so a member named exactly
+# the prefix -- which sorts BEFORE the value the client sent -- came back in the
+# page. The prefix now starts the page exclusively.
+#
+# The directory here is MBRA, MBRB, MBRC, MBRCXXXX, MBRF1, MBR03, TESTMBR, in
+# EBCDIC order: MBRC pads with blanks and 0x40 sorts below 'X'.
+echo ""
+echo "--- List PDS Members (over-long start=, issue #240) ---"
+
+curl -s -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary "MEMBER MBRCXXXX" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(MBRCXXXX)"
+
+# eight characters still fit, so start= keeps naming the first member of the page
+LIST=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRCXXXX" |
+	jq -r '.items[].member' 2>/dev/null)
+
+if [ "$(echo "$LIST" | head -1)" = "MBRCXXXX" ]; then
+	pass "start=MBRCXXXX (8 chars) is inclusive"
+else
+	fail "start=MBRCXXXX (8 chars) is inclusive" \
+		"got: $(echo "$LIST" | tr '\n' ' ')"
+fi
+
+# nine characters do not: MBRCXXXX sorts before MBRCXXXXY and must be dropped
+LIST=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=MBRCXXXXY" |
+	jq -r '.items[].member' 2>/dev/null)
+
+if [ "$(echo "$LIST" | head -1)" = "MBRF1" ] &&
+   ! echo "$LIST" | grep -qx 'MBRCXXXX'; then
+	pass "start=MBRCXXXXY (9 chars) starts after the truncated prefix"
+else
+	fail "start=MBRCXXXXY (9 chars) starts after the truncated prefix" \
+		"got: $(echo "$LIST" | tr '\n' ' ') -- a truncated start= must not readmit the prefix"
+fi
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(MBRCXXXX)"
 
 for M in MBRA MBRB MBRC MBRF1 MBR03; do
 	curl -s -o /dev/null -X DELETE -u "$AUTH" \


### PR DESCRIPTION
Fixes #240

## The defect

`make_query_key()` cuts its input to the longest name the key can hold — eight
characters for a member, 44 for a dataset. The comment at `dsapi.c:1579`
justified that for `start=`:

> a key longer than a name simply sorts past every entry

After the cut it is no longer longer. It *becomes* the prefix and sorts exactly
there, so an entry named exactly the prefix was included in the page even though
it sorts before the value the client sent — the client got back a row it already
had.

Reproduced against the live build before the fix (`a218d3d`):

```
GET /ds/SYS1.PROCLIB/member?start=JES20098    -> ["JES20098","JES20099","LINKS"]
GET /ds/SYS1.PROCLIB/member?start=JES20098X   -> ["JES20098","JES20099","LINKS"]   <-- wrong
GET /ds?dslevel=IBMUSER.CURL&start=<44-char>  -> ["<44-char>","IBMUSER.CURL.MALF"]
GET /ds?dslevel=IBMUSER.CURL&start=<44-char>X -> ["<44-char>","IBMUSER.CURL.MALF"] <-- wrong
```

## The fix

`make_query_key()` reports truncation through an out-parameter, and both list
handlers make the start of the page exclusive when it happened. `pattern=`
passes `NULL` — an over-long pattern is still rejected with 400 before the key
is built (#236), and that behaviour is untouched.

The reasoning differs per handler, as noted on the issue, so the two are derived
separately rather than sharing a rule:

- **dataset list** — `strcmp(ds->dsn, start_key)`, NUL terminated. A prefix
  always sorts before the longer value: the prefix ends in 0x00, below every
  byte the value can continue with. Exactly correct, no edge case.
- **member list** — `memcmp(&blk[pos], start_key, 8)`, eight blank-padded bytes.
  The name runs out into 0x40 and the value carries on; every character a client
  can send there sorts above the blank. Exact for anything a URL query can carry.

## Tests

`tests/curl-datasets.sh` gains four assertions — for each endpoint, that the
maximum-length value is still **inclusive** and that one character more starts
the page **after** the prefix. The dataset case needs a name of exactly 44
characters to collide with, so the suite builds one under `${MVSMF_USER}.CURL`,
uses it, and deletes it; if no 44-character name fits under that level the case
skips rather than passing vacuously.

## Verification

Deployed and activated into the live `HTTPD.LINKLIB`; `/zosmf/test?fn=version`
reports `1a16ebb`, matching the branch HEAD that was built. The four probes
above now answer:

```
start=JES20098    -> ["JES20098","JES20099","LINKS"]   (8 chars, still inclusive)
start=JES20098X   -> ["JES20099","LINKS","LIST"]
start=<44-char>   -> ["<44-char>","IBMUSER.CURL.MALF"] (44 chars, still inclusive)
start=<44-char>X  -> ["IBMUSER.CURL.MALF"]
```

Both suites green against MVS:

- `tests/curl-datasets.sh` — 107 passed, 0 failed, 0 skipped (was 103)
- `tests/zowe-datasets.sh` — 39 passed, 0 failed, 0 skipped