### PR TITLE
dsapi: keep blank lines and full-width records on the text write path

### DIFF
--- a/docs/endpoints/datasets/members-put.md
+++ b/docs/endpoints/datasets/members-put.md
@@ -39,10 +39,27 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 Only a missing *dataset* is an error here. A member that does not exist yet is
 what a create looks like, and it is written normally.
 
+## Text mode framing
+- A record ends at LF, CR or CRLF. The terminator is not part of the record.
+- A line of exactly LRECL characters is accepted. Only a longer line is
+  rejected, with "Record too long"; it is never silently split across two
+  records. Until issue #233 the usable length was LRECL-2, so 80-column source
+  could not be uploaded into an FB80 library at all.
+- For RECFM=V the usable line length is LRECL-4: the record descriptor word is
+  not content. A longer line used to be split into a second record without
+  notice and is now rejected.
+- A blank line is written as a record of blanks — it used to disappear (#233).
+- A body whose last line carries no terminator still produces that record, and
+  a body ending in a newline does not gain a trailing blank one.
+- With `Transfer-Encoding: chunked` a line split across two chunks stays one
+  record; a chunk boundary is a transport boundary, not a record boundary.
+
 ## Limitations
-- Text mode: a line longer than the dataset's LRECL is rejected with an error
-  ("Record too long"); it is not silently split across two records
 - Binary mode: the final incomplete record is padded with binary zeros to LRECL
+- A rejected upload does not leave the previous member content in place. The
+  member is opened for output before the body is read, so on "Record too long"
+  the records written up to that line are already stored and the previous
+  content is gone.
 
 There is no fixed upper bound on the record size: the write buffer is sized
 from the dataset's own DCB (LRECL, or BLKSIZE for RECFM=U). Records above

--- a/docs/endpoints/datasets/put.md
+++ b/docs/endpoints/datasets/put.md
@@ -34,11 +34,28 @@ On successful completion, this request returns HTTP status code 204 (No Content)
     - Dataset not found or cannot be opened for writing
     - I/O error during write
 
+## Text mode framing
+- A record ends at LF, CR or CRLF. The terminator is not part of the record.
+- A line of exactly LRECL characters is accepted. Only a longer line is
+  rejected, with "Record too long"; it is never silently split across two
+  records. Until issue #233 the usable length was LRECL-2, so 80-column source
+  could not be uploaded into an FB80 dataset at all.
+- For RECFM=V the usable line length is LRECL-4: the record descriptor word is
+  not content. A longer line used to be split into a second record without
+  notice and is now rejected.
+- A blank line is written as a record of blanks — it used to disappear (#233).
+- A body whose last line carries no terminator still produces that record, and
+  a body ending in a newline does not gain a trailing blank one.
+- With `Transfer-Encoding: chunked` a line split across two chunks stays one
+  record; a chunk boundary is a transport boundary, not a record boundary.
+
 ## Limitations
 - Only sequential (PS) datasets are supported; PDS datasets return HTTP 400
-- Text mode: a line longer than the dataset's LRECL is rejected with an error
-  ("Record too long"); it is not silently split across two records
 - Binary mode: the final incomplete record is padded with binary zeros to LRECL
+- A rejected upload does not leave the previous content in place. The dataset
+  is opened for output before the body is read, so on "Record too long" the
+  records written up to that line are already in the dataset and everything
+  that was there before is gone.
 
 There is no fixed upper bound on the record size: the write buffer is sized
 from the dataset's own DCB (LRECL, or BLKSIZE for RECFM=U). Records above

--- a/include/reclines.h
+++ b/include/reclines.h
@@ -1,0 +1,83 @@
+#ifndef RECLINES_H
+#define RECLINES_H
+
+#include <stddef.h>
+
+/**
+ * @file reclines.h
+ * @brief Byte stream to fixed-length records: the framing used by the text
+ *        write paths in dsapi.c.
+ *
+ * A text upload arrives as a stream of ASCII bytes and has to become data set
+ * records. Both PUT handlers (sequential and PDS member) do that twice each --
+ * once for Content-Length, once for chunked -- which is why the same off-by-one
+ * had to be fixed in four places and was then wrong in four places again
+ * (issues #198, #233). The state machine lives here so there is one copy of it,
+ * and so test/host/tstrecl.c can exercise the real code on the host.
+ *
+ * The rules it implements:
+ *
+ *   - The terminator is never stored. `content_max` therefore counts payload
+ *     only, and a line of exactly LRECL characters fits.
+ *   - LF, CR and CRLF all end a record; the LF of a CRLF pair is swallowed
+ *     through the normal byte loop, so the caller never has to read ahead
+ *     (and never consumes a byte it did not count).
+ *   - A blank line is a record, not a no-op: it is emitted as a single blank.
+ *     libc370 pads a short record out to LRECL with blanks, but a zero-length
+ *     fwrite() leaves its buffer empty and fflush() then returns at its
+ *     empty-buffer guard -- the record would silently disappear (#233).
+ *   - State survives a chunk boundary, including one that falls between the
+ *     CR and the LF of a CRLF pair, so a line split across two chunks stays
+ *     one record.
+ *
+ * The bytes are ASCII here: this runs before the ASCII->EBCDIC translation in
+ * write_record(), so the terminators and the blank are ASCII values, not the
+ * compiler's (EBCDIC) character literals.
+ */
+
+/* Result of recline_put(). */
+#define RECLINE_MORE		0	/* byte consumed, record not complete yet */
+#define RECLINE_RECORD		1	/* record complete, returned in rec/rec_len */
+#define RECLINE_TOOLONG		2	/* content would exceed content_max         */
+
+typedef struct {
+	char	*buf;			/* caller's buffer, at least content_max bytes  */
+	size_t	 len;			/* content bytes currently held in buf          */
+	size_t	 content_max;	/* usable content bytes per record, must be > 0 */
+	int	 pending_lf;		/* last byte was CR: a following LF belongs to it */
+} RECLINE;
+
+/**
+ * Start framing into `buf`, which must hold at least `content_max` bytes.
+ * `content_max` is the record's usable content length -- LRECL for RECFM=F,
+ * LRECL-4 for RECFM=V (the RDW is not content), BLKSIZE for RECFM=U -- and
+ * must be greater than zero.
+ */
+void recline_init(RECLINE *rl, char *buf, size_t content_max)	asm("MFRECINI");
+
+/**
+ * Feed one ASCII byte.
+ *
+ * Returns RECLINE_RECORD when the byte completed a record; *rec and *rec_len
+ * then describe it, and remain valid until the next recline_put(). The caller
+ * must write that record out before feeding the next byte -- the buffer is
+ * reused, and write_record() translates it in place.
+ *
+ * Returns RECLINE_TOOLONG when the byte would be content number
+ * content_max + 1. Nothing is stored and the stream cannot be continued; the
+ * caller is expected to fail the request.
+ *
+ * Returns RECLINE_MORE otherwise; *rec and *rec_len are not touched.
+ */
+int recline_put(RECLINE *rl, char c, char **rec, size_t *rec_len)
+														asm("MFRECPUT");
+
+/**
+ * Take the trailing record of a body that did not end in a terminator.
+ *
+ * Returns 1 with *rec/*rec_len set when content is pending, 0 when there is
+ * none -- a body ending in a newline must not produce a phantom blank record.
+ */
+int recline_flush(RECLINE *rl, char **rec, size_t *rec_len)	asm("MFRECFLS");
+
+#endif /* RECLINES_H */

--- a/project.toml
+++ b/project.toml
@@ -44,6 +44,15 @@ name = "TSTMTLN"
 sources = ["test/host/tstmtln.c"]
 norent = true
 
+# TSTRECL: #233 — framing a text upload into data set records. Blank lines must
+# survive, and a line of exactly LRECL columns must be accepted. The TU
+# #includes src/reclines.c so it drives the real state machine the four write
+# loops in dsapi.c use — do not list reclines.c here.
+[[test]]
+name = "TSTRECL"
+sources = ["test/host/tstrecl.c"]
+norent = true
+
 # TSTJCLN: #220 — a failed realloc while growing the JCL line table must leave
 # the lines[] array and the line buffer consistent. Portable C (test-host); the
 # TU #includes src/jclines.c with a fault-injecting realloc, so it exercises the

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -14,6 +14,7 @@
 #include "dsapi_err.h"
 #include "common.h"
 #include "httpcgi.h"
+#include "reclines.h"
 
 // Record format flags
 #define FIXED     0x0001
@@ -445,6 +446,29 @@ static int parse_data_type(const char *data_type) {
     return DATA_TYPE_TEXT;  // Default to text for unknown values
 }
 
+/* Usable content bytes in one record of this data set.
+ *
+ * RECFM=F spends the whole LRECL on content. RECFM=V spends four of it on the
+ * RDW: libc370 sizes its write buffer at LRECL-4 (@@fpopen.c) and varflush()
+ * writes an RDW of len+4, so a longer line was silently split into a second
+ * record. RECFM=U has no LRECL and is bounded by the block size.
+ *
+ * eff_lrecl is the caller's LRECL, or BLKSIZE where RECFM=U leaves LRECL 0.
+ */
+__asm__("\n&FUNC    SETC 'rec_content_max'");
+static size_t record_content_max(FILE *fp, size_t eff_lrecl, int is_undefined)
+{
+    if (is_undefined) {
+        return eff_lrecl;
+    }
+
+    if ((fp->recfm & _FILE_RECFM_TYPE) == _FILE_RECFM_V) {
+        return eff_lrecl > 4 ? eff_lrecl - 4 : 0;
+    }
+
+    return eff_lrecl;
+}
+
 /* Helper function to write a complete record.
  *
  * TEXT records are translated to EBCDIC in place, inside the caller's buffer.
@@ -454,13 +478,18 @@ static int parse_data_type(const char *data_type) {
  * buffer is already sized to the data set and its contents are dead once this
  * returns, so no second buffer is needed at all.
  *
- * eff_lrecl: the caller's allocation size and record limit in one value -- the
- * data set's LRECL, or its BLKSIZE for RECFM=U where LRECL is 0. Clamping
- * against fp->lrecl instead cut every record of a RECFM=U data set to zero
- * length, because a text-mode write is selected by the X-IBM-Data-Type header
- * and does not care what RECFM the data set has.
+ * Record framing is NOT done here: the text callers hand over one finished
+ * record, terminator already removed, courtesy of the state machine in
+ * reclines.c. This function used to strip the terminator itself, which is how
+ * a blank line ended up as a zero-length fwrite() and disappeared (#233).
+ *
+ * content_max: the usable content length of one record -- LRECL for RECFM=F,
+ * LRECL-4 for RECFM=V (the RDW is not content), BLKSIZE for RECFM=U where
+ * LRECL is 0. Clamping against fp->lrecl instead cut every record of a
+ * RECFM=U data set to zero length, because a text-mode write is selected by
+ * the X-IBM-Data-Type header and does not care what RECFM the data set has.
  */
-static int write_record(Session *session, FILE *fp, char *record_buffer, size_t record_length, size_t *total_written, int *line_count, int data_type, size_t eff_lrecl)
+static int write_record(Session *session, FILE *fp, char *record_buffer, size_t record_length, size_t *total_written, int *line_count, int data_type, size_t content_max)
 {
     int recfm = fp->recfm;  // Get record format from file handle
 
@@ -489,7 +518,15 @@ static int write_record(Session *session, FILE *fp, char *record_buffer, size_t 
             break;
             
         case DATA_TYPE_RECORD:
-            // Record mode - each record is preceded by 4-byte length
+            /* Record mode - each record is preceded by 4-byte length.
+             *
+             * NOTE: nothing frames a length-prefixed stream on the write path.
+             * X-IBM-Data-Type: record shares the text loop, which cuts the
+             * body at newlines, so the four bytes read below are a length
+             * prefix only by accident -- a body produced by the read path
+             * (which does emit the prefixes) cannot be written back. Unusable
+             * as it stands, exercised by no test, and tracked separately; this
+             * branch is left as it was found. */
             if (record_length < 4) return -1;  // Need at least 4 bytes for length
             
             // First 4 bytes contain the record length
@@ -525,24 +562,14 @@ static int write_record(Session *session, FILE *fp, char *record_buffer, size_t 
         case DATA_TYPE_TEXT:
         default:
             // Text mode - convert from ASCII to EBCDIC
-            
-            // Remove newline if present (ASCII LF = 0x0A, ASCII CR = 0x0D)
-            if (record_length > 0 && (record_buffer[record_length-1] == 0x0A || record_buffer[record_length-1] == 0x0D)) {
-                record_length--;
-            }
 
-            // Also remove CR if we had CRLF
-            if (record_length > 0 && record_buffer[record_length-1] == 0x0D) {
-                record_length--;
-            }
-            
-            /* Backstop only: every text caller already rejects a line at
-               eff_lrecl - 1 with "Record too long", so this cannot normally
+            /* Backstop only: recline_put() already rejects a line longer than
+               content_max with "Record too long", so this cannot normally
                fire. It stays as the last line of defence against a caller
                and this function disagreeing about the limit -- which is
                precisely how issue #198 happened. */
-            if (eff_lrecl && record_length > eff_lrecl) {
-                record_length = eff_lrecl;
+            if (content_max && record_length > content_max) {
+                record_length = content_max;
             }
 
             // Convert to EBCDIC in place -- the caller's buffer is sized to the
@@ -1098,13 +1125,17 @@ int datasetPutHandler(Session *session)
     int line_count = 0;
     char *record_buffer = NULL;
     size_t eff_lrecl = 0;
+    size_t content_max = 0;
     int is_undefined = 0;
     size_t record_pos = 0;
+    RECLINE rl;
+    char *rec = NULL;
+    size_t rec_len = 0;
     int data_type;
 
     // Validate parameters
     dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
-    
+
     if (!dsname) {
         wtof("MVSMF31E Missing required parameter: dsname=NULL");
         return handle_error(session, ERR_INVALID_PARAM, "Dataset name is required");
@@ -1179,7 +1210,8 @@ int datasetPutHandler(Session *session)
     /* For RECFM=U (undefined record format), lrecl is 0. Use blksize instead. */
     is_undefined = ((fp->recfm & _FILE_RECFM_TYPE) == _FILE_RECFM_U);
     eff_lrecl = is_undefined ? (size_t)fp->blksize : (size_t)fp->lrecl;
-    if (eff_lrecl == 0) {
+    content_max = record_content_max(fp, eff_lrecl, is_undefined);
+    if (eff_lrecl == 0 || content_max == 0) {
         wtof("MVSMF34E Dataset has zero record length: %s", dsname);
         session_fclose(session, fp);
         return handle_error(session, ERR_IO, "Dataset has zero record length");
@@ -1192,6 +1224,7 @@ int datasetPutHandler(Session *session)
         session_fclose(session, fp);
         return handle_error(session, ERR_MEMORY, "Memory allocation failed");
     }
+    recline_init(&rl, record_buffer, content_max);
 
     if (is_chunked) {
         // Handle chunked transfer encoding
@@ -1225,13 +1258,25 @@ int datasetPutHandler(Session *session)
 
             if (chunk_size == 0) {
                 // Write last incomplete record if any
-                if (record_pos > 0) {
-                    if (data_type == DATA_TYPE_BINARY && !is_undefined) {
-                        /* Pad to full LRECL for fixed-length binary records */
-                        memset(record_buffer + record_pos, 0x00, eff_lrecl - record_pos);
-                        record_pos = eff_lrecl;
+                if (data_type == DATA_TYPE_BINARY) {
+                    if (record_pos > 0) {
+                        if (!is_undefined) {
+                            /* Pad to full LRECL for fixed-length binary records */
+                            memset(record_buffer + record_pos, 0x00, eff_lrecl - record_pos);
+                            record_pos = eff_lrecl;
+                        }
+                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
+                            wtof("MVSMF39E Error writing final record");
+                            free(record_buffer);
+                            session_fclose(session, fp);
+                            return handle_error(session, ERR_IO, "Error writing final record");
+                        }
                     }
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                } else if (recline_flush(&rl, &rec, &rec_len)) {
+                    /* Text: a body whose last line has no terminator. Nothing
+                       is pending when it ended on one, so a trailing newline
+                       does not add a phantom record. */
+                    if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                         wtof("MVSMF39E Error writing final record");
                         free(record_buffer);
                         session_fclose(session, fp);
@@ -1279,7 +1324,7 @@ int datasetPutHandler(Session *session)
                     record_pos += n;
 
                     if (record_pos >= eff_lrecl) {
-                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
                             wtof("MVSMF42E Error writing record");
                             free(record_buffer);
                             session_fclose(session, fp);
@@ -1290,7 +1335,11 @@ int datasetPutHandler(Session *session)
                 }
                 /* Do NOT flush buffer at end of chunk for binary */
             } else {
-                /* Text mode: split records at newline boundaries */
+                /* Text mode: split records at newline boundaries.
+                   The RECLINE state lives across chunks on purpose -- a chunk
+                   is a transport boundary, not a record boundary. Flushing
+                   here (as this did) turned every line split across two chunks
+                   into two records. */
                 while (bytes_read < chunk_size) {
                     if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                         wtof("MVSMF38E Error reading chunk data");
@@ -1300,34 +1349,25 @@ int datasetPutHandler(Session *session)
                     }
                     bytes_read++;
 
-                    if (record_pos >= eff_lrecl - 1) {
+                    switch (recline_put(&rl, c, &rec, &rec_len)) {
+                    case RECLINE_TOOLONG:
                         wtof("MVSMF43E Record too long");
                         free(record_buffer);
                         session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Record too long");
-                    }
-                    record_buffer[record_pos++] = c;
 
-                    if (c == 0x0A) {
-                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                    case RECLINE_RECORD:
+                        if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                             wtof("MVSMF42E Error writing record");
                             free(record_buffer);
                             session_fclose(session, fp);
                             return handle_error(session, ERR_IO, "Error writing record");
                         }
-                        record_pos = 0;
-                    }
-                }
+                        break;
 
-                /* Write any remaining text data at end of chunk */
-                if (record_pos > 0) {
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
-                        wtof("MVSMF39E Error writing final record");
-                        free(record_buffer);
-                        session_fclose(session, fp);
-                        return handle_error(session, ERR_IO, "Error writing final record");
+                    default:
+                        break;
                     }
-                    record_pos = 0;
                 }
             }
 
@@ -1363,7 +1403,7 @@ int datasetPutHandler(Session *session)
                 record_pos += n;
 
                 if (record_pos >= eff_lrecl) {
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
                         wtof("MVSMF46E Error writing record");
                         free(record_buffer);
                         session_fclose(session, fp);
@@ -1379,7 +1419,7 @@ int datasetPutHandler(Session *session)
                     memset(record_buffer + record_pos, 0x00, eff_lrecl - record_pos);
                     record_pos = eff_lrecl;
                 }
-                if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
                     wtof("MVSMF39E Error writing final record");
                     free(record_buffer);
                     session_fclose(session, fp);
@@ -1387,7 +1427,11 @@ int datasetPutHandler(Session *session)
                 }
             }
         } else {
-            /* Text mode: split records at newline boundaries */
+            /* Text mode: split records at newline boundaries. LF, CR and CRLF
+               all end a record; recline_put() swallows the LF of a CRLF pair
+               on the next pass through this loop, so every byte read is a byte
+               counted -- the read-ahead this used to do consumed one byte more
+               than Content-Length allowed whenever a CR stood alone. */
             char c;
             while (bytes_remaining > 0) {
                 if (recv(session->httpc->socket, &c, 1, 0) != 1) {
@@ -1398,39 +1442,30 @@ int datasetPutHandler(Session *session)
                 }
                 bytes_remaining--;
 
-                if (record_pos >= eff_lrecl - 1) {
+                switch (recline_put(&rl, c, &rec, &rec_len)) {
+                case RECLINE_TOOLONG:
                     wtof("MVSMF43E Record too long");
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Record too long");
-                }
-                record_buffer[record_pos++] = c;
 
-                if (c == 0x0A || c == 0x0D) {
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                case RECLINE_RECORD:
+                    if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                         wtof("MVSMF46E Error writing record");
                         free(record_buffer);
                         session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing record");
                     }
-                    record_pos = 0;
-                    if (c == 0x0D) {
-                        char next;
-                        if (recv(session->httpc->socket, &next, 1, 0) == 1 && next == 0x0A) {
-                            bytes_remaining--;
-                        } else {
-                            record_buffer[record_pos++] = next;
-                        }
-                    }
+                    break;
+
+                default:
+                    break;
                 }
             }
 
-            /* Write any remaining text data as the last record */
-            if (record_pos > 0) {
-                if (record_pos > eff_lrecl) {
-                    record_pos = eff_lrecl;
-                }
-                if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+            /* A last line without a terminator is still a record */
+            if (recline_flush(&rl, &rec, &rec_len)) {
+                if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                     wtof("MVSMF39E Error writing final record");
                     free(record_buffer);
                     session_fclose(session, fp);
@@ -1853,8 +1888,12 @@ int memberPutHandler(Session *session)
     int line_count = 0;
     char *record_buffer = NULL;
     size_t eff_lrecl = 0;
+    size_t content_max = 0;
     int is_undefined = 0;
     size_t record_pos = 0;
+    RECLINE rl;
+    char *rec = NULL;
+    size_t rec_len = 0;
     int data_type;
 
     // Validate parameters
@@ -1945,7 +1984,8 @@ int memberPutHandler(Session *session)
        therefore overran it (issue #198). For RECFM=U, lrecl is 0; use blksize. */
     is_undefined = ((fp->recfm & _FILE_RECFM_TYPE) == _FILE_RECFM_U);
     eff_lrecl = is_undefined ? (size_t)fp->blksize : (size_t)fp->lrecl;
-    if (eff_lrecl == 0) {
+    content_max = record_content_max(fp, eff_lrecl, is_undefined);
+    if (eff_lrecl == 0 || content_max == 0) {
         wtof("MVSMF06E Dataset has zero record length: %s", dataset);
         session_fclose(session, fp);
         return handle_error(session, ERR_IO, "Dataset has zero record length");
@@ -1958,6 +1998,7 @@ int memberPutHandler(Session *session)
         session_fclose(session, fp);
         return handle_error(session, ERR_MEMORY, "Memory allocation failed");
     }
+    recline_init(&rl, record_buffer, content_max);
 
     if (is_chunked) {
         // Handle chunked transfer encoding
@@ -1991,13 +2032,22 @@ int memberPutHandler(Session *session)
 
             if (chunk_size == 0) {
                 // Write last incomplete record if any
-                if (record_pos > 0) {
-                    if (data_type == DATA_TYPE_BINARY) {
+                if (data_type == DATA_TYPE_BINARY) {
+                    if (record_pos > 0) {
                         // Pad to full LRECL for fixed-length binary records
                         memset(record_buffer + record_pos, 0x00, eff_lrecl - record_pos);
                         record_pos = eff_lrecl;
+                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
+                            wtof("MVSMF11E Error writing final record");
+                            free(record_buffer);
+                            session_fclose(session, fp);
+                            return handle_error(session, ERR_IO, "Error writing final record");
+                        }
                     }
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                } else if (recline_flush(&rl, &rec, &rec_len)) {
+                    /* Text: only a last line without a terminator is pending
+                       here -- a body ending in a newline adds no record. */
+                    if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                         wtof("MVSMF11E Error writing final record");
                         free(record_buffer);
                         session_fclose(session, fp);
@@ -2045,7 +2095,7 @@ int memberPutHandler(Session *session)
                     record_pos += n;
 
                     if (record_pos >= eff_lrecl) {
-                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
                             wtof("MVSMF14E Error writing record");
                             free(record_buffer);
                             session_fclose(session, fp);
@@ -2056,7 +2106,9 @@ int memberPutHandler(Session *session)
                 }
                 // Do NOT flush buffer at end of chunk for binary
             } else {
-                // Text mode: split records at newline boundaries
+                /* Text mode: split records at newline boundaries. The RECLINE
+                   state deliberately survives the chunk boundary -- see the
+                   sequential handler. */
                 while (bytes_read < chunk_size) {
                     if (recv(session->httpc->socket, &c, 1, 0) != 1) {
                         wtof("MVSMF13E Error reading chunk data");
@@ -2066,34 +2118,25 @@ int memberPutHandler(Session *session)
                     }
                     bytes_read++;
 
-                    if (record_pos >= eff_lrecl - 1) {
+                    switch (recline_put(&rl, c, &rec, &rec_len)) {
+                    case RECLINE_TOOLONG:
                         wtof("MVSMF43E Record too long");
                         free(record_buffer);
                         session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Record too long");
-                    }
-                    record_buffer[record_pos++] = c;
 
-                    if (c == 0x0A) {
-                        if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                    case RECLINE_RECORD:
+                        if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                             wtof("MVSMF14E Error writing record");
                             free(record_buffer);
                             session_fclose(session, fp);
                             return handle_error(session, ERR_IO, "Error writing record");
                         }
-                        record_pos = 0;
-                    }
-                }
+                        break;
 
-                // Write any remaining text data at end of chunk
-                if (record_pos > 0) {
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
-                        wtof("MVSMF39E Error writing final record");
-                        free(record_buffer);
-                        session_fclose(session, fp);
-                        return handle_error(session, ERR_IO, "Error writing final record");
+                    default:
+                        break;
                     }
-                    record_pos = 0;
                 }
             }
             
@@ -2129,7 +2172,7 @@ int memberPutHandler(Session *session)
                 record_pos += n;
 
                 if (record_pos >= eff_lrecl) {
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
                         wtof("MVSMF18E Error writing record");
                         free(record_buffer);
                         session_fclose(session, fp);
@@ -2143,7 +2186,7 @@ int memberPutHandler(Session *session)
             if (record_pos > 0) {
                 memset(record_buffer + record_pos, 0x00, eff_lrecl - record_pos);
                 record_pos = eff_lrecl;
-                if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, content_max) < 0) {
                     wtof("MVSMF19E Error writing final record");
                     free(record_buffer);
                     session_fclose(session, fp);
@@ -2151,7 +2194,9 @@ int memberPutHandler(Session *session)
                 }
             }
         } else {
-            // Text mode: split records at newline boundaries
+            /* Text mode: split records at newline boundaries -- same framing
+               as the sequential handler, including the CRLF handling that
+               replaces the old read-ahead. */
             char c;
             while (bytes_remaining > 0) {
                 if (recv(session->httpc->socket, &c, 1, 0) != 1) {
@@ -2162,39 +2207,30 @@ int memberPutHandler(Session *session)
                 }
                 bytes_remaining--;
 
-                if (record_pos >= eff_lrecl - 1) {
+                switch (recline_put(&rl, c, &rec, &rec_len)) {
+                case RECLINE_TOOLONG:
                     wtof("MVSMF43E Record too long");
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Record too long");
-                }
-                record_buffer[record_pos++] = c;
 
-                if (c == 0x0A || c == 0x0D) {
-                    if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+                case RECLINE_RECORD:
+                    if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                         wtof("MVSMF18E Error writing record");
                         free(record_buffer);
                         session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error writing record");
                     }
-                    record_pos = 0;
-                    if (c == 0x0D) {
-                        char next;
-                        if (recv(session->httpc->socket, &next, 1, 0) == 1 && next == 0x0A) {
-                            bytes_remaining--;
-                        } else {
-                            record_buffer[record_pos++] = next;
-                        }
-                    }
+                    break;
+
+                default:
+                    break;
                 }
             }
 
-            // Write any remaining text data
-            if (record_pos > 0) {
-                if (record_pos > eff_lrecl) {
-                    record_pos = eff_lrecl;
-                }
-                if (write_record(session, fp, record_buffer, record_pos, &total_written, &line_count, data_type, eff_lrecl) < 0) {
+            /* A last line without a terminator is still a record */
+            if (recline_flush(&rl, &rec, &rec_len)) {
+                if (write_record(session, fp, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                     wtof("MVSMF19E Error writing final record");
                     free(record_buffer);
                     session_fclose(session, fp);

--- a/src/reclines.c
+++ b/src/reclines.c
@@ -1,0 +1,90 @@
+#include <stddef.h>
+
+#include "reclines.h"
+
+/*
+ * Byte stream to fixed-length records. See reclines.h for the framing rules
+ * and why they live in their own translation unit; issues #198 and #233 for
+ * what four copies of this cost.
+ *
+ * ASCII values, deliberately: the payload is still ASCII at this point --
+ * write_record() translates it to EBCDIC afterwards -- so the compiler's
+ * character literals (EBCDIC under cc370) would be the wrong bytes here.
+ */
+#define ASCII_LF	0x0A
+#define ASCII_CR	0x0D
+#define ASCII_BLANK	0x20
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'recline_init'");
+#endif
+void
+recline_init(RECLINE *rl, char *buf, size_t content_max)
+{
+	rl->buf         = buf;
+	rl->len         = 0;
+	rl->content_max = content_max;
+	rl->pending_lf  = 0;
+}
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'recline_put'");
+#endif
+int
+recline_put(RECLINE *rl, char c, char **rec, size_t *rec_len)
+{
+	/* The LF of a CRLF pair: the CR already ended the record. Cleared on any
+	   byte, so a lone CR followed by content behaves like a terminator too --
+	   and the byte is consumed by the caller's normal read loop, which is what
+	   keeps the Content-Length accounting straight. */
+	if (rl->pending_lf) {
+		rl->pending_lf = 0;
+		if (c == ASCII_LF) {
+			return RECLINE_MORE;
+		}
+	}
+
+	if (c == ASCII_LF || c == ASCII_CR) {
+		if (rl->len == 0) {
+			/* A blank line is a real record of blanks. One blank is enough:
+			   libc370's fixflush() pads to LRECL, while a zero-length record
+			   would never reach the data set at all (#233). */
+			rl->buf[0] = ASCII_BLANK;
+			rl->len    = 1;
+		}
+
+		*rec     = rl->buf;
+		*rec_len = rl->len;
+		rl->len  = 0;
+
+		if (c == ASCII_CR) {
+			rl->pending_lf = 1;
+		}
+		return RECLINE_RECORD;
+	}
+
+	/* The terminator is never stored, so this counts content only: a line of
+	   exactly content_max characters fits. */
+	if (rl->len >= rl->content_max) {
+		return RECLINE_TOOLONG;
+	}
+
+	rl->buf[rl->len++] = c;
+	return RECLINE_MORE;
+}
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'recline_flush'");
+#endif
+int
+recline_flush(RECLINE *rl, char **rec, size_t *rec_len)
+{
+	if (rl->len == 0) {
+		return 0;	/* body ended on a terminator -- no trailing record */
+	}
+
+	*rec     = rl->buf;
+	*rec_len = rl->len;
+	rl->len  = 0;
+	return 1;
+}

--- a/test/host/tstrecl.c
+++ b/test/host/tstrecl.c
@@ -1,0 +1,254 @@
+/*
+ * tstrecl.c - #233 regression: framing a text upload into data set records.
+ *
+ * Two defects on the text write path, both in four copies of the same loop in
+ * dsapi.c:
+ *
+ *   1. A blank line produced a zero-length record. write_record() stripped the
+ *      terminator, fwrite() then wrote nothing, and libc370's fflush() returned
+ *      at its empty-buffer guard -- the record vanished and the upload still
+ *      answered 204.
+ *   2. The length guard ran before the byte was stored AND counted the
+ *      terminator, so the usable line length was LRECL-2: a line of exactly 80
+ *      characters into an FB80 data set was rejected with "Record too long".
+ *
+ * Fix: the terminator is never buffered, so the limit counts content only, and
+ * a terminated empty line is emitted as a single blank (libc370 pads a short
+ * record out to LRECL).
+ *
+ * ====================================================================
+ * This test drives the REAL state machine: src/reclines.c is #included
+ * below, so a later refactor stays covered. dsapi.c itself cannot compile
+ * on the host (MVS intrinsics, HLASM labels, live sockets), which is why
+ * the framing lives in its own TU.
+ * ====================================================================
+ *
+ * The input streams are built from ASCII bytes, never from the compiler's
+ * '\n': under cc370 that literal is EBCDIC 0x15, while an HTTP body carries
+ * 0x0A. Each escape sits in its own string literal so the hex escape cannot
+ * swallow the following character. Content bytes are compared against the same
+ * literals that produced them, so their encoding does not matter.
+ *
+ * Runs on host via `make test-host`.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <mbtcheck.h>
+
+#include "../../src/reclines.c"
+
+#define LF	"\x0a"
+#define CR	"\x0d"
+
+/* ---- harness --------------------------------------------------------------
+ * Feeds bytes through the real recline_put() and records every record it
+ * hands back, exactly as the dsapi.c loops do. */
+
+#define MAX_RECS	8
+#define MAX_RECLEN	100
+#define CANARY		0x7E	/* guards the bytes past content_max */
+
+static char	g_buf[MAX_RECLEN + 8];
+static char	g_rec[MAX_RECS][MAX_RECLEN];
+static size_t	g_reclen[MAX_RECS];
+static int	g_nrec;
+static int	g_toolong;
+
+static RECLINE	g_rl;
+
+static void feed_start(size_t content_max)
+{
+	memset(g_buf, CANARY, sizeof(g_buf));
+	memset(g_rec, 0, sizeof(g_rec));
+	memset(g_reclen, 0, sizeof(g_reclen));
+	g_nrec    = 0;
+	g_toolong = 0;
+	recline_init(&g_rl, g_buf, content_max);
+}
+
+/* One chunk of the body. Call repeatedly on the same stream to model a chunk
+ * boundary -- the RECLINE keeps its state across calls, as it does in the
+ * handlers. */
+static void feed(const char *bytes, size_t n)
+{
+	char   *rec;
+	size_t  rec_len;
+	size_t  i;
+	int     act;
+
+	for (i = 0; i < n; i++) {
+		act = recline_put(&g_rl, bytes[i], &rec, &rec_len);
+		if (act == RECLINE_TOOLONG) {
+			g_toolong = 1;
+			return;			/* the handler fails the request here */
+		}
+		if (act == RECLINE_RECORD && g_nrec < MAX_RECS) {
+			memcpy(g_rec[g_nrec], rec, rec_len);
+			g_reclen[g_nrec] = rec_len;
+			g_nrec++;
+		}
+	}
+}
+
+/* The end of the body: a trailing record only if content is pending. */
+static int feed_end(void)
+{
+	char   *rec;
+	size_t  rec_len;
+
+	if (!recline_flush(&g_rl, &rec, &rec_len)) {
+		return 0;
+	}
+	if (g_nrec < MAX_RECS) {
+		memcpy(g_rec[g_nrec], rec, rec_len);
+		g_reclen[g_nrec] = rec_len;
+		g_nrec++;
+	}
+	return 1;
+}
+
+/* Record n equals the given bytes. */
+static int rec_is(int n, const char *want, size_t want_len)
+{
+	if (n >= g_nrec) {
+		return 0;
+	}
+	return g_reclen[n] == want_len && memcmp(g_rec[n], want, want_len) == 0;
+}
+
+/* Nothing was written past the usable content length. */
+static int canary_intact(size_t content_max)
+{
+	size_t i;
+
+	for (i = content_max; i < sizeof(g_buf); i++) {
+		if (g_buf[i] != (char)CANARY) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+static char	line80[80];
+static char	line81[81];
+
+int main(void)
+{
+	static const char blank = 0x20;		/* ASCII, as the record carries it */
+	char              stream[128];
+
+	printf("=== TSTRECL: #233 text record framing ===\n");
+
+	memset(line80, 'A', sizeof(line80));
+	memset(line81, 'A', sizeof(line81));
+
+	/* 1. the reported case: a blank line is a record, not a no-op */
+	feed_start(80);
+	feed("ERSTE" LF LF "DRITTE" LF, 5 + 1 + 1 + 6 + 1);
+	CHECK_EQ(g_nrec, 3, "blank line: three records for three lines");
+	CHECK(rec_is(0, "ERSTE", 5), "blank line: first record is the first line");
+	CHECK(rec_is(1, &blank, 1), "blank line: second record is one blank");
+	CHECK(rec_is(2, "DRITTE", 6), "blank line: third record is the third line");
+	CHECK_EQ(feed_end(), 0, "blank line: no trailing record after the last LF");
+
+	/* 2. a line that exactly fills the record must be accepted (the bug) */
+	feed_start(80);
+	memcpy(stream, line80, 80);
+	memcpy(stream + 80, LF, 1);
+	feed(stream, 81);
+	CHECK_EQ(g_toolong, 0, "LRECL: 80 columns into LRECL=80 accepted");
+	CHECK_EQ(g_nrec, 1, "LRECL: one record");
+	CHECK(rec_is(0, line80, 80), "LRECL: all 80 columns kept");
+	CHECK(canary_intact(80), "LRECL: nothing written past the record length");
+
+	/* 3. one column too many is still rejected, and before storing anything */
+	feed_start(80);
+	memcpy(stream, line81, 81);
+	memcpy(stream + 81, LF, 1);
+	feed(stream, 82);
+	CHECK_EQ(g_toolong, 1, "over-long: 81 columns into LRECL=80 rejected");
+	CHECK_EQ(g_nrec, 0, "over-long: no record emitted");
+	CHECK(canary_intact(80), "over-long: nothing written past the record length");
+
+	/* 4. CRLF at exactly the record length -- the CR ends it, the LF is
+	 *    swallowed and must not open a blank record */
+	feed_start(80);
+	memcpy(stream, line80, 80);
+	memcpy(stream + 80, CR, 1);
+	memcpy(stream + 81, LF, 1);
+	feed(stream, 82);
+	CHECK_EQ(g_toolong, 0, "CRLF: 80 columns plus CRLF accepted");
+	CHECK_EQ(g_nrec, 1, "CRLF: one record, the LF did not start a second");
+	CHECK(rec_is(0, line80, 80), "CRLF: all 80 columns kept");
+
+	/* 5. a lone CR ends a record too, and the byte after it is ordinary
+	 *    content -- no read-ahead, so the caller's byte count stays exact */
+	feed_start(80);
+	feed("AB" CR "CD" CR, 2 + 1 + 2 + 1);
+	CHECK_EQ(g_nrec, 2, "lone CR: two records");
+	CHECK(rec_is(0, "AB", 2), "lone CR: first record");
+	CHECK(rec_is(1, "CD", 2), "lone CR: second record");
+	CHECK_EQ(feed_end(), 0, "lone CR: nothing pending afterwards");
+
+	/* 6. a body that does not end in a terminator still has a last record */
+	feed_start(80);
+	feed("ABC", 3);
+	CHECK_EQ(g_nrec, 0, "no terminator: nothing written while reading");
+	CHECK_EQ(feed_end(), 1, "no terminator: the tail becomes a record");
+	CHECK(rec_is(0, "ABC", 3), "no terminator: the tail is the content");
+
+	/* 7. a body ending in a terminator must not gain a phantom blank record */
+	feed_start(80);
+	feed("ABC" LF, 4);
+	CHECK_EQ(g_nrec, 1, "trailing LF: one record");
+	CHECK_EQ(feed_end(), 0, "trailing LF: no phantom trailing record");
+
+	/* 8. a chunk boundary in mid-line keeps the line one record */
+	feed_start(80);
+	feed("AB", 2);
+	feed("CD" LF, 3);
+	CHECK_EQ(g_nrec, 1, "chunk split: one record across the boundary");
+	CHECK(rec_is(0, "ABCD", 4), "chunk split: content joined");
+
+	/* 9. a chunk boundary between the CR and the LF of one pair */
+	feed_start(80);
+	feed("AB" CR, 3);
+	feed(LF "CD" LF, 4);
+	CHECK_EQ(g_nrec, 2, "CRLF split: two records, the stray LF swallowed");
+	CHECK(rec_is(0, "AB", 2), "CRLF split: first record");
+	CHECK(rec_is(1, "CD", 2), "CRLF split: second record");
+
+	/* 10. blank lines with CRLF endings */
+	feed_start(80);
+	feed(CR LF CR LF, 4);
+	CHECK_EQ(g_nrec, 2, "CRLF blanks: two blank records");
+	CHECK(rec_is(0, &blank, 1), "CRLF blanks: first is one blank");
+	CHECK(rec_is(1, &blank, 1), "CRLF blanks: second is one blank");
+
+	/* 11. the degenerate record length still holds one column, and a blank
+	 *     line fits in it */
+	feed_start(1);
+	feed("A" LF LF "B" LF, 5);
+	CHECK_EQ(g_toolong, 0, "LRECL=1: single columns accepted");
+	CHECK_EQ(g_nrec, 3, "LRECL=1: three records");
+	CHECK(rec_is(1, &blank, 1), "LRECL=1: the blank line still fits");
+	CHECK(canary_intact(1), "LRECL=1: nothing written past the record length");
+
+	feed_start(1);
+	feed("AB" LF, 3);
+	CHECK_EQ(g_toolong, 1, "LRECL=1: two columns rejected");
+
+	/* 12. whatever the caller computes as the usable length is what gets
+	 *     enforced -- RECFM=V passes LRECL-4, so the RDW is not spent on
+	 *     content and a long line no longer spills into a second record */
+	memset(stream, 'V', sizeof(stream));
+	feed_start(4);
+	feed(stream, 4);
+	CHECK_EQ(g_toolong, 0, "content_max=4: four columns accepted");
+	feed(stream, 1);
+	CHECK_EQ(g_toolong, 1, "content_max=4: the fifth column is rejected");
+
+	return mbt_test_summary("TSTRECL");
+}

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -1305,6 +1305,182 @@ fi
 
 rm -f /tmp/curl_ds_big.txt /tmp/curl_ds_big.bin /tmp/curl_ds_big_rt.bin
 
+# =========================================================================
+# Text record framing (issue #233)
+#
+# Two defects on the text write path, both reproducible with plain ASCII
+# into the FB80 PDS above:
+#
+#   - a blank line produced a zero-length fwrite(), which libc370's fflush()
+#     discards at its empty-buffer guard -- the record disappeared and the
+#     upload still answered 204;
+#   - the length guard ran before the byte was stored and counted the
+#     terminator, so the usable line length was LRECL-2: 79 and 80 columns
+#     were rejected as "Record too long".
+#
+# Record counts are checked through a BINARY read: it returns the stored
+# records verbatim (80 bytes each), while the text read strips the padding
+# and would hide a missing blank record.
+# =========================================================================
+
+echo ""
+echo "--- Text framing: blank lines are records (issue #233) ---"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary $'ERSTE ZEILE\n\nDRITTE ZEILE\n' \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(BLANKT)")
+assert_http_status "204" "$HTTP_CODE" "write member with a blank line"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /tmp/curl_ds_blank.bin \
+	-u "$AUTH" \
+	-H "X-IBM-Data-Type: binary" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(BLANKT)")
+assert_http_status "200" "$HTTP_CODE" "read back the member"
+
+RT_SIZE=$(wc -c < /tmp/curl_ds_blank.bin | tr -d ' ')
+if [ "$RT_SIZE" = "240" ]; then
+	pass "three lines stored as three records ($RT_SIZE bytes)"
+else
+	fail "three lines stored as three records" \
+		"expected 240 bytes (3 x 80), got $RT_SIZE"
+fi
+
+CONTENT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(BLANKT)")
+LINE2=$(echo "$CONTENT" | sed -n '2p')
+if [ -z "$LINE2" ]; then
+	pass "the blank line reads back as an empty line"
+else
+	fail "the blank line reads back as an empty line" "got '$LINE2'"
+fi
+
+echo ""
+echo "--- Text framing: a full-width line fits (issue #233) ---"
+
+# 77..80 columns into LRECL=80. 79 and 80 were rejected before the fix.
+# Each width gets its own member and is read back on the spot -- writing them
+# all to one member would only ever prove something about the last one.
+# The line is uploaded from a file: the trailing newline is the byte the old
+# guard tripped over, and a command substitution would strip it.
+for COLS in 77 78 79 80; do
+	awk -v n="$COLS" 'BEGIN { s = ""; while (length(s) < n) s = s "A"; print substr(s, 1, n) }' \
+		> /tmp/curl_ds_wide.txt
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "Content-Type: application/octet-stream" \
+		--data-binary @/tmp/curl_ds_wide.txt \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(WIDE${COLS})")
+	assert_http_status "204" "$HTTP_CODE" "write a ${COLS}-column line into LRECL=80"
+
+	# Binary read: one stored record is exactly LRECL bytes, whatever the
+	# line's own width, so this catches a line that was split in two.
+	curl -s -o /tmp/curl_ds_wide.bin -u "$AUTH" \
+		-H "X-IBM-Data-Type: binary" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(WIDE${COLS})"
+	RT_SIZE=$(wc -c < /tmp/curl_ds_wide.bin | tr -d ' ')
+	if [ "$RT_SIZE" = "80" ]; then
+		pass "the ${COLS}-column line is one record ($RT_SIZE bytes)"
+	else
+		fail "the ${COLS}-column line is one record" \
+			"expected 80 bytes, got $RT_SIZE"
+	fi
+
+	CONTENT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(WIDE${COLS})")
+	RT_COLS=$(echo "$CONTENT" | head -1 | tr -d '\r' | awk '{ print length($0) }')
+	if [ "$RT_COLS" = "$COLS" ]; then
+		pass "all ${COLS} columns survive the round trip"
+	else
+		fail "all ${COLS} columns survive the round trip" \
+			"expected $COLS characters, got $RT_COLS"
+	fi
+done
+
+echo ""
+echo "--- Text framing: one column too many is still rejected ---"
+
+awk 'BEGIN { s = ""; while (length(s) < 81) s = s "A"; print substr(s, 1, 81) }' \
+	> /tmp/curl_ds_wide.txt
+BODY=$(curl -s -w '\n%{http_code}' \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary @/tmp/curl_ds_wide.txt \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TOOWIDE)")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+assert_http_status "500" "$HTTP_CODE" "an 81-column line is rejected"
+if echo "$CONTENT" | grep -qi "Record too long"; then
+	pass "the rejection names the reason (Record too long)"
+else
+	fail "the rejection names the reason" "got: $CONTENT"
+fi
+
+echo ""
+echo "--- Text framing: terminators and chunked transfer (issue #233) ---"
+
+# CRLF endings, a body that does not end in a newline, and a body that does:
+# each must produce exactly two records and no phantom third one.
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary $'ALPHA\r\nBETA\r\n' \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(CRLFT)")
+assert_http_status "204" "$HTTP_CODE" "write a CRLF body"
+
+curl -s -o /tmp/curl_ds_crlf.bin -u "$AUTH" \
+	-H "X-IBM-Data-Type: binary" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(CRLFT)"
+RT_SIZE=$(wc -c < /tmp/curl_ds_crlf.bin | tr -d ' ')
+if [ "$RT_SIZE" = "160" ]; then
+	pass "CRLF body stored as two records ($RT_SIZE bytes)"
+else
+	fail "CRLF body stored as two records" "expected 160 bytes, got $RT_SIZE"
+fi
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary $'ALPHA\nBETA' \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(NOEOLT)")
+assert_http_status "204" "$HTTP_CODE" "write a body without a trailing newline"
+
+curl -s -o /tmp/curl_ds_noeol.bin -u "$AUTH" \
+	-H "X-IBM-Data-Type: binary" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(NOEOLT)"
+RT_SIZE=$(wc -c < /tmp/curl_ds_noeol.bin | tr -d ' ')
+if [ "$RT_SIZE" = "160" ]; then
+	pass "last line without a terminator still stored ($RT_SIZE bytes)"
+else
+	fail "last line without a terminator still stored" \
+		"expected 160 bytes, got $RT_SIZE"
+fi
+
+# Chunked: the framing state has to survive the chunk boundaries curl inserts,
+# and a trailing newline must not add a blank record at the end.
+printf 'CHUNK ONE\n\nCHUNK THREE\n' > /tmp/curl_ds_chunk.txt
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	-H "Transfer-Encoding: chunked" \
+	--data-binary @/tmp/curl_ds_chunk.txt \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(CHUNKT)")
+assert_http_status "204" "$HTTP_CODE" "write a chunked body with a blank line"
+
+curl -s -o /tmp/curl_ds_chunk.bin -u "$AUTH" \
+	-H "X-IBM-Data-Type: binary" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(CHUNKT)"
+RT_SIZE=$(wc -c < /tmp/curl_ds_chunk.bin | tr -d ' ')
+if [ "$RT_SIZE" = "240" ]; then
+	pass "chunked body stored as three records ($RT_SIZE bytes)"
+else
+	fail "chunked body stored as three records" \
+		"expected 240 bytes (3 x 80), got $RT_SIZE"
+fi
+
+rm -f /tmp/curl_ds_blank.bin /tmp/curl_ds_wide.txt /tmp/curl_ds_wide.bin \
+	/tmp/curl_ds_crlf.bin /tmp/curl_ds_noeol.bin /tmp/curl_ds_chunk.txt \
+	/tmp/curl_ds_chunk.bin
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -63,6 +63,8 @@ TEST_SEQ2="${MVS_USER}.ZOWE.TESTSEQ2"
 TEST_PDS="${MVS_USER}.ZOWE.TESTPDS"
 # Large-LRECL fixture for issue #198 (records above the old 1024-byte limit)
 TEST_BIG="${MVS_USER}.ZOWE.TESTBIG"
+# Text framing fixture for issue #233 (blank lines, full-width records)
+TEST_FRAME="${MVS_USER}.ZOWE.TESTFRM"
 
 # --- state ---
 PASSED=0
@@ -492,6 +494,53 @@ fi
 RC=0
 OUTPUT=$(run_zowe files delete ds "$TEST_BIG" -f) || RC=$?
 assert_rc 0 "$RC" "cleanup: delete large-LRECL dataset"
+
+# --- Text record framing (issue #233) ---
+# A blank line used to be written as a zero-length record, which never reached
+# the data set, and the usable line length was LRECL-2 -- 80-column source into
+# an FB80 data set came back as "Record too long".
+echo ""
+echo "--- Text framing: blank lines and full-width records (issue #233) ---"
+
+RC=0
+OUTPUT=$(run_zowe files create ps "$TEST_FRAME" --recfm FB --lrecl 80 --blksize 3120 --size 1TRK) || RC=$?
+assert_rc 0 "$RC" "create FB80 dataset"
+
+TMPFILE=$(mktemp)
+awk 'BEGIN { s = ""; while (length(s) < 80) s = s "A";
+             print "ERSTE ZEILE"; print ""; print substr(s, 1, 80) }' > "$TMPFILE"
+RC=0
+OUTPUT=$(run_zowe files upload ftds "$TMPFILE" "$TEST_FRAME") || RC=$?
+rm -f "$TMPFILE"
+assert_rc 0 "$RC" "upload a blank line and an 80-column line"
+
+RC=0
+OUTPUT=$(run_zowe files view ds "$TEST_FRAME") || RC=$?
+assert_rc 0 "$RC" "read back the framed dataset"
+
+LINES=$(echo "$OUTPUT" | wc -l | tr -d ' ')
+if [ "$LINES" = "3" ]; then
+	pass "three lines in, three lines out ($LINES)"
+else
+	fail "three lines in, three lines out" "expected 3 lines, got $LINES"
+fi
+
+if [ -z "$(echo "$OUTPUT" | sed -n '2p')" ]; then
+	pass "the blank line survived"
+else
+	fail "the blank line survived" "line 2 is not empty"
+fi
+
+WIDTH=$(echo "$OUTPUT" | sed -n '3p' | tr -d '\r' | awk '{ print length($0) }')
+if [ "$WIDTH" = "80" ]; then
+	pass "the 80-column line kept all its columns ($WIDTH)"
+else
+	fail "the 80-column line kept all its columns" "expected 80, got $WIDTH"
+fi
+
+RC=0
+OUTPUT=$(run_zowe files delete ds "$TEST_FRAME" -f) || RC=$?
+assert_rc 0 "$RC" "cleanup: delete the framing dataset"
 
 # --- Cleanup: delete PDS ---
 echo ""


### PR DESCRIPTION
Fixes #233

## What was wrong

Text uploads were framed into records by four near-identical byte loops (sequential and member handler, each once for Content-Length and once for chunked). Both reported defects sat in all four.

**Blank lines vanished.** `write_record()` stripped the terminator and wrote what was left — for a blank line, zero bytes. libc370's `fflush()` returns at its empty-buffer guard (`@@fflush.c:26`), so no record reached the data set, and the upload still answered 204.

**The usable line length was LRECL-2.** The guard ran before the byte was stored *and* the terminator was counted as content, so 79 and 80 columns into an FB80 data set came back as `Record too long`. 80-column source is the normal case on this platform.

## What changed

The framing moved into `src/reclines.c` as one state machine that all four loops drive:

- the terminator is never buffered, so the limit counts content only and a line of exactly LRECL fits;
- a terminated empty line is emitted as a single blank, which libc370's `fixflush()` pads out to LRECL;
- LF, CR and CRLF all end a record. The LF of a CRLF pair is swallowed on the next pass through the caller's read loop;
- the state survives a chunk boundary, including one falling between the CR and the LF of a pair.

`write_record()` no longer does any framing — it clamps, translates and writes.

### Taken along deliberately

Three things in the same code could not be left as they were, or would have made the fix incoherent:

1. **The end-of-chunk flush is gone.** Both chunked paths wrote whatever was buffered at the end of every chunk, so a line split across two chunks became two records. A chunk boundary is a transport boundary.
2. **The read-ahead `recv()` is gone.** On a CR the Content-Length paths read the next byte to check for LF; when it was not LF, the byte was buffered without decrementing `bytes_remaining` — one byte past the body. The `swallow_lf` flag handles the pair through the normal loop instead.
3. **The record limit is computed per RECFM.** libc370 buffers only LRECL-4 for RECFM=V because the RDW is not content (`@@fpopen.c`, `varflush()`), so a longer line could not have been written as one record. **Behaviour change:** a VB line between LRECL-3 and LRECL is now rejected as `Record too long` instead of being split without notice.

## Verification

`test/host/tstrecl.c` drives the real state machine on the host (`make test-host`) — blank lines, exactly LRECL, LRECL+1, CRLF at LRECL, a lone CR, both chunk-boundary cases, and a body with and without a trailing newline. It is a red→green gate: 13 assertions fail when the old semantics are simulated in `reclines.c`.

On a live MVS 3.8j, after deploy + activation (`/zosmf/test?fn=version` confirmed to equal the built HEAD):

- `tests/curl-datasets.sh` — 131 passed, 0 failed
- `tests/zowe-datasets.sh` — 46 passed, 0 failed

Both suites gained cases for this issue; record counts are checked through a binary read, because the text read strips the padding and would hide a missing blank record.

## Not in scope, to be filed separately

- **A rejected upload destroys the previous content.** The data set is opened `"w"` before the body is read, so a `Record too long` leaves the records written up to that line and nothing of what was there. Documented as current behaviour in `docs/endpoints/datasets/`; staging plus rename needs its own design.
- **`#define VARIABLE 0x0002` (`dsapi.c:20`) is the wrong mask** — V is 0x40, 0x02 is machine control characters. It must not be corrected on its own: it is the only reason `write_record()`'s binary branch never prepends its own RDW, which `varflush()` would then duplicate.
- **Record mode on the write path never frames a length-prefixed stream** — `X-IBM-Data-Type: record` shares the text loop, so a body produced by the read path cannot be written back. Left exactly as found, with a note in the code.
- The issue's remark about the response line count does not apply: the 204 has no body and `line_count` is never reported.