### PR TITLE
info: fail the Host parse when there is no host name

### DIFF
--- a/docs/endpoints/info.md
+++ b/docs/endpoints/info.md
@@ -48,6 +48,12 @@ own connection, so the public scheme and port can only come from the proxy's
 `SERVER_PORT` is deliberately not consulted: it is the HTTPD's listen port, not the port
 the client dialled.
 
+`zosmf_hostname` follows the same rule and falls back to `127.0.0.1` when the header
+carries no usable name — including the cases that have a colon but nothing in front of
+it, `Host: :8080` and `Host: :::garbage:::`. Those used to be reported as an empty
+string (issue #260). The two halves fall back independently: `Host: :8080` still yields
+port `8080`.
+
 ## Error Responses
 
 None. A `Host` header that cannot be parsed falls back to the defaults above and the

--- a/include/hostparse.h
+++ b/include/hostparse.h
@@ -26,6 +26,13 @@
  * The contract every caller depends on: **a non-zero return means the output
  * is unusable and the caller must fall back.** Returning 0 with an empty host
  * name would be worse than failing, because it looks like success.
+ *
+ * One input still breaks that contract: an IPv6 literal. `[::1]:8080` has its
+ * first colon at offset 1, so the name comes back as "[" and the return is 0.
+ * MVS 3.8j has no IPv6 stack, so nothing on the target can dial one -- but a
+ * reverse proxy could forward such a header, and this code already
+ * accommodates proxies through X-Forwarded-*. Splitting on the last colon
+ * outside brackets would fix it; nobody has needed it yet.
  */
 
 /**

--- a/include/hostparse.h
+++ b/include/hostparse.h
@@ -1,0 +1,63 @@
+#ifndef HOSTPARSE_H
+#define HOSTPARSE_H
+
+#include <stddef.h>
+
+/**
+ * @file hostparse.h
+ * @brief Splitting a `Host` header into a host name and a port.
+ *
+ * `/zosmf/info` echoes the host and port back to the client so it can build
+ * self-referential URLs, and it derives both from the `Host` header -- never
+ * from `SERVER_PORT`, which is httpd's listen port and not the one the client
+ * dialled.
+ *
+ * That header is client-supplied and arrives malformed often enough that the
+ * endpoint has now been broken twice by it: issue #175 (an odd Host dropped
+ * the connection) and issue #260 (a Host starting with a colon parsed
+ * "successfully" as an empty name, so the caller's fallback never ran). The
+ * parsing lives here so there is one copy of it and so test/host/tsthost.c can
+ * exercise the real code on the host.
+ *
+ * All three are pure string functions -- no session, no httpd, no MVS. The
+ * scheme-dependent default (`default_port()`) stays in infoapi.c, because it
+ * needs the request.
+ *
+ * The contract every caller depends on: **a non-zero return means the output
+ * is unusable and the caller must fall back.** Returning 0 with an empty host
+ * name would be worse than failing, because it looks like success.
+ */
+
+/**
+ * Extract the host name from a `Host` header value ("name" or "name:port").
+ *
+ * @param value   header value; may be NULL
+ * @param outHost buffer for the name, always nul-terminated on success
+ * @param outSize size of outHost
+ * @return 0 on success, -1 on a bad argument, -2 if outHost is too small,
+ *         -3 if the value carries no host name at all (":8080", ":::x:::").
+ *         Anything non-zero leaves outHost untouched.
+ */
+int parse_host_name(const char *value, char *outHost, size_t outSize)
+															asm("MFHSTNAM");
+
+/**
+ * Extract the port from a `Host` header value.
+ *
+ * A value with no port, or with a colon and nothing after it, is not an error:
+ * RFC 7230 5.4 lets the header omit the port, and then the scheme implies it.
+ * outPort is set empty and 0 returned, and it is the caller's job to supply
+ * the scheme default.
+ *
+ * @return 0 on success, -1 on a bad argument, -2 if outPort is too small
+ */
+int parse_port_string(const char *value, char *outPort, size_t outSize)
+															asm("MFHSTPRT");
+
+/**
+ * @return 0 if `port` is all digits and in 1..65535, -1 otherwise.
+ *         An empty or NULL port is invalid -- see parse_port_string().
+ */
+int validate_port(const char *port)							asm("MFHSTVPT");
+
+#endif /* HOSTPARSE_H */

--- a/project.toml
+++ b/project.toml
@@ -78,5 +78,14 @@ name = "TSTABND"
 sources = ["test/host/tstabnd.c"]
 norent = true
 
+# TSTHOST: #260 — a Host header with no name in front of the colon parsed as
+# success with an empty string, so /zosmf/info's fallback never ran. Portable C
+# (test-host); the TU #includes src/hostparse.c so it drives the real parser
+# infoapi.c calls — do not list hostparse.c here.
+[[test]]
+name = "TSTHOST"
+sources = ["test/host/tsthost.c"]
+norent = true
+
 [release]
 version_files = ["VERSION"]

--- a/src/hostparse.c
+++ b/src/hostparse.c
@@ -1,0 +1,102 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "hostparse.h"
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'parse_host_name'");
+#endif
+int
+parse_host_name(const char *value, char *outHost, size_t outSize)
+{
+	const char *colon;
+	size_t hostLen;
+
+	if (!value || !outHost || outSize == 0) {
+		return -1;
+	}
+
+	colon = strchr(value, ':');
+	hostLen = colon ? (size_t)(colon - value) : strlen(value);
+
+	/* No name at all -- ":8080", or the ":::garbage:::" a broken client sends.
+	   This used to return 0 with an empty string, which looked like success,
+	   so the caller's fallback to the default host never ran and the client
+	   got "zosmf_hostname":"" (issue #260). */
+	if (hostLen == 0) {
+		return -3;
+	}
+
+	if (hostLen >= outSize) {
+		return -2;
+	}
+
+	strncpy(outHost, value, hostLen);
+	outHost[hostLen] = '\0';
+
+	return 0;
+}
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'parse_port_string'");
+#endif
+int
+parse_port_string(const char *value, char *outPort, size_t outSize)
+{
+	const char *colon;
+	const char *portStr;
+
+	if (!value || !outPort || outSize == 0) {
+		return -1;
+	}
+
+	/* No port, or a colon with nothing behind it: not an error, the scheme
+	   implies the port (RFC 7230 5.4). The caller supplies the default. */
+	colon = strchr(value, ':');
+	if (!colon) {
+		outPort[0] = '\0';
+		return 0;
+	}
+
+	portStr = colon + 1;
+	if (*portStr == '\0') {
+		outPort[0] = '\0';
+		return 0;
+	}
+
+	if (strlen(portStr) + 1 > outSize) {
+		return -2;
+	}
+
+	strncpy(outPort, portStr, outSize - 1);
+	outPort[outSize - 1] = '\0';
+
+	return 0;
+}
+
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'validate_port'");
+#endif
+int
+validate_port(const char *port)
+{
+	const char *p;
+	long value;
+
+	if (!port || !*port) {
+		return -1;
+	}
+
+	for (p = port; *p; p++) {
+		if (*p < '0' || *p > '9') {
+			return -1;
+		}
+	}
+
+	value = atol(port);
+	if (value < 1 || value > 65535) {
+		return -1;
+	}
+
+	return 0;
+}

--- a/src/infoapi.c
+++ b/src/infoapi.c
@@ -1,5 +1,6 @@
 #include <string.h>
 
+#include "hostparse.h"
 #include "infoapi.h"
 #include "common.h"
 #include "json.h"
@@ -20,9 +21,6 @@
 // private function prototypes
 //
 
-static int parse_host_name(const char *value, char *outHost, size_t outSize);
-static int parse_port_string(const char *value, char *outPort, size_t outSize);
-static int validate_port(const char *port);
 static void default_port(Session *session, char *outPort, size_t outSize);
 
 //
@@ -53,7 +51,12 @@ infoHandler(Session *session)
 		   nothing at all and dropping the connection (issue #175). Fall back
 		   silently and still answer 200 -- the client sent the header, so the
 		   operator has nothing to act on, and a probing client would repeat
-		   the message on every poll (issue #201). */
+		   the message on every poll (issue #201).
+
+		   This fallback is only as good as the parser's honesty about
+		   failing: a value with no host name in front of the colon used to
+		   come back as success plus an empty string, so this branch never ran
+		   and the client got "zosmf_hostname":"" (issue #260). */
 		if (parse_host_name(value, hostname, sizeof(hostname)) != 0) {
 			strcpy(hostname, DEFAULT_HOST);
 		}
@@ -107,118 +110,6 @@ quit:
 // private functions
 //
 
-/**
- * Extracts the hostname from a host:port string
- *
- * @param value Input string in format "hostname:port" or just "hostname"
- * @param outHost Buffer to store the extracted hostname
- * @param outSize Size of the outHost buffer
- * @return 0 on success, -1 if parameters are invalid, -2 if outHost buffer is too small
- */
-__asm__("\n&FUNC	SETC 'parse_host_name'");
-static int 
-parse_host_name(const char *value, char *outHost, size_t outSize)
-{
-    if (!value || !outHost || outSize == 0) {
-        return -1;
-    }
-
-    const char *colon = strchr(value, ':');
-    size_t hostLen = 0;
-
-    if (colon) {
-        hostLen = (size_t)(colon - value);
-    } else {
-        hostLen = strlen(value);
-    }
-
-    if (hostLen >= outSize) {
-        return -2; 
-    }
-
-    strncpy(outHost, value, hostLen);
-    outHost[hostLen] = '\0';
-
-    return 0;
-}
-
-/**
- * Extracts the port from a host:port string
- *
- * @param value Input string in format "hostname:port" or just "hostname"
- * @param outPort Buffer to store the extracted port
- * @param outSize Size of the outPort buffer
- * @return 0 on success, -1 if parameters are invalid, -2 if outPort buffer is too small
- *         If no port is specified in the input string, outPort will be empty
- */
-__asm__("\n&FUNC	SETC 'parse_port_string'");
-static int
-parse_port_string(const char *value, char *outPort, size_t outSize)	
-{
-	if (!value || !outPort || outSize == 0) {
-        return -1;
-    }
-
-    const char *colon = strchr(value, ':');
-    if (!colon) {
-        if (outSize > 0) {
-            outPort[0] = '\0';
-        }
-        return 0; 
-    }
-
-    const char *portStr = colon + 1;
-
-    if (*portStr == '\0') {
-        if (outSize > 0) {
-            outPort[0] = '\0';
-        }
-        return 0;
-    }
-
-    size_t needed = strlen(portStr) + 1; /* +1 for null termination */
-    if (needed > outSize) {
-        return -2; /* outPort buffer too small */
-    }
-
-    strncpy(outPort, portStr, outSize - 1);
-    outPort[outSize - 1] = '\0';
-
-    return 0;
-}
-
-/**
- * Validates a port string
- * Checks if the port is a valid number between 1 and 65535
- *
- * @param port Port string to validate
- * @return 0 if valid, -1 if invalid
- */
-__asm__("\n&FUNC	SETC 'validate_port'");
-static int
-validate_port(const char *port)
-{
-    if (!port || !*port) {
-        return -1;
-    }
-
-    // Check if all characters are digits
-    const char *p = port;
-    while (*p) {
-        if (*p < '0' || *p > '9') {
-            return -1;
-        }
-        p++;
-    }
-
-    // Convert to number and validate range
-    long value = atol(port);
-    if (value < 1 || value > 65535) {
-        return -1;
-    }
-
-    return 0;
-}
 
 /**
  * Determines the port for a Host header that carries none

--- a/test/host/tsthost.c
+++ b/test/host/tsthost.c
@@ -1,0 +1,168 @@
+/*
+ * tsthost.c - #260 regression: splitting a Host header into host name and port.
+ *
+ * /zosmf/info echoes the host and port back so the client can build
+ * self-referential URLs. The header is client-supplied and has now broken the
+ * endpoint twice:
+ *
+ *   #175  an odd Host made the handler send nothing and drop the connection
+ *   #260  a Host with no name in front of the colon (":8080", ":::garbage:::")
+ *         parsed as SUCCESS with an empty string, so the caller's fallback to
+ *         DEFAULT_HOST never ran and the client got "zosmf_hostname":""
+ *
+ * The contract the caller depends on, and the one this test pins down: a
+ * non-zero return means the output is unusable. Returning 0 with an empty host
+ * name is worse than failing, because it looks like it worked.
+ *
+ * ====================================================================
+ * This test drives the REAL parser: src/hostparse.c is #included below.
+ * infoapi.c itself cannot compile on the host (it pulls in the httpd
+ * session headers), which is why the parsing lives in its own TU.
+ * ====================================================================
+ *
+ * Runs on host via `make test-host`.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include <mbtcheck.h>
+
+#include "../../src/hostparse.c"
+
+/* The buffer sizes infoapi.c uses, so the -2 cases are the real ones. */
+#define HOSTBUF 256
+#define PORTBUF 6      /* max port 65535 = 5 digits + nul */
+
+static char msg[160];
+
+/* Parse `value` and assert both the return code and, on success, the output.
+   The buffer is poisoned first, so a parser that returns 0 without writing
+   anything fails here rather than reading as success -- which is exactly the
+   shape of #260. */
+static void
+check_host(const char *value, int want_rc, const char *want_host)
+{
+	char buf[HOSTBUF];
+	int rc;
+
+	memset(buf, '@', sizeof(buf));
+	buf[sizeof(buf) - 1] = '\0';
+
+	rc = parse_host_name(value, buf, sizeof(buf));
+	sprintf(msg, "parse_host_name(\"%s\") returns %d", value, want_rc);
+	CHECK_EQ(rc, want_rc, msg);
+
+	if (want_rc == 0) {
+		sprintf(msg, "parse_host_name(\"%s\") yields \"%s\"", value, want_host);
+		CHECK(strcmp(buf, want_host) == 0, msg);
+	}
+}
+
+static void
+check_port(const char *value, int want_rc, const char *want_port)
+{
+	char buf[PORTBUF];
+	int rc;
+
+	memset(buf, '@', sizeof(buf));
+	buf[sizeof(buf) - 1] = '\0';
+
+	rc = parse_port_string(value, buf, sizeof(buf));
+	sprintf(msg, "parse_port_string(\"%s\") returns %d", value, want_rc);
+	CHECK_EQ(rc, want_rc, msg);
+
+	if (want_rc == 0) {
+		sprintf(msg, "parse_port_string(\"%s\") yields \"%s\"",
+			value, want_port);
+		CHECK(strcmp(buf, want_port) == 0, msg);
+	}
+}
+
+int
+main(void)
+{
+	char small[4];
+
+	printf("\n--- #260: a Host with no name must FAIL, not succeed empty ---\n");
+
+	/* Each of these carries no host name. Before the fix they returned 0
+	   with an empty string, and the caller read that as success. */
+	check_host(":8080",         -3, NULL);
+	check_host(":",             -3, NULL);
+	check_host(":::garbage:::", -3, NULL);
+
+	printf("\n--- ordinary values ---\n");
+
+	check_host("example.org:8080", 0, "example.org");
+	check_host("example.org",      0, "example.org");
+	check_host("mvsdev.lan:1080",  0, "mvsdev.lan");
+	check_host("127.0.0.1:8080",   0, "127.0.0.1");
+
+	printf("\n--- bad arguments and short buffers ---\n");
+
+	CHECK_EQ(parse_host_name(NULL, small, sizeof(small)), -1,
+		"parse_host_name with a null value");
+	CHECK_EQ(parse_host_name("example.org", NULL, HOSTBUF), -1,
+		"parse_host_name with a null buffer");
+	CHECK_EQ(parse_host_name("example.org", small, 0), -1,
+		"parse_host_name with outSize 0");
+	CHECK_EQ(parse_host_name("example.org", small, sizeof(small)), -2,
+		"parse_host_name into a buffer that is too small");
+	CHECK_EQ(parse_host_name("abcd", small, sizeof(small)), -2,
+		"parse_host_name with hostLen == outSize still fails");
+	CHECK_EQ(parse_host_name("abc", small, sizeof(small)), 0,
+		"parse_host_name with hostLen == outSize - 1 fits");
+
+	printf("\n--- ports ---\n");
+
+	check_port("example.org:8080", 0, "8080");
+	check_port("example.org:80",   0, "80");
+	check_port("example.org",      0, "");   /* no port: scheme implies it */
+	check_port("example.org:",     0, "");   /* colon, nothing behind it   */
+	check_port(":8080",            0, "8080");
+	CHECK_EQ(parse_port_string(NULL, small, sizeof(small)), -1,
+		"parse_port_string with a null value");
+	/* 6 digits + nul does not fit PORTBUF; the caller then falls back */
+	check_port("example.org:999999", -2, NULL);
+
+	printf("\n--- port validation ---\n");
+
+	CHECK_EQ(validate_port("8080"),   0, "8080 is a valid port");
+	CHECK_EQ(validate_port("1"),      0, "1 is a valid port");
+	CHECK_EQ(validate_port("65535"),  0, "65535 is a valid port");
+	CHECK_EQ(validate_port("0"),     -1, "0 is not a valid port");
+	CHECK_EQ(validate_port("65536"), -1, "65536 is out of range");
+	CHECK_EQ(validate_port("99999"), -1, "99999 is out of range");
+	CHECK_EQ(validate_port("80a"),   -1, "a non-digit is not a valid port");
+	CHECK_EQ(validate_port("-80"),   -1, "a negative port is not valid");
+	CHECK_EQ(validate_port(""),      -1, "an empty port is not valid");
+	CHECK_EQ(validate_port(NULL),    -1, "a null port is not valid");
+
+	printf("\n--- the /zosmf/info path, as infoapi.c runs it ---\n");
+
+	/* A junk Host must leave BOTH outputs on their fallbacks. This is the
+	   combination #260 got wrong: the port fell back correctly while the
+	   host name came back empty. */
+	{
+		char host[HOSTBUF];
+		char port[PORTBUF];
+		int used_default_host = 0;
+
+		strcpy(host, "127.0.0.1");      /* DEFAULT_HOST */
+		if (parse_host_name(":::garbage:::", host, sizeof(host)) != 0) {
+			strcpy(host, "127.0.0.1");
+			used_default_host = 1;
+		}
+		if (parse_port_string(":::garbage:::", port, sizeof(port)) != 0) {
+			port[0] = '\0';
+		}
+
+		CHECK(used_default_host,
+			"a junk Host falls back to the default host name");
+		CHECK(host[0] != '\0', "zosmf_hostname is never reported empty");
+		CHECK(validate_port(port) != 0,
+			"a junk Host leaves the port for the scheme default");
+	}
+
+	return mbt_test_summary("TSTHOST");
+}

--- a/tests/curl-info.sh
+++ b/tests/curl-info.sh
@@ -170,6 +170,20 @@ info -H "Host: ${TEST_HOST}" -H "X-Forwarded-Port: nonsense"
 assert_http_status "200" "$CODE" "invalid X-Forwarded-Port"
 assert_json_field "$BODY" ".zosmf_port" "80" "invalid X-Forwarded-Port is ignored"
 
+# A Host with no name in front of the colon used to parse as SUCCESS with an
+# empty string, so the handler's fallback to DEFAULT_HOST never ran and the
+# client got "zosmf_hostname":"" (issue #260). The port fell back correctly in
+# the same request, which is what hid it.
+info -H "Host: :::garbage:::"
+assert_http_status "200" "$CODE" "Host with no host name"
+assert_json_field "$BODY" ".zosmf_hostname" "127.0.0.1" "hostname falls back to the default"
+assert_json_field "$BODY" ".zosmf_port" "80" "unparsable port falls back to 80"
+
+info -H "Host: :8080"
+assert_http_status "200" "$CODE" "Host that is only a port"
+assert_json_field "$BODY" ".zosmf_hostname" "127.0.0.1" "hostname falls back to the default"
+assert_json_field "$BODY" ".zosmf_port" "8080" "the port is still taken from the header"
+
 # =========================================================================
 # 5. The rest of the payload
 # =========================================================================


### PR DESCRIPTION
Fixes #260.

## The bug

`parse_host_name()` took everything before the first colon and called it a
success — including when that was nothing:

```
$ curl -s -u U:P -H 'Host: :::garbage:::' http://mvsdev:8080/zosmf/info
{"zosmf_hostname":"","zosmf_port":"80", ...}
```

`hostLen` is 0, `strncpy` copies nothing, the function returns 0. So the
caller's fallback never ran:

```c
if (parse_host_name(value, hostname, sizeof(hostname)) != 0) {
    strcpy(hostname, DEFAULT_HOST);
}
```

The port fell back correctly in the same request, which is what made it look
like the header had been handled.

Same failure class as #175: `/zosmf/info` is the unauthenticated liveness probe
every client calls first, so a header quirk has to degrade to the documented
defaults rather than to an empty answer. The contract a fallback depends on is
that the parser is honest about failing — returning 0 with an empty string is
worse than failing, because it looks like it worked.

## The fix

A value with no host name returns `-3` and leaves the buffer untouched. One
line.

## Why the diff is bigger than one line

`infoapi.c` cannot compile on the host — it pulls in the httpd session headers
— so there was no way to test this. This parser has now produced two issues, so
the three pure string functions follow `reclines.c` and `jclines.c` into their
own TU (`src/hostparse.c` + `include/hostparse.h`), and `test/host/tsthost.c`
`#include`s it to drive the real code. `default_port()` stays in `infoapi.c`,
since it needs the request to read the scheme.

**The test reproduces the bug**, which is the point of it — with the one-line
fix reverted, `TSTHOST` fails 5 of 42:

```
TSTHOST    FAIL rc=1    37 pass / 5 fail     <- fix removed
TSTHOST    ok  rc=0     42 pass / 0 fail     <- fix in place
```

## Verified

Host build clean (`-Wall -Werror`), `make test-host` 127 assertions across 5
suites, 0 fail.

Deployed to mvsdev (`/zosmf/test?fn=version` = `cb9f616` = HEAD at deploy) and
measured:

| `Host:` | `zosmf_hostname` | `zosmf_port` |
|---|---|---|
| `:::garbage:::` | `127.0.0.1` (was `""`) | `80` |
| `:8080` | `127.0.0.1` (was `""`) | `8080` |
| `mvsdev.lan:99999` | `mvsdev.lan` | `80` |
| `mvsdev.lan` | `mvsdev.lan` | `80` |
| `mvsdev.lan:8080` | `mvsdev.lan` | `8080` |
| *(header absent)* | `127.0.0.1` | `8080` |

The two halves fall back independently — `Host: :8080` has no usable name but a
perfectly good port, and keeps it.

Regression against the live stand, all green:

| suite | result |
|---|---|
| `curl-info.sh` | 40 passed, 0 failed (was 34; +6 for #260) |
| `curl-datasets.sh` | 131 passed, 0 failed |
| `curl-jobs.sh` | 98 passed, 0 failed, 1 skipped |
| `curl-uss.sh` | 64 passed, 0 failed, 1 skipped |
| `curl-console.sh` | 64 passed, 0 failed |
| `curl-auth.sh` | 14 passed, 0 failed |
| `curl-binary.sh` | 10 passed, 0 failed |

`docs/endpoints/info.md` documents the host-name fallback alongside the port
table.