### PR TITLE
Derive port and scheme from the request headers

### DIFF
--- a/docs/endpoints/console/issue-command.md
+++ b/docs/endpoints/console/issue-command.md
@@ -58,6 +58,11 @@ After issuing, the MTT is polled for ~3 s for the correlated response.
 
 `sol-key-detected` is present only when `sol-key` was supplied. A `cmd-response` of `""` means nothing was captured within the window — use the [Collect Command Response](collect.md) endpoint to retrieve the rest.
 
+`cmd-response-url` (and `detection-url`, where present) take their host from the request's
+`Host` header and their scheme from `X-Forwarded-Proto` — `https` when a reverse proxy
+reports it, `http` otherwise. mvsMF itself only ever sees plain HTTP behind a
+TLS-terminating proxy, so the header is the only source for the client's scheme.
+
 ### Asynchronous (`async` = `Y`) — HTTP 200
 Returns immediately without `cmd-response` (the `cmd-response-key`/`-url`/`-uri` only).
 

--- a/docs/endpoints/info.md
+++ b/docs/endpoints/info.md
@@ -26,9 +26,34 @@ On successful completion, this request returns HTTP status code 200 (OK) and a J
 }
 ```
 
+## Host and Port
+
+`zosmf_hostname` and `zosmf_port` describe the endpoint **the client used**, not the
+address the HTTPD listens on, so both are derived from the request headers:
+
+| Request | `zosmf_port` |
+|---|---|
+| `Host: name:port` | that port |
+| `Host: name`, `X-Forwarded-Port: p` | `p` |
+| `Host: name`, `X-Forwarded-Proto: https` | `443` |
+| `Host: name` | `80` |
+| no `Host` header | `8080` |
+
+A `Host` header without a port is valid — [RFC 7230 §5.4](https://www.rfc-editor.org/rfc/rfc7230#section-5.4)
+leaves the port implied by the scheme — and is what browsers and reverse proxies send for
+the default ports. Behind a TLS-terminating proxy mvsMF only ever sees plain HTTP on its
+own connection, so the public scheme and port can only come from the proxy's
+`X-Forwarded-*` headers.
+
+`SERVER_PORT` is deliberately not consulted: it is the HTTPD's listen port, not the port
+the client dialled.
+
 ## Error Responses
-- HTTP 500 (Internal Server Error)
-    - Failed to parse host name or port
+
+None. A `Host` header that cannot be parsed is logged to the console
+(`MVSMF01E`/`MVSMF02E`/`MVSMF03E`) and falls back to the defaults above; the request still
+returns 200. `/zosmf/info` is the unauthenticated liveness probe every client calls first
+and must not fail on a header quirk (issue #175).
 
 ## Examples
 

--- a/docs/endpoints/jobs/files.md
+++ b/docs/endpoints/jobs/files.md
@@ -67,7 +67,7 @@ zowe jobs list spool-files-by-jobid JOB00123
         "stepname": "JES2",
         "procstep": "",
         "class": "H",
-        "records-url": "/zosmf/restjobs/jobs/TESTJOB/JOB00123/files/2/records"
+        "records-url": "http://mvs:1080/zosmf/restjobs/jobs/TESTJOB/JOB00123/files/2/records"
     },
     {
         "jobname": "TESTJOB",
@@ -81,7 +81,10 @@ zowe jobs list spool-files-by-jobid JOB00123
         "stepname": "JES2",
         "procstep": "",
         "class": "H",
-        "records-url": "/zosmf/restjobs/jobs/TESTJOB/JOB00123/files/3/records"
+        "records-url": "http://mvs:1080/zosmf/restjobs/jobs/TESTJOB/JOB00123/files/3/records"
     }
 ]
 ```
+
+`records-url` is absolute. Its host comes from the request's `Host` header and its scheme
+from `X-Forwarded-Proto` (`https` when a reverse proxy reports it, `http` otherwise).

--- a/docs/endpoints/jobs/list.md
+++ b/docs/endpoints/jobs/list.md
@@ -148,10 +148,14 @@ zowe jobs list jobs --prefix "TEST*" --exec-data
         "owner": "MIKE",
         "type": "JOB",
         "class": "A",
-        "url": "/zosmf/restjobs/jobs/TESTJOB/JOB00123",
-        "files-url": "/zosmf/restjobs/jobs/TESTJOB/JOB00123/files",
+        "url": "http://mvs:1080/zosmf/restjobs/jobs/TESTJOB/JOB00123",
+        "files-url": "http://mvs:1080/zosmf/restjobs/jobs/TESTJOB/JOB00123/files",
         "status": "OUTPUT",
         "retcode": "CC 0000"
     }
 ]
 ```
+
+`url` and `files-url` are absolute. Their host comes from the request's `Host` header and
+their scheme from `X-Forwarded-Proto` (`https` when a reverse proxy reports it, `http`
+otherwise).

--- a/docs/endpoints/jobs/status.md
+++ b/docs/endpoints/jobs/status.md
@@ -86,9 +86,13 @@ mmf job status TESTJOB JOB00123
     "owner": "MIKE",
     "type": "JOB",
     "class": "A",
-    "url": "/zosmf/restjobs/jobs/TESTJOB/JOB00123",
-    "files-url": "/zosmf/restjobs/jobs/TESTJOB/JOB00123/files",
+    "url": "http://mvs:1080/zosmf/restjobs/jobs/TESTJOB/JOB00123",
+    "files-url": "http://mvs:1080/zosmf/restjobs/jobs/TESTJOB/JOB00123/files",
     "status": "OUTPUT",
     "retcode": "CC 0000"
 }
 ```
+
+`url` and `files-url` are absolute. Their host comes from the request's `Host` header and
+their scheme from `X-Forwarded-Proto` (`https` when a reverse proxy reports it, `http`
+otherwise) — mvsMF itself only ever sees plain HTTP behind a TLS-terminating proxy.

--- a/include/common.h
+++ b/include/common.h
@@ -100,6 +100,20 @@ char *getPathParam(Session *session, const char *name) asm("CMN0002");
 char *getHeaderParam(Session *session, const char *name) asm("CMN0003");
 
 /**
+ * @brief Gets the scheme the client used to reach this server
+ *
+ * mvsMF cannot infer the scheme from its own connection: behind a
+ * TLS-terminating reverse proxy it always sees plain HTTP, whatever the
+ * client used. The proxy reports the original scheme in X-Forwarded-Proto,
+ * so that header is the only source. Absent or anything but https, the
+ * answer is http.
+ *
+ * @param session Current session context
+ * @return "https" or "http" (a literal, never NULL — do not free)
+ */
+const char *getRequestScheme(Session *session) asm("CMN0004");
+
+/**
  * @brief Sends default HTTP headers for a response
  *
  * Sends standard HTTP headers including status code, content type,

--- a/src/common.c
+++ b/src/common.c
@@ -42,7 +42,26 @@ getHeaderParam(Session *session, const char *name)
 	return get_env_param(session, "HTTP_", name);
 }
 
-int 
+const char *
+getRequestScheme(Session *session)
+{
+	const char *proto = getHeaderParam(session, "X-Forwarded-Proto");
+
+	if (!proto) {
+		return "http";
+	}
+
+	/* Chained proxies append their own value, so the header can be a list
+	   ("https, http"); the leftmost entry is the one the client used. */
+	if (http_cmpn((const UCHAR *)proto, (const UCHAR *)"https", 5) == 0 &&
+		(proto[5] == '\0' || proto[5] == ',' || proto[5] == ' ')) {
+		return "https";
+	}
+
+	return "http";
+}
+
+int
 sendDefaultHeaders(Session *session, int status, const char *content_type,
 					   size_t content_length)
 {

--- a/src/consapi.c
+++ b/src/consapi.c
@@ -518,6 +518,7 @@ int consoleIssueHandler(Session *session)
 	const char *cn = getPathParam(session, "console-name");
 	const char *ct = getHeaderParam(session, "Content-Type");
 	const char *host = getHeaderParam(session, "Host");
+	const char *scheme = getRequestScheme(session);
 	int cmdlen, cnlen, i, is_async, sol_detected = 0;
 	unsigned delivered = 0;
 	unsigned long long issue_tod;
@@ -639,7 +640,8 @@ int consoleIssueHandler(Session *session)
 	         (unsigned)(issue_tod >> 32), (unsigned)issue_tod);
 	snprintf(uri, sizeof(uri),
 	         "/zosmf/restconsoles/consoles/%s/solmsgs/%s", cn, key);
-	snprintf(url, sizeof(url), "http://%s%s", host ? host : "localhost", uri);
+	snprintf(url, sizeof(url), "%s://%s%s", scheme, host ? host : "localhost",
+	         uri);
 
 	resp = malloc(RESP_CAP);
 	if (!resp) {
@@ -765,7 +767,8 @@ int consoleIssueHandler(Session *session)
 		char duri[200], durl[256];
 		snprintf(duri, sizeof(duri),
 		         "/zosmf/restconsoles/consoles/%s/detections/%s", cn, dkey);
-		snprintf(durl, sizeof(durl), "http://%s%s", host ? host : "localhost", duri);
+		snprintf(durl, sizeof(durl), "%s://%s%s", scheme,
+		         host ? host : "localhost", duri);
 		if (addJsonString(b, "detection-key", dkey) < 0 ||
 		    addJsonString(b, "detection-url", durl) < 0 ||
 		    addJsonString(b, "detection-uri", duri) < 0) {

--- a/src/infoapi.c
+++ b/src/infoapi.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "infoapi.h"
 #include "common.h"
 #include "json.h"
@@ -7,6 +9,9 @@
 
 /** Maximum length of a port string (max port 65535 = 5 digits + nul) */
 #define MAX_PORT_LENGTH 6
+
+/** Default host if the request carries no Host header */
+#define DEFAULT_HOST "127.0.0.1"
 
 /** Default port if none specified */
 #define DEFAULT_PORT "8080"
@@ -18,6 +23,7 @@
 static int parse_host_name(const char *value, char *outHost, size_t outSize);
 static int parse_port_string(const char *value, char *outPort, size_t outSize);
 static int validate_port(const char *port);
+static void default_port(Session *session, char *outPort, size_t outSize);
 
 //
 // public functions
@@ -28,7 +34,7 @@ infoHandler(Session *session)
 {
 	int rc = RC_SUCCESS;
 	
-	char hostname[MAX_HOST_NAME_LENGTH] = "127.0.0.1";
+	char hostname[MAX_HOST_NAME_LENGTH] = DEFAULT_HOST;
 	char port_str[MAX_PORT_LENGTH] = DEFAULT_PORT;
 
 	JsonBuilder *builder = createJsonBuilder();
@@ -41,22 +47,29 @@ infoHandler(Session *session)
 
 	char *value = getHeaderParam(session, "Host"); // e.g. "example.org:8080"
 	if (value) {
+		/* A Host header this handler cannot make sense of must not fail the
+		   request: /zosmf/info is the unauthenticated liveness probe every
+		   client calls first, and it used to answer an odd Host by sending
+		   nothing at all and dropping the connection (issue #175). Log the
+		   oddity, fall back, still answer 200. */
 		if (parse_host_name(value, hostname, sizeof(hostname)) != 0) {
 			wtof("MVSMF01E Unable to parse host name");
-			rc = RC_ERROR;
-			goto quit;
+			strcpy(hostname, DEFAULT_HOST);
 		}
 
 		if (parse_port_string(value, port_str, sizeof(port_str)) != 0) {
 			wtof("MVSMF02E Unable to parse port");
-			rc = RC_ERROR;
-			goto quit;
+			port_str[0] = '\0';
 		}
 
 		if (validate_port(port_str) != 0) {
-			wtof("MVSMF03E Invalid port number");
-			rc = RC_ERROR;
-			goto quit;
+			/* An empty port is not an error: RFC 7230 5.4 lets a Host header
+			   omit it, and then the scheme implies it. Only a non-empty port
+			   that fails validation is worth a message. */
+			if (port_str[0] != '\0') {
+				wtof("MVSMF03E Invalid port number");
+			}
+			default_port(session, port_str, sizeof(port_str));
 		}
 	}
 
@@ -209,4 +222,37 @@ validate_port(const char *port)
     }
 
     return 0;
+}
+
+/**
+ * Determines the port for a Host header that carries none
+ *
+ * RFC 7230 5.4 lets a Host header omit the port, which the scheme then
+ * implies - and most clients do exactly that for the default ports. Behind a
+ * TLS-terminating reverse proxy mvsMF only ever sees plain HTTP on its own
+ * connection, so the public port has to come from the proxy: X-Forwarded-Port
+ * where it is set (the only source that gets a non-default public port such as
+ * 8443 right), the scheme's default otherwise.
+ *
+ * SERVER_PORT is deliberately not consulted: it is the HTTPD's listen port,
+ * not the port the client dialled, so self-referential z/OSMF URLs built from
+ * it would be wrong.
+ *
+ * @param session Current session context
+ * @param outPort Buffer to store the port, never left empty
+ * @param outSize Size of the outPort buffer
+ */
+__asm__("\n&FUNC	SETC 'default_port'");
+static void
+default_port(Session *session, char *outPort, size_t outSize)
+{
+	const char *fwd_port = getHeaderParam(session, "X-Forwarded-Port");
+
+	if (fwd_port && strlen(fwd_port) < outSize && validate_port(fwd_port) == 0) {
+		strcpy(outPort, fwd_port);
+		return;
+	}
+
+	strcpy(outPort, strcmp(getRequestScheme(session), "https") == 0
+					? "443" : "80");
 }

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -70,7 +70,7 @@ static int  want_exec_data(Session *session);
 static const char* format_exec_time(const time64_t *t, int tzadjust, char *out, size_t outlen);
 static const char* job_status_str(const JESJOB *job);
 static int  process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *status,
-                        const char *host, int exec_data);
+                        const char *host, const char *scheme, int exec_data);
 static JESJOB* find_job_by_name_and_id(Session *session, const char *jobname, const char *jobid, JESJOB ***out_joblist);
 static int process_job_files(Session *session, JESJOB *job, const char *host, JsonBuilder *builder);
 static int validate_intrdr_headers(Session *session);
@@ -151,6 +151,8 @@ jobListHandler(Session *session)
 	startArray(builder);
 
 	const int exec_data = want_exec_data(session);
+	/* hoisted out of the loop: one env lookup for the whole job list */
+	const char *scheme = getRequestScheme(session);
 
 	/* max-jobs caps the jobs *returned*, not the queue entries looked at: with
 	   a status or owner filter in play the first max_jobs entries of the spool
@@ -160,7 +162,7 @@ jobListHandler(Session *session)
 	unsigned ii = 0;
 	for (ii = 0; ii < array_count(&joblist) && emitted < max_jobs; ii++) {
 		rc = process_job(builder, joblist[ii], owner,
-						status[0] ? status : NULL, host, exec_data);
+						status[0] ? status : NULL, host, scheme, exec_data);
 		if (rc < 0) {
 			goto quit;
 		}
@@ -1002,7 +1004,7 @@ format_exec_time(const time64_t *t, int tzadjust, char *out, size_t outlen)
 __asm__("\n&FUNC	SETC 'process_job'");
 static int
 process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *status,
-			const char *host, int exec_data)
+			const char *host, const char *scheme, int exec_data)
 {
 	int rc = 0;
 
@@ -1031,7 +1033,8 @@ process_job(JsonBuilder *builder, JESJOB *job, const char *owner, const char *st
 
 	// url is the full url to the job
 	rc = snprintf(url_str, sizeof(url_str),
-					"http://%s/zosmf/restjobs/jobs/%s/%s", host_str, job->jobname, job->jobid);
+					"%s://%s/zosmf/restjobs/jobs/%s/%s", scheme, host_str,
+					job->jobname, job->jobid);
 	
 	// files_url is the full url to the job sysout files
 	rc = snprintf(files_url_str, sizeof(files_url_str), "%s/files", url_str);
@@ -1209,7 +1212,8 @@ int process_job_files(Session *session, JESJOB *job, const char *host, JsonBuild
     int rc = 0;
     
 	const char *host_str = host ? host : "127.0.0.1:8080";
-    
+	const char *scheme = getRequestScheme(session);
+
 	char url_str[MAX_URL_LENGTH] = {0};
     char recfm_str[RECFM_STR_SIZE] = {0};
 
@@ -1225,8 +1229,8 @@ int process_job_files(Session *session, JESJOB *job, const char *host, JsonBuild
         }
 
         rc = snprintf(url_str, sizeof(url_str),
-                    "http://%s/zosmf/restjobs/jobs/%s/%s/files/%d/records", 
-                    host_str, job->jobname, job->jobid, dd->dsid);
+                    "%s://%s/zosmf/restjobs/jobs/%s/%s/files/%d/records",
+                    scheme, host_str, job->jobname, job->jobid, dd->dsid);
 
         get_recfm_string(dd->recfm, recfm_str);
 
@@ -1609,7 +1613,8 @@ send_job_status_response(Session *session, JESJOB *job, const char *host)
         return -1;
     }
 
-    rc = process_job(builder, job, NULL, NULL, host, want_exec_data(session));
+    rc = process_job(builder, job, NULL, NULL, host, getRequestScheme(session),
+                     want_exec_data(session));
     if (rc < 0) {
         freeJsonBuilder(builder);
         return rc;

--- a/tests/curl-info.sh
+++ b/tests/curl-info.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# =========================================================================
+# mvsMF Information service REST API - curl test suite
+#
+# Tests GET /zosmf/info, with the emphasis on how zosmf_port is derived
+# from the request headers:
+#
+#   Host: name:port          -> that port, unchanged
+#   Host: name               -> RFC 7230 5.4: the port is implied by the
+#                               scheme, so it comes from X-Forwarded-Port,
+#                               else X-Forwarded-Proto, else 80 (issue #175)
+#
+# A Host header this handler cannot make sense of must never fail the
+# request: /zosmf/info is the unauthenticated liveness probe every client
+# calls first. Before #175 a port-less Host answered nothing at all and
+# dropped the connection (curl exit 52 / HTTP 000).
+#
+# Prerequisites:
+#   - Copy .env.example to .env at the repo root and fill in
+#   - curl and jq must be installed
+#
+# Usage:
+#   ./tests/curl-info.sh
+# =========================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found."
+	echo "Copy .env.example to .env and fill in your values."
+	exit 1
+fi
+
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+BASE_URL="http://${MVSMF_HOST}:${MVSMF_PORT}"
+INFO_URL="${BASE_URL}/zosmf/info"
+AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+
+# The name used in the Host header under test. Deliberately not the address
+# curl dials, so a response echoing it proves the header was the source.
+TEST_HOST="mvsmf.test.example"
+
+# --- state ---
+PASSED=0
+FAILED=0
+TOTAL=0
+
+pass() { PASSED=$((PASSED + 1)); TOTAL=$((TOTAL + 1)); echo "  PASS: $1"; }
+fail() {
+	FAILED=$((FAILED + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"
+	[ -n "${2:-}" ] && echo "        $2"
+}
+
+assert_http_status() {
+	if [ "$2" = "$1" ]; then pass "$3 (HTTP $2)"
+	else fail "$3" "expected HTTP $1, got $2"; fi
+}
+
+assert_json_field() {
+	local actual
+	actual=$(echo "$1" | jq -r "$2" 2>/dev/null) || actual=""
+	if [ "$actual" = "$3" ]; then pass "$4 ($2=$actual)"
+	else fail "$4" "$2: expected '$3', got '$actual'"; fi
+}
+
+BODYF=$(mktemp)
+trap 'rm -f "$BODYF"' EXIT
+
+# GET /zosmf/info with the given extra headers; sets CODE and BODY.
+# Every argument is passed to curl verbatim (use one -H per header).
+info() {
+	CODE=$(curl -s -u "$AUTH" -o "$BODYF" -w '%{http_code}' "$@" "$INFO_URL")
+	BODY=$(cat "$BODYF")
+}
+
+echo "========================================"
+echo " mvsMF Information service - curl tests"
+echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
+echo "========================================"
+
+# =========================================================================
+# 1. Host with an explicit port
+# =========================================================================
+echo ""
+echo "--- Host with an explicit port ---"
+
+info -H "Host: ${TEST_HOST}:${MVSMF_PORT}"
+assert_http_status "200" "$CODE" "explicit port is accepted"
+assert_json_field "$BODY" ".zosmf_hostname" "$TEST_HOST" "hostname comes from Host"
+assert_json_field "$BODY" ".zosmf_port" "$MVSMF_PORT" "port comes from Host"
+
+info -H "Host: ${TEST_HOST}:443"
+assert_http_status "200" "$CODE" "a port mvsMF does not listen on is echoed"
+assert_json_field "$BODY" ".zosmf_port" "443" "port 443 from Host"
+
+# =========================================================================
+# 2. Host without a port (issue #175)
+# =========================================================================
+echo ""
+echo "--- Host without a port ---"
+
+info -H "Host: ${TEST_HOST}"
+assert_http_status "200" "$CODE" "port-less Host does not drop the connection"
+assert_json_field "$BODY" ".zosmf_hostname" "$TEST_HOST" "hostname still comes from Host"
+assert_json_field "$BODY" ".zosmf_port" "80" "port defaults to the http scheme"
+
+info -H "Host: 127.0.0.1"
+assert_http_status "200" "$CODE" "port-less Host, bare address"
+assert_json_field "$BODY" ".zosmf_port" "80" "port defaults to 80"
+
+# =========================================================================
+# 3. Port-less Host behind a reverse proxy
+# =========================================================================
+echo ""
+echo "--- port-less Host with X-Forwarded-* ---"
+
+info -H "Host: ${TEST_HOST}" -H "X-Forwarded-Proto: https"
+assert_http_status "200" "$CODE" "X-Forwarded-Proto: https"
+assert_json_field "$BODY" ".zosmf_port" "443" "https implies port 443"
+
+info -H "Host: ${TEST_HOST}" -H "X-Forwarded-Proto: http"
+assert_http_status "200" "$CODE" "X-Forwarded-Proto: http"
+assert_json_field "$BODY" ".zosmf_port" "80" "http implies port 80"
+
+# Chained proxies append their own value; the leftmost is the client's.
+info -H "Host: ${TEST_HOST}" -H "X-Forwarded-Proto: https, http"
+assert_http_status "200" "$CODE" "X-Forwarded-Proto list"
+assert_json_field "$BODY" ".zosmf_port" "443" "leftmost value of the list wins"
+
+# A non-default public port: only X-Forwarded-Port can carry it.
+info -H "Host: ${TEST_HOST}" -H "X-Forwarded-Proto: https" -H "X-Forwarded-Port: 8443"
+assert_http_status "200" "$CODE" "X-Forwarded-Port"
+assert_json_field "$BODY" ".zosmf_port" "8443" "X-Forwarded-Port wins over the scheme"
+
+# An explicit port in Host is the client's own statement - it is not
+# overridden by what a proxy claims.
+info -H "Host: ${TEST_HOST}:8080" -H "X-Forwarded-Port: 8443"
+assert_http_status "200" "$CODE" "Host port with X-Forwarded-Port"
+assert_json_field "$BODY" ".zosmf_port" "8080" "Host port wins over X-Forwarded-Port"
+
+# =========================================================================
+# 4. Malformed input degrades, it does not fail
+# =========================================================================
+echo ""
+echo "--- malformed Host ---"
+
+info -H "Host: ${TEST_HOST}:"
+assert_http_status "200" "$CODE" "trailing colon, no port"
+assert_json_field "$BODY" ".zosmf_port" "80" "empty port falls back to 80"
+
+info -H "Host: ${TEST_HOST}:99999999"
+assert_http_status "200" "$CODE" "over-long port"
+assert_json_field "$BODY" ".zosmf_port" "80" "unparsable port falls back to 80"
+
+info -H "Host: ${TEST_HOST}:abc"
+assert_http_status "200" "$CODE" "non-numeric port"
+assert_json_field "$BODY" ".zosmf_port" "80" "invalid port falls back to 80"
+
+info -H "Host: ${TEST_HOST}:0"
+assert_http_status "200" "$CODE" "port 0"
+assert_json_field "$BODY" ".zosmf_port" "80" "out-of-range port falls back to 80"
+
+info -H "Host: ${TEST_HOST}" -H "X-Forwarded-Port: nonsense"
+assert_http_status "200" "$CODE" "invalid X-Forwarded-Port"
+assert_json_field "$BODY" ".zosmf_port" "80" "invalid X-Forwarded-Port is ignored"
+
+# =========================================================================
+# 5. The rest of the payload
+# =========================================================================
+echo ""
+echo "--- payload ---"
+
+info -H "Host: ${TEST_HOST}:${MVSMF_PORT}"
+assert_json_field "$BODY" ".zos_version" "MVS 3.8j" "zos_version"
+assert_json_field "$BODY" ".api_version" "1" "api_version"
+assert_json_field "$BODY" ".zosmf_saf_realm" "SAFRealm" "zosmf_saf_realm"
+
+if [ -n "$(echo "$BODY" | jq -r '.zosmf_version // empty' 2>/dev/null)" ]; then
+	pass "zosmf_version is present"
+else
+	fail "zosmf_version is present" "missing or empty"
+fi
+
+# =========================================================================
+# Summary
+# =========================================================================
+echo ""
+echo "========================================"
+echo " Total: ${TOTAL}  Passed: ${PASSED}  Failed: ${FAILED}"
+echo "========================================"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Fixes #175
Fixes #254

Two related defects in how mvsMF describes the endpoint the client actually used.

## #175 — a Host header without a port killed `/zosmf/info`

`/zosmf/info` split `Host` into name and port and failed the request when the port half
came back empty. A port-less `Host` is valid — [RFC 7230 §5.4](https://www.rfc-editor.org/rfc/rfc7230#section-5.4)
leaves the port implied by the scheme — and is what browsers and reverse proxies send for
the default ports. Behind nginx/HAProxy the endpoint therefore died on every request:
`MVSMF03E`, nothing on the wire, connection dropped, `502 Bad Gateway` at the proxy.

Two things were wrong:

- `port_str` was initialized to the default and then unconditionally overwritten with `""`
  by `parse_port_string()`, so the default never applied.
- All three parse failures (`MVSMF01E`/`02E`/`03E`) did `rc = RC_ERROR; goto quit;` having
  sent **nothing**. That is the dropped connection, not a 500 — the `HTTP 500` that
  `docs/endpoints/info.md` promised never existed.

The empty port is now filled from `X-Forwarded-Port` where the proxy sets it (the only
source that gets a non-default public port such as `8443` right), else `X-Forwarded-Proto`,
else `80`. `SERVER_PORT` is deliberately not consulted: it is the HTTPD's listen port, not
the port the client dialled.

The parse failures degrade to those defaults and still answer 200. `/zosmf/info` is the
unauthenticated liveness probe every client calls first; a header quirk must not take it
down. That also covers the neighbours the old code failed on — a trailing colon, an
over-long port, an IPv6 literal whose brackets confuse the colon split.

**One correction to the issue text:** it says mvsMF "aborts every request". Only
`/zosmf/info` parses a port, so only it hard-failed; `restfiles` and `restjobs` answered 200
with a port-less `Host` both before and after. It *looks* like a total outage because
`/zosmf/info` is the handshake call.

## #254 — self-referential URLs hardcoded `http://`

Four sites built their URL with a literal scheme: `url`/`files-url` on a job,
`records-url` on a spool file, `cmd-response-url` and `detection-url` on a console command.
The host came from `Host` and was right; the scheme was not. Behind a TLS-terminating proxy
mvsMF only ever sees plain HTTP on its own connection, so a request that arrived as `https`
got back `http` URLs — a port that is not open to the outside, or mixed content.

All four now take the scheme from the shared `getRequestScheme()` helper. In the job list
the lookup is hoisted out of the loop, so a listing costs one env lookup, not one per job.

## Verification

Deployed to a live TK5 stand and activated (`/zosmf/test?fn=version` == `9506b43` == HEAD).

New suite `tests/curl-info.sh`, built from the issue's repro table — **34/34 pass**:

```
Host: name:8080                              -> 200, zosmf_port 8080
Host: name:443                               -> 200, zosmf_port 443
Host: name                                   -> 200, zosmf_port 80     (was: 000)
Host: 127.0.0.1                              -> 200, zosmf_port 80     (was: 000)
Host: name  + X-Forwarded-Proto: https       -> 200, zosmf_port 443
Host: name  + X-Forwarded-Proto: https, http -> 200, zosmf_port 443    (chained proxies)
Host: name  + X-Forwarded-Port: 8443         -> 200, zosmf_port 8443
Host: name:8080 + X-Forwarded-Port: 8443     -> 200, zosmf_port 8080   (Host wins)
Host: name: / :99999999 / :abc / :0          -> 200, zosmf_port 80     (degrades, logs)
```

Scheme, live, all four sites:

```
plain                        -> http://mvsdev.lan:8080/zosmf/restjobs/jobs/HTTPD/STC00874
X-Forwarded-Proto: https     -> https://mvs.example.org/zosmf/restjobs/jobs/HTTPD/STC00874
                             -> https://mvs.example.org/.../files/1/records
                             -> https://mvs.example.org/.../solmsgs/E31FE7A22C55A881
                             -> https://mvs.example.org/.../detections/DAF2DF58
```

Regression: `curl-jobs.sh` 98/98, `curl-console.sh` 64/64. Host build clean under
`-Wall -Werror`.

## Docs

`docs/endpoints/info.md` gains the derivation table and loses the error section that
described a response that was never sent. The `url`/`files-url`/`records-url` samples in
the jobs docs showed relative paths; they are absolute, and now say where their scheme
comes from.

## Note

Once nginx no longer has to append the port, the workaround in #175
(`proxy_set_header Host $host:$server_port`) can go back to `proxy_set_header Host $host`
— but it keeps working either way, an explicit port in `Host` still wins.