### PR TITLE
router: pass the abend code through to the client

### DIFF
--- a/docs/endpoints/datasets/members-put.md
+++ b/docs/endpoints/datasets/members-put.md
@@ -35,6 +35,12 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 - HTTP 500 (Internal Server Error)
     - The dataset exists but cannot be opened for writing (I/O error)
     - I/O error during write
+    - The library ran out of space or directory blocks mid-upload. The write
+      abends, the router's recovery closes and frees the DD, and the message
+      names the abend: `Internal server error (abend SB37: out of space on the
+      volume)`, `SD37: primary extent full, no secondary allocation` or
+      `SE37: extent limit reached` (issue #256). Any other handler abend
+      carries its code the same way, e.g. `(abend S0C4)`.
 
 Only a missing *dataset* is an error here. A member that does not exist yet is
 what a create looks like, and it is written normally.

--- a/docs/endpoints/datasets/put.md
+++ b/docs/endpoints/datasets/put.md
@@ -33,6 +33,13 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 - HTTP 500 (Internal Server Error)
     - Dataset not found or cannot be opened for writing
     - I/O error during write
+    - The dataset ran out of space mid-upload. The write abends, the router's
+      recovery closes and frees the DD, and the message names the abend:
+      `Internal server error (abend SB37: out of space on the volume)`,
+      `SD37: primary extent full, no secondary allocation` or
+      `SE37: extent limit reached` (issue #256). Any other handler abend
+      carries its code the same way, e.g. `(abend S0C4)`. The dataset is left
+      as the abend left it — the upload is not retried.
 
 ## Text mode framing
 - A record ends at LF, CR or CRLF. The terminator is not part of the record.

--- a/include/abendmsg.h
+++ b/include/abendmsg.h
@@ -1,0 +1,48 @@
+#ifndef ABENDMSG_H
+#define ABENDMSG_H
+
+#include <stddef.h>
+
+/**
+ * @file abendmsg.h
+ * @brief The client-visible message for a handler abend.
+ *
+ * When a handler abends, the router's ESTAE recovery closes what the handler
+ * left open and answers 500. The abend code itself used to stay behind on the
+ * console, so the client read only "Internal server error (abend recovery)" --
+ * a data set that ran out of space and a protection exception were the same
+ * sentence, and telling them apart cost a console round trip every time
+ * (issue #256).
+ *
+ * The message carries the code, and the x37 family is named outright because
+ * that is what a write into a full data set produces and what the caller can
+ * actually act on:
+ *
+ *   SB37  out of space on the volume
+ *   SD37  primary extent full, no secondary allocation
+ *   SE37  extent limit reached
+ *
+ * The status stays 500 (in the z/OSMF list for the files API) and the error
+ * report keeps its shape -- only the `message` field changes.
+ *
+ * This lives in its own translation unit so test/host/tstabnd.c can drive the
+ * real function: router.c cannot compile on the host (clibwto, clibtry, the
+ * httpd callback table).
+ */
+
+/** Buffer size for abend_message(); holds the longest text (SD37) plus NUL. */
+#define ABEND_MSG_SIZE	96
+
+/**
+ * Format the message for a handler abend into `buf`.
+ *
+ * @param buf   destination, at least ABEND_MSG_SIZE bytes. Must be writable
+ *              storage -- MVSMF is link-edited RENT, and this runs in the
+ *              recovery path, where a second abend would be unrecoverable.
+ * @param size  size of `buf`; the text is truncated to fit.
+ * @param sys   system completion code, 0 for a user abend.
+ * @param usr   user completion code, used only when `sys` is 0.
+ */
+void abend_message(char *buf, size_t size, unsigned sys, unsigned usr);
+
+#endif /* ABENDMSG_H */

--- a/project.toml
+++ b/project.toml
@@ -62,5 +62,14 @@ name = "TSTJCLN"
 sources = ["test/host/tstjcln.c"]
 norent = true
 
+# TSTABND: #256 — the abend code has to reach the client, and the x37 family
+# has to be named. Portable C (test-host); the TU #includes src/abendmsg.c so
+# it drives the real formatter router.c calls from its ESTAE recovery — do not
+# list abendmsg.c here.
+[[test]]
+name = "TSTABND"
+sources = ["test/host/tstabnd.c"]
+norent = true
+
 [release]
 version_files = ["VERSION"]

--- a/src/abendmsg.c
+++ b/src/abendmsg.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stddef.h>
+
+#include "abendmsg.h"
+
+/*
+ * The client-visible message for a handler abend. See abendmsg.h for why the
+ * abend code belongs in the response, and issue #256 for what its absence cost.
+ */
+
+#define ABEND_B37	0xB37
+#define ABEND_D37	0xD37
+#define ABEND_E37	0xE37
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'abend_message'");
+#endif
+void
+abend_message(char *buf, size_t size, unsigned sys, unsigned usr)
+{
+	const char *detail = NULL;
+
+	switch (sys) {
+		case ABEND_B37:	detail = "out of space on the volume";			break;
+		case ABEND_D37:	detail = "primary extent full, no secondary allocation";	break;
+		case ABEND_E37:	detail = "extent limit reached";			break;
+		default:	break;
+	}
+
+	if (sys == 0) {
+		/* a user abend carries no system code -- U0100, not S000 */
+		snprintf(buf, size, "Internal server error (abend U%04d)", usr);
+	} else if (detail) {
+		snprintf(buf, size, "Internal server error (abend S%03X: %s)",
+			 sys, detail);
+	} else {
+		snprintf(buf, size, "Internal server error (abend S%03X)", sys);
+	}
+}

--- a/src/router.c
+++ b/src/router.c
@@ -6,6 +6,7 @@
 #include "router.h"
 #include "common.h"
 #include "httpcgi.h"
+#include "abendmsg.h"
 
 
 #define INITIAL_BUFFER_SIZE 4096
@@ -148,12 +149,17 @@ int handle_request(Router *router, Session *session)
         unsigned abend = tryrc();
         unsigned sys = (abend >> 12) & 0xFFF;
         unsigned usr = abend & 0xFFF;
+        // on the stack, not static: MVSMF is RENT, and this runs in the
+        // recovery path where a second abend would be unrecoverable
+        char msg[ABEND_MSG_SIZE];
         wtof("MVSMF99E Handler abend S%03X U%04d for %s %s",
              sys, usr, method, path);
         session_cleanup(session);
         if (!session->headers_sent) {
-            sendErrorResponse(session, 500, 6, 8, 99,
-                "Internal server error (abend recovery)", NULL, 0);
+            // the abend code is all the caller gets -- the console message
+            // stays behind on the system (#256)
+            abend_message(msg, sizeof(msg), sys, usr);
+            sendErrorResponse(session, 500, 6, 8, 99, msg, NULL, 0);
         } else {
             wtof("MVSMF99W Headers already sent, cannot send error response");
         }

--- a/test/host/tstabnd.c
+++ b/test/host/tstabnd.c
@@ -1,0 +1,116 @@
+/*
+ * tstabnd.c - #256: the abend code has to reach the client.
+ *
+ * A space abend during a dataset PUT used to arrive as a bare "Internal server
+ * error (abend recovery)". The router's ESTAE recovery had the code in hand
+ * when it built the response -- it printed it to the console and then dropped
+ * it -- so a full data set and a protection exception read identically and
+ * telling them apart cost a console round trip.
+ *
+ * What this pins down:
+ *
+ *   1. The code is in the message, for every abend.
+ *   2. The x37 family is named, since that is what a write into a full data
+ *      set produces (the measured case was SD37 on SPACE=TRK(1,0,0)).
+ *   3. Nothing is truncated: SD37 is the longest text at 80 characters, and
+ *      ABEND_MSG_SIZE has to keep holding it. snprintf() truncates silently,
+ *      so a buffer that shrinks below the text would ship a cut-off sentence
+ *      and nothing would surface it.
+ *   4. A user abend renders as U0100, not as S000.
+ *
+ * ====================================================================
+ * This test drives the REAL function: src/abendmsg.c is #included below.
+ * router.c itself cannot compile on the host (clibwto, clibtry, the httpd
+ * callback table), which is why the message lives in its own TU.
+ * ====================================================================
+ *
+ * Expected texts are compared against string literals the same compiler
+ * produced, so the runtime encoding does not matter -- the test is portable
+ * and runs under `make test-host`.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include <mbtcheck.h>
+
+#include "../../src/abendmsg.c"
+
+#define CANARY	0x7E	/* guards the bytes past the formatted text */
+
+static char	g_buf[ABEND_MSG_SIZE + 8];
+
+/* Format into a canary-filled buffer, as the recovery path does with its
+ * stack buffer. Returns the text. */
+static const char *fmt(unsigned sys, unsigned usr)
+{
+	memset(g_buf, CANARY, sizeof(g_buf));
+	abend_message(g_buf, ABEND_MSG_SIZE, sys, usr);
+	return g_buf;
+}
+
+/* Nothing was written past the buffer the caller declared. */
+static int canary_intact(void)
+{
+	size_t i;
+
+	for (i = ABEND_MSG_SIZE; i < sizeof(g_buf); i++) {
+		if (g_buf[i] != (char) CANARY) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+int main(void)
+{
+	/* 1. the x37 family is named, not just numbered */
+	CHECK(strcmp(fmt(0xB37, 0),
+		     "Internal server error (abend SB37: out of space on the volume)") == 0,
+	      "SB37: names the volume being full");
+	CHECK(canary_intact(), "SB37: nothing written past the buffer");
+
+	CHECK(strcmp(fmt(0xD37, 0),
+		     "Internal server error (abend SD37: primary extent full, "
+		     "no secondary allocation)") == 0,
+	      "SD37: names the missing secondary allocation");
+	CHECK(canary_intact(), "SD37: nothing written past the buffer");
+
+	/* the longest text there is -- it must survive whole, since snprintf
+	 * would truncate it without a word */
+	CHECK_EQ((int) strlen(fmt(0xD37, 0)), 80, "SD37: the longest text is not truncated");
+
+	CHECK(strcmp(fmt(0xE37, 0),
+		     "Internal server error (abend SE37: extent limit reached)") == 0,
+	      "SE37: names the extent limit");
+
+	/* 2. every other system abend still carries its code */
+	CHECK(strcmp(fmt(0x0C4, 0), "Internal server error (abend S0C4)") == 0,
+	      "S0C4: the code reaches the client");
+	CHECK(strcmp(fmt(0x001, 0), "Internal server error (abend S001)") == 0,
+	      "S001: three digits, not one");
+	CHECK(strcmp(fmt(0x322, 0), "Internal server error (abend S322)") == 0,
+	      "S322: the code reaches the client");
+
+	/* 3. a user abend has no system code -- U0100, never S000 */
+	CHECK(strcmp(fmt(0, 100), "Internal server error (abend U0100)") == 0,
+	      "U0100: rendered as a user abend");
+	CHECK(strcmp(fmt(0, 0), "Internal server error (abend U0000)") == 0,
+	      "U0000: rendered as a user abend");
+
+	/* 4. the prefix is what the router promised the client all along */
+	CHECK(strncmp(fmt(0x0C4, 0), "Internal server error", 21) == 0,
+	      "the message still starts with Internal server error");
+
+	/* 5. a caller passing a short buffer gets a NUL-terminated truncation,
+	 *    not an overrun */
+	{
+		char small[16];
+
+		memset(small, CANARY, sizeof(small));
+		abend_message(small, 10, 0xD37, 0);
+		CHECK_EQ((int) strlen(small), 9, "short buffer: truncated to fit");
+		CHECK(small[10] == (char) CANARY, "short buffer: nothing written past it");
+	}
+
+	return mbt_test_summary("TSTABND");
+}


### PR DESCRIPTION
Fixes #256

## Problem

A handler abend reached the caller as a bare `Internal server error (abend recovery)`. The recovery block in `router.c` already decoded `sys`/`usr` for its WTO and then dropped them, so a data set that ran out of space and a protection exception read identically — diagnosing the measured SD37 case cost a console round trip every time.

## Change

The message now carries the code, and the x37 family is named:

| Abend | Message |
|-------|---------|
| SB37 | `Internal server error (abend SB37: out of space on the volume)` |
| SD37 | `Internal server error (abend SD37: primary extent full, no secondary allocation)` |
| SE37 | `Internal server error (abend SE37: extent limit reached)` |
| other | `Internal server error (abend S0C4)` |
| user abend | `Internal server error (abend U0100)` |

The user-abend branch is not in the issue but is the same code path: without it a `sys == 0` abend would render as `(abend S000)`.

Status stays **500** (in the z/OSMF list for the files API) and the error report keeps its `category`/`rc`/`reason` shape — only `message` changes. The abend is not swallowed and nothing is retried; the data set is left as the abend left it.

## Notes on the implementation

- The formatter is a separate TU (`src/abendmsg.c` + `include/abendmsg.h`) so `test/host/tstabnd.c` can `#include` and drive the real function — `router.c` cannot compile on the host (clibwto, clibtry, the httpd callback table). Same pattern as `reclines.c` / `jclines.c`.
- The buffer is on the stack (`char msg[ABEND_MSG_SIZE]`), never static: MVSMF is link-edited RENT, and a second abend inside the recovery path would be unrecoverable.
- `ABEND_MSG_SIZE` is 96; the longest text (SD37) is 80 characters. `snprintf()` truncates silently, so the test asserts that length explicitly.

## Verification

- `make` — clean cross-compile, no new warnings under `-Wall -Werror`.
- `make test-host` — 4 suites, 85 assertions, all pass; TSTABND contributes 14.
- Mutation check: reverting the formatter to the old fixed string makes TSTABND fail 4 assertions, so the test covers the actual behaviour rather than the code shape.
- Not yet exercised on MVS. There is no host path that abends; end-to-end confirmation needs `make deploy` + `tests/jcl/mvsmfact.jcl`, then a PUT into a PS allocated `SPACE=TRK(1,0,0)`, checking the body reads `(abend SD37: …)` and the console still shows the `MVSMF99E`/`MVSMF99I` pair unchanged.

## Docs

`docs/endpoints/datasets/put.md` and `members-put.md` gained the out-of-space case under their HTTP 500 lists.