### PR TITLE
jobsapi: apply the status query parameter when listing jobs

### DIFF
--- a/docs/endpoints/jobs/list.md
+++ b/docs/endpoints/jobs/list.md
@@ -12,8 +12,8 @@ GET
 - `owner` (optional): Filter by job owner. Use `*` for all owners. Default: current authenticated user.
 - `prefix` (optional): Filter by job name prefix. Use `*` for all jobs.
 - `jobid` (optional): Filter by specific job ID.
-- `status` (optional): Filter by job status (`INPUT`, `ACTIVE`, `OUTPUT`). Use `*` for all.
-- `max-jobs` (optional): Maximum number of jobs to return (1-1000). Default: 1000.
+- `status` (optional): Filter by job status (`INPUT`, `ACTIVE`, `OUTPUT`). Use `*` for all. See [Status filter](#status-filter).
+- `max-jobs` (optional): Maximum number of jobs **returned** (1-1000). Default: 1000. The filters are applied first, so `max-jobs` caps the matching jobs, not the checkpoint entries scanned.
 - `exec-data` (optional): `Y` adds the execution timestamps to each job object. Any other value (or omitting the parameter) returns the object unchanged. The Zowe CLI sends `exec-data=Y` for `zowe jobs list jobs --exec-data`.
 
 ## Response
@@ -44,6 +44,25 @@ With `exec-data=Y`, two further fields follow `retcode`:
 ```
 
 See [Execution timestamps](#execution-timestamps).
+
+## Status filter
+
+`status` is compared against the value the job reports in its own `status`
+field — the same derivation, so the filter can never disagree with the response.
+The comparison is case insensitive (`status=active` works), and `*` or an
+omitted parameter means no filtering.
+
+JES2 on 3.8j has queues z/OSMF does not name, so besides `INPUT`, `ACTIVE` and
+`OUTPUT` a job can report `XMIT`, `SETUP`, `RECEIVE` or `UNKNOWN`; those values
+can be filtered on as well. The queue flags are not exclusive — a job on the
+execution and the output queue at once reports `ACTIVE` — so a job matches
+exactly one status.
+
+A value that names no status (`status=NOSUCH`) is not an error: it simply
+matches nothing, and the request returns HTTP 200 with an empty array.
+
+The filter is applied by mvsMF while walking the checkpoint, not by JES2 —
+unlike `prefix` and `jobid`, which become the JES filter for the scan itself.
 
 ## Execution timestamps
 
@@ -104,6 +123,9 @@ curl "http://mvs:1080/zosmf/restjobs/jobs?prefix=TEST*"
 
 # List jobs by job ID
 curl "http://mvs:1080/zosmf/restjobs/jobs?jobid=JOB00123"
+
+# List only the jobs currently executing
+curl "http://mvs:1080/zosmf/restjobs/jobs?owner=*&status=ACTIVE"
 
 # List jobs with execution timestamps
 curl "http://mvs:1080/zosmf/restjobs/jobs?prefix=TEST*&exec-data=Y"

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -32,6 +32,10 @@
 #define JES_INFO_SIZE   20 + 1
 #define TYPE_STR_SIZE    3 + 1
 #define CLASS_STR_SIZE   3 + 1
+/* room for the longest status job_status_str() reports ("RECEIVE") plus slack:
+   a requested value long enough to be truncated here is 15 characters and can
+   never equal one of them, so truncation can only mean "matches nothing". */
+#define STATUS_STR_SIZE 16
 #define RECFM_STR_SIZE   4 + 1
 #define JOBNAME_STR_SIZE 8      // the +1 for null termination will be added on initialization
 #define JOBID_STR_SIZE   8      // the +1 for null termination will be added on initialization
@@ -59,11 +63,14 @@ extern int __tzget(void);
 static int  do_print_sysout(Session *session, JESJOB *job, unsigned dsid);
 
 // needed by jobListHandler
-static void process_job_list_filters(Session *session, const char **filter, JESFILT *jesfilt);
+static void process_job_list_filters(Session *session, const char **filter, JESFILT *jesfilt,
+                                     char *status, size_t status_size);
 static unsigned get_max_jobs(Session *session);
 static int  want_exec_data(Session *session);
 static const char* format_exec_time(const time64_t *t, int tzadjust, char *out, size_t outlen);
-static int  process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *host, int exec_data);
+static const char* job_status_str(const JESJOB *job);
+static int  process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *status,
+                        const char *host, int exec_data);
 static JESJOB* find_job_by_name_and_id(Session *session, const char *jobname, const char *jobid, JESJOB ***out_joblist);
 static int process_job_files(Session *session, JESJOB *job, const char *host, JsonBuilder *builder);
 static int validate_intrdr_headers(Session *session);
@@ -115,6 +122,8 @@ jobListHandler(Session *session)
 	const char *owner = getQueryParam(session, "owner");
 	const unsigned max_jobs = get_max_jobs(session);
 	UCHAR ownerid[64];
+	/* MVSMF is link-edited RENT, so the normalized status stays on the stack */
+	char status[STATUS_STR_SIZE];
 
 	if (owner == NULL) {
 		/* z/OSMF default: jobs owned by the caller, from the identity
@@ -126,7 +135,7 @@ jobListHandler(Session *session)
 		owner = NULL;
 	}
 
-	process_job_list_filters(session, &filter, &jesfilt);
+	process_job_list_filters(session, &filter, &jesfilt, status, sizeof(status));
 
 	jes = jesopen();
 	if (!jes) {
@@ -143,12 +152,19 @@ jobListHandler(Session *session)
 
 	const int exec_data = want_exec_data(session);
 
-	int ii = 0;
-	for (ii = 0; ii < MIN(max_jobs, array_count(&joblist)); ii++) {
-		rc = process_job(builder, joblist[ii], owner, host, exec_data);
+	/* max-jobs caps the jobs *returned*, not the queue entries looked at: with
+	   a status or owner filter in play the first max_jobs entries of the spool
+	   are mostly rows this request does not want, and capping the scan would
+	   answer "no ACTIVE jobs" for a system that has them (issue #157). */
+	unsigned emitted = 0;
+	unsigned ii = 0;
+	for (ii = 0; ii < array_count(&joblist) && emitted < max_jobs; ii++) {
+		rc = process_job(builder, joblist[ii], owner,
+						status[0] ? status : NULL, host, exec_data);
 		if (rc < 0) {
 			goto quit;
 		}
+		emitted += (unsigned)rc;
 	}
 
 	endArray(builder);
@@ -793,20 +809,37 @@ quit:
 	return rc;
 }
 
+/* Reads the list filters off the query string.  prefix/jobid become the JES
+   filter the checkpoint scan itself understands; status has no JES2 equivalent
+   and is returned normalized (upper case, "" when absent or "*") for
+   should_skip_job() to compare against each job's reported status. */
 __asm__("\n&FUNC	SETC 'process_job_list_filters'");
-static void 
-process_job_list_filters(Session *session, const char **filter, JESFILT *jesfilt) 
+static void
+process_job_list_filters(Session *session, const char **filter, JESFILT *jesfilt,
+						char *status, size_t status_size)
 {
-	const char *prefix = getQueryParam(session, "prefix");
-	const char *status = getQueryParam(session, "status");
-	const char *jobid  = getQueryParam(session, "jobid");
+	const char *prefix     = getQueryParam(session, "prefix");
+	const char *req_status = getQueryParam(session, "status");
+	const char *jobid      = getQueryParam(session, "jobid");
 
 	if (prefix && prefix[0] == '*') {
 		prefix = NULL;
 	}
 
-	if (status && status[0] == '*') {
-		status = NULL;
+	if (req_status && req_status[0] == '*') {
+		req_status = NULL;
+	}
+
+	if (status && status_size > 0) {
+		size_t ii = 0;
+
+		if (req_status) {
+			while (ii < status_size - 1 && req_status[ii] != '\0') {
+				status[ii] = (char)toupper((unsigned char)req_status[ii]);
+				ii++;
+			}
+		}
+		status[ii] = '\0';
 	}
 
 	if (prefix && !jobid) {
@@ -822,8 +855,8 @@ process_job_list_filters(Session *session, const char **filter, JESFILT *jesfilt
 }
 
 __asm__("\n&FUNC	SETC 'should_skip_job'");
-static int 
-should_skip_job(const JESJOB *job, const char *owner) 
+static int
+should_skip_job(const JESJOB *job, const char *owner, const char *status)
 {
 	if (!job) {
 		return 1;
@@ -854,7 +887,47 @@ should_skip_job(const JESJOB *job, const char *owner)
 		return 1;
 	}
 
+	/* compare against the very string this job reports as its status, so the
+	   filter can never disagree with the "status" field in the response */
+	if (status && strcmp(job_status_str(job), status) != 0) {
+		return 1;
+	}
+
 	return 0;
+}
+
+/* The job's status as z/OSMF names it.  The queue flags are not exclusive -- a
+   job can sit on the execution and the output queue at once -- so the order of
+   the tests is what decides, and it must stay the single source of the value:
+   both the reported "status" field and the status filter go through here. */
+__asm__("\n&FUNC	SETC 'job_status_str'");
+static const char *
+job_status_str(const JESJOB *job)
+{
+	if (!job || !job->q_type) {
+		return "UNKNOWN";
+	}
+
+	if (job->q_type & _XEQ) {
+		return "ACTIVE";
+	}
+	if (job->q_type & _INPUT) {
+		return "INPUT";
+	}
+	if (job->q_type & _XMIT) {
+		return "XMIT";
+	}
+	if (job->q_type & _SETUP) {
+		return "SETUP";
+	}
+	if (job->q_type & _RECEIVE) {
+		return "RECEIVE";
+	}
+	if (job->q_type & (_OUTPUT | _HARDCPY)) {
+		return "OUTPUT";
+	}
+
+	return "UNKNOWN";
 }
 
 /* z/OSMF gates the exec-* fields on exec-data=Y; the Zowe CLI sends exactly
@@ -923,9 +996,13 @@ format_exec_time(const time64_t *t, int tzadjust, char *out, size_t outlen)
 	return out;
 }
 
+/* Appends one job object to the array.  Returns 1 when the job was emitted, 0
+   when a filter skipped it (so the caller can count what it returns against
+   max-jobs) and a negative value on error. */
 __asm__("\n&FUNC	SETC 'process_job'");
 static int
-process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *host, int exec_data)
+process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *status,
+			const char *host, int exec_data)
 {
 	int rc = 0;
 
@@ -935,9 +1012,9 @@ process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *ho
 	char class_str[CLASS_STR_SIZE];
 	char url_str[MAX_URL_LENGTH];
 	char files_url_str[MAX_URL_LENGTH];
-	char *stat_str = "UNKNOWN";
+	const char *stat_str = job_status_str(job);
 
-	if (should_skip_job(job, owner)) {
+	if (should_skip_job(job, owner, status)) {
 		return 0;
 	}
 
@@ -962,24 +1039,6 @@ process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *ho
 	if (rc < 0) {
 		wtof("MVSMF19E internal error");
 		return -1;
-	}
-
-	if (job->q_type) {
-		if (job->q_type & _XEQ) {
-			stat_str = "ACTIVE";
-		} else if (job->q_type & _INPUT) {
-			stat_str = "INPUT";
-		} else if (job->q_type & _XMIT) {
-			stat_str = "XMIT";
-		} else if (job->q_type & _SETUP) {
-			stat_str = "SETUP";
-		} else if (job->q_type & _RECEIVE) {
-			stat_str = "RECEIVE";
-		} else if (job->q_type & _OUTPUT || job->q_type & _HARDCPY) {
-			stat_str = "OUTPUT";
-		} else {
-			stat_str = "UNKNOWN";
-		}
 	}
 
 	rc = startJsonObject(builder);
@@ -1041,8 +1100,11 @@ process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *ho
 	}
 
 	rc = endJsonObject(builder);
+	if (rc < 0) {
+		return rc;
+	}
 
-	return rc;
+	return 1;
 }
 
 __asm__("\n&FUNC    SETC 'find_job_by_name_and_id'");
@@ -1547,7 +1609,7 @@ send_job_status_response(Session *session, JESJOB *job, const char *host)
         return -1;
     }
 
-    rc = process_job(builder, job, NULL, host, want_exec_data(session));
+    rc = process_job(builder, job, NULL, NULL, host, want_exec_data(session));
     if (rc < 0) {
         freeJsonBuilder(builder);
         return rc;

--- a/static/js/programs/spool.js
+++ b/static/js/programs/spool.js
@@ -210,9 +210,9 @@ Programs.register({
       if (st.status !== "*") q.set("status", st.status);
       const resp = await api("/zosmf/restjobs/jobs?" + q.toString());
       let jobs = await resp.json();   // plain JSON array
-      // jobListHandler currently ignores the status parameter (#157) —
-      // filter client-side; the param stays so the server-side filter
-      // is picked up automatically once implemented
+      // jobListHandler applies the status parameter since #157, so this is a
+      // no-op against a current server; it stays as the fallback for a build
+      // deployed before that fix, which returns every status regardless
       if (st.status !== "*") jobs = jobs.filter(j => j.status === st.status);
       return jobs;
     }

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -508,15 +508,67 @@ test_list_jobs_with_jobid() {
 	assert_json_array_nonempty "$BODY" "list by jobid returns results"
 }
 
+# every element of the array must carry the requested status.  An empty array
+# is a pass: status=ACTIVE legitimately matches nothing on a quiet system.
+assert_all_status() {
+	local json="$1"
+	local want="$2"
+	local label="$3"
+	local len others
+	len=$(echo "$json" | jq 'length' 2>/dev/null) || len=0
+	others=$(echo "$json" | jq --arg s "$want" '[.[] | select(.status != $s)] | length' 2>/dev/null) || others="?"
+	if [ "$others" = "0" ]; then
+		pass "$label ($len jobs, all $want)"
+	else
+		fail "$label" "$others of $len jobs have a status other than $want"
+	fi
+}
+
 test_list_jobs_with_status() {
 	echo ""
 	echo "--- List Jobs: with status filter ---"
 
-	local resp
+	local resp all_len out_len
+
 	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=OUTPUT&owner=*")
 	split_response "$resp"
-
 	assert_http_status "200" "$HTTP_STATUS" "list jobs status=OUTPUT"
+	assert_all_status "$BODY" "OUTPUT" "status=OUTPUT excludes other statuses"
+	out_len=$(echo "$BODY" | jq 'length' 2>/dev/null) || out_len=0
+
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=ACTIVE&owner=*")
+	split_response "$resp"
+	assert_http_status "200" "$HTTP_STATUS" "list jobs status=ACTIVE"
+	assert_all_status "$BODY" "ACTIVE" "status=ACTIVE excludes OUTPUT jobs"
+
+	# the filter is case insensitive
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=output&owner=*")
+	split_response "$resp"
+	assert_http_status "200" "$HTTP_STATUS" "list jobs status=output (lower case)"
+	assert_all_status "$BODY" "OUTPUT" "lower case status filters the same way"
+
+	# '*' means no filter, so it can only ever return a superset
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=*&owner=*")
+	split_response "$resp"
+	assert_http_status "200" "$HTTP_STATUS" "list jobs status=*"
+	all_len=$(echo "$BODY" | jq 'length' 2>/dev/null) || all_len=0
+	if [ "$all_len" -ge "$out_len" ] 2>/dev/null; then
+		pass "status=* is a superset of status=OUTPUT ($all_len >= $out_len)"
+	else
+		fail "status=* returned fewer jobs than status=OUTPUT" "$all_len < $out_len"
+	fi
+
+	# an unknown status matches nothing - 200 with an empty array, not an error
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=NOSUCH&owner=*")
+	split_response "$resp"
+	assert_http_status "200" "$HTTP_STATUS" "list jobs status=NOSUCH"
+	local len
+	len=$(echo "$BODY" | jq 'length' 2>/dev/null) || len="?"
+	if [ "$len" = "0" ]; then
+		pass "unknown status returns an empty array"
+	else
+		fail "unknown status returned jobs" "got $len results"
+	fi
 }
 
 test_list_jobs_with_max() {
@@ -535,6 +587,26 @@ test_list_jobs_with_max() {
 		pass "max-jobs=2 respected (got $len)"
 	else
 		fail "max-jobs=2 not respected" "got $len results"
+	fi
+
+	# max-jobs caps the jobs returned, not the queue entries scanned: combined
+	# with a filter it must still fill up to the limit
+	local out_total out_capped
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?owner=*&status=OUTPUT")
+	split_response "$resp"
+	out_total=$(echo "$BODY" | jq 'length' 2>/dev/null) || out_total=0
+
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?owner=*&status=OUTPUT&max-jobs=1")
+	split_response "$resp"
+	assert_http_status "200" "$HTTP_STATUS" "list jobs status=OUTPUT&max-jobs=1"
+	out_capped=$(echo "$BODY" | jq 'length' 2>/dev/null) || out_capped=0
+
+	if [ "$out_total" -eq 0 ] 2>/dev/null; then
+		skip "max-jobs with status filter (no OUTPUT jobs on the system)"
+	elif [ "$out_capped" -eq 1 ] 2>/dev/null; then
+		pass "max-jobs=1 with status=OUTPUT returned 1 job (of $out_total)"
+	else
+		fail "max-jobs limits the scan, not the result" "got $out_capped of $out_total"
 	fi
 }
 

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -530,11 +530,25 @@ test_list_jobs_with_status() {
 
 	local resp all_len out_len
 
+	# '*' means no filter, so it can only ever return a superset. Listed first
+	# on purpose: the two counts come from separate requests, and a job purged
+	# in between can only shrink the later one, never break the comparison.
+	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=*&owner=*")
+	split_response "$resp"
+	assert_http_status "200" "$HTTP_STATUS" "list jobs status=*"
+	all_len=$(echo "$BODY" | jq 'length' 2>/dev/null) || all_len=0
+
 	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=OUTPUT&owner=*")
 	split_response "$resp"
 	assert_http_status "200" "$HTTP_STATUS" "list jobs status=OUTPUT"
 	assert_all_status "$BODY" "OUTPUT" "status=OUTPUT excludes other statuses"
 	out_len=$(echo "$BODY" | jq 'length' 2>/dev/null) || out_len=0
+
+	if [ "$all_len" -ge "$out_len" ] 2>/dev/null; then
+		pass "status=* is a superset of status=OUTPUT ($all_len >= $out_len)"
+	else
+		fail "status=* returned fewer jobs than status=OUTPUT" "$all_len < $out_len"
+	fi
 
 	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=ACTIVE&owner=*")
 	split_response "$resp"
@@ -546,17 +560,6 @@ test_list_jobs_with_status() {
 	split_response "$resp"
 	assert_http_status "200" "$HTTP_STATUS" "list jobs status=output (lower case)"
 	assert_all_status "$BODY" "OUTPUT" "lower case status filters the same way"
-
-	# '*' means no filter, so it can only ever return a superset
-	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=*&owner=*")
-	split_response "$resp"
-	assert_http_status "200" "$HTTP_STATUS" "list jobs status=*"
-	all_len=$(echo "$BODY" | jq 'length' 2>/dev/null) || all_len=0
-	if [ "$all_len" -ge "$out_len" ] 2>/dev/null; then
-		pass "status=* is a superset of status=OUTPUT ($all_len >= $out_len)"
-	else
-		fail "status=* returned fewer jobs than status=OUTPUT" "$all_len < $out_len"
-	fi
 
 	# an unknown status matches nothing - 200 with an empty array, not an error
 	resp=$(do_curl GET "${BASE_URL}/zosmf/restjobs/jobs?status=NOSUCH&owner=*")


### PR DESCRIPTION
Fixes #157

`process_job_list_filters()` read `status` and normalized `*` to NULL, but nothing ever used the value — only `prefix`/`jobid` became a JES filter and only `owner` was checked per job, so `?status=ACTIVE` returned jobs in every status.

## What changed

**The filter itself.** JES2 has no checkpoint filter for the status, so it is compared per job while walking the list, in `should_skip_job()`. To keep the filter from ever disagreeing with the field it filters on, the queue-flag decoding moved out of `process_job()` into `job_status_str()` — the reported `"status"` field and the comparison now go through that one function. The flags are not exclusive (a job on the execution *and* output queue reports ACTIVE), so a parallel request-string→flags mapping would have disagreed with the response on exactly those jobs.

The requested value is normalized to upper case in a **stack** buffer (MVSMF is RENT), so `status=active` works. A value naming no status matches nothing and returns 200 with an empty array rather than an error — that keeps the response inside the enumerated z/OSMF status contract, and 200-with-`[]` cannot break the Desktop client the way a new 400 could.

**`max-jobs` now caps the jobs returned, not the checkpoint entries scanned.** This is adjacent to the reported bug and deliberate, not scope creep: the old loop was `MIN(max_jobs, array_count(&joblist))`, so with a filter that excludes most rows, `max-jobs=10&status=ACTIVE` answers "no ACTIVE jobs" for a system that has them as soon as the first ten entries happen to be OUTPUT — the parameter being fixed here would have been defeated by the one next to it. `process_job()` now reports whether it emitted a job (1/0/negative) so the loop can count what it returns.

## Verified live (mvsdev.lan, build `053ddbd`)

The issue's own repro, before → after:

```
GET /zosmf/restjobs/jobs?prefix=HTTPD*&owner=*&status=ACTIVE
  before: 69 jobs, 68 of them OUTPUT
  after:  1 job  — HTTPD STC00874 ACTIVE
```

Full breakdown with `owner=*`: `status=*` 565, `ACTIVE` 5, `OUTPUT` 560, `INPUT` 0, `active` 5 (case insensitive), `NOSUCH` 0. `status=ACTIVE&max-jobs=1|2|3` returns 1, 2, 3 — under the old scan cap it would have returned 0. Single-job status, `prefix`, `owner` and `exec-data=Y` unchanged.

`tests/curl-jobs.sh` 98 passed / 0 failed / 1 skipped, `tests/zowe-jobs.sh` 38 passed / 0 failed / 1 skipped.

## Tests and docs

`tests/curl-jobs.sh` asserted only HTTP 200 for `status=OUTPUT` — which passed while the bug was live. It now asserts *absence* (`[.[] | select(.status != $s)] | length` must be 0) rather than a non-empty array, since `status=ACTIVE` legitimately matches nothing on a quiet system, plus the lower-case, `*`-superset, unknown-value and `max-jobs`-composition cases.

**No Zowe test:** `zowe jobs list jobs` exposes `--owner`, `--prefix` and `--exec-data` only — there is no `--status` flag to drive, confirmed against the installed CLI.

`docs/endpoints/jobs/list.md` gains a "Status filter" section (case insensitivity, the extra 3.8j queue values `XMIT`/`SETUP`/`RECEIVE`/`UNKNOWN`, unknown value → empty array) and the corrected `max-jobs` wording.