### PR TITLE
uss: delete a path in one call, without the existence probe

### DIFF
--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -1016,8 +1016,10 @@ uss_recursive_delete(UFS *ufs, const char *path)
 //
 // Deletes a file or directory. Strategy:
 // 1. Try ufs_remove() first (works for regular files)
-// 2. If ISDIR (RC 40): use ufs_rmdir() or recursive_delete()
+// 2. If ISDIR (RC 40): use ufs_rmdir() or uss_recursive_delete()
 //    depending on X-IBM-Option: recursive header
+// 3. Any other non-zero rc is reported from ufs_last_rc() — NOFILE (28)
+//    for a path that is not there, so no existence probe is needed.
 //
 // Response: 204 No Content on success
 //
@@ -1028,13 +1030,10 @@ int ussDeleteHandler(Session *session)
 	int rc = 0;
 	int urc;
 	int is_recursive = 0;
-	int is_dir = 0;
 	char *raw_path = NULL;
 	char abspath[UFS_PATH_MAX];
 	char *option = NULL;
 	UFS *ufs = NULL;
-	UFSFILE *fp = NULL;
-	UFSDDESC *dd = NULL;
 
 	// Get filepath from path variable and build absolute path
 	raw_path = getPathParam(session, "filepath");
@@ -1060,75 +1059,33 @@ int ussDeleteHandler(Session *session)
 		return -1;
 	}
 
-	// Probe whether the path is a file or directory.
-	// ufs_remove() may return 0 even for non-existent paths,
-	// so we must verify existence before attempting delete.
-	fp = ufs_fopen(ufs, abspath, "r");
-	if (fp) {
-		if (fp->error == UFSD_RC_OK) {
-			// It's a regular file — close and delete
-			ufs_fclose(&fp);
-			rc = ufs_remove(ufs, abspath);
-			if (rc == 0) {
-				rc = sendDefaultHeaders(session, 204,
-					HTTP_CONTENT_TYPE_NONE, 0);
-				goto quit;
-			}
-			urc = ufs_last_rc(ufs);
-			rc = sendErrorResponse(session,
-				ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
-				ufsd_rc_message(urc), NULL, 0);
-			goto quit;
-		}
-		// fopen succeeded but error set (e.g. ISDIR) — check below
-		urc = fp->error;
-		ufs_fclose(&fp);
-		fp = NULL;
-		if (urc == UFSD_RC_ISDIR) {
-			is_dir = 1;
-		} else {
-			rc = sendErrorResponse(session,
-				ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
-				ufsd_rc_message(urc), NULL, 0);
-			goto quit;
-		}
-	} else {
-		// fopen returned NULL — check if it's a directory
-		dd = ufs_diropen(ufs, abspath, NULL);
-		if (dd) {
-			ufs_dirclose(&dd);
-			is_dir = 1;
-		} else {
-			// Neither file nor directory — not found
-			rc = sendErrorResponse(session, 404, 6, 8, 1,
-				"File or directory not found", NULL, 0);
-			goto quit;
-		}
+	// Regular file — one round trip. ufs_remove() reports ISDIR for a
+	// directory and NOFILE for a path that does not exist (ufsd#9).
+	rc = ufs_remove(ufs, abspath);
+	if (rc == 0) {
+		return sendDefaultHeaders(session, 204, HTTP_CONTENT_TYPE_NONE, 0);
 	}
 
-	// Path is a directory — use rmdir or recursive delete
-	if (is_dir) {
-		if (is_recursive) {
-			rc = uss_recursive_delete(ufs, abspath);
-		} else {
-			rc = ufs_rmdir(ufs, abspath);
-		}
-
-		if (rc == 0) {
-			rc = sendDefaultHeaders(session, 204,
-				HTTP_CONTENT_TYPE_NONE, 0);
-			goto quit;
-		}
-
-		urc = ufs_last_rc(ufs);
-		rc = sendErrorResponse(session,
+	urc = ufs_last_rc(ufs);
+	if (urc != UFSD_RC_ISDIR) {
+		return sendErrorResponse(session,
 			ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
 			ufsd_rc_message(urc), NULL, 0);
 	}
 
-quit:
-	if (ufs) {
+	// Path is a directory — use rmdir or recursive delete
+	if (is_recursive) {
+		rc = uss_recursive_delete(ufs, abspath);
+	} else {
+		rc = ufs_rmdir(ufs, abspath);
 	}
 
-	return rc;
+	if (rc == 0) {
+		return sendDefaultHeaders(session, 204, HTTP_CONTENT_TYPE_NONE, 0);
+	}
+
+	urc = ufs_last_rc(ufs);
+	return sendErrorResponse(session,
+		ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
+		ufsd_rc_message(urc), NULL, 0);
 }


### PR DESCRIPTION
Fixes #104

`ussDeleteHandler` probed with `ufs_fopen()` / `ufs_diropen()` before every delete, because `ufs_remove()` used to return 0 for a path that was not there (mvslovers/ufsd#9) — which would have turned "nothing to delete" into a 204.

That is fixed on the ufsd side and released in **v1.1.0**, which is what `mbt.lock` already pins: `do_remove()` returns `UFSD_RC_NOFILE` (28) when the path lookup fails and `UFSD_RC_ISDIR` (40) for a directory, and the client records both in `ufs_last_rc()`. So the handler now goes straight at it:

1. `ufs_remove()` — 0 means done, 204
2. `UFSD_RC_ISDIR` → `ufs_rmdir()`, or `uss_recursive_delete()` with `X-IBM-Option: recursive`
3. anything else → the existing `ufsd_rc_to_http()` / `_category()` / `_message()` mapping, which turns NOFILE into the same 404 body the probe used to build by hand

No response changes: the 404 message string is byte-identical to the old hardcoded one. Two round trips less per delete, 43 lines less handler, and the empty `quit:` label is gone with it.

## Verification

Deployed to `mvsdev.lan` and activated into the httpd STEPLIB (`/zosmf/test?fn=version` = the build under test), then `tests/curl-uss.sh`:

```
Results: 64 passed, 0 failed, 1 skipped (65 total)
```

The delete assertions that carry this change:

| Case | Expected | Got |
|---|---|---|
| delete file | 204 | PASS |
| deleted file re-read | 404 | PASS |
| **delete non-existent file** | **404** | **PASS** |
| delete empty directory | 204 | PASS |
| delete non-empty dir, no recursive | 400 | PASS |
| delete non-empty dir, recursive | 204 | PASS |
| recursively deleted dir | 404 | PASS |

The running UFSD is ≥ v1.1.0 independently of the banner: client and server both address subsystem `UFS1` (`UFSD_SSNAME`, renamed in ufsd #59 for v1.1.0), so a pre-1.1.0 server would not answer the USS calls that pass today.

`docs/endpoints/uss/delete.md` already documented this strategy — no doc change needed.

https://claude.ai/code/session_019TT2zwWGXK6rL6zMmV22j4