### PR TITLE
Answer 206 Partial content when X-IBM-Max-Items truncates a listing

### DIFF
--- a/docs/endpoints/datasets/list.md
+++ b/docs/endpoints/datasets/list.md
@@ -19,10 +19,17 @@ GET
   itself, and one equal to the prefix sorts before it (issue #240).
 
 ## Request Headers
-- `X-IBM-Max-Items` (optional): Maximum number of items to return. Value `0` means unlimited (default behavior). When the result set is truncated, `moreRows` is set to `true`.
+- `X-IBM-Max-Items` (optional): Maximum number of items to return. Value `0` means unlimited (default behavior). When the result set is truncated, `moreRows` is set to `true` and the status is **206** rather than 200.
 
 ## Response
-On successful completion, this request returns HTTP status code 200 (OK) and a JSON object:
+A complete listing returns HTTP status code 200 (OK). A listing cut short by
+`X-IBM-Max-Items` returns **206 (Partial content)** — the body is identical in
+shape, so a client that reads `moreRows` needs no change, but one that keys off
+the status can now tell a page from a whole list. The header being present is
+not what makes the response partial: a limit no listing reaches is a complete
+answer and stays 200.
+
+Both carry a JSON object:
 
 ```json
 {

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -38,7 +38,13 @@ or with explicit volume:
 - `X-IBM-Max-Items` (optional): Maximum number of members to return. Omitted or `0` returns all of them.
 
 ## Response
-On successful completion, this request returns HTTP status code 200 (OK) and a JSON object:
+A complete listing returns HTTP status code 200 (OK). A listing cut short by
+`X-IBM-Max-Items` returns **206 (Partial content)** — same body, so a client
+reading `moreRows` needs no change, but the status alone now distinguishes a
+page from a whole directory. A limit no directory reaches is a complete answer
+and stays 200.
+
+Both carry a JSON object:
 
 ```json
 {

--- a/docs/endpoints/uss/list.md
+++ b/docs/endpoints/uss/list.md
@@ -22,7 +22,7 @@ GET /zosmf/restfiles/fs?path=<filepath>
 |-------------------|----------|---------|-------------|
 | `X-IBM-Max-Items` | No       | 1000    | Maximum items to return. 0 = unlimited |
 
-## Response (200 OK)
+## Response (200 OK, or 206 when truncated by `X-IBM-Max-Items`)
 
 ```json
 {
@@ -64,6 +64,23 @@ When `X-IBM-Max-Items` is set and the directory contains more entries:
 - `returnedRows` = number of items in the response
 - `totalRows` = total entries in the directory (excluding `.` and `..`)
 - `moreRows` = `true` when results were truncated
+- the status is **206 (Partial content)** rather than 200
+
+A limit no directory reaches is a complete listing and stays 200 — the header
+being present is not what makes the response partial.
+
+**The default limit does not produce 206.** With no `X-IBM-Max-Items` the
+handler still caps the listing at 1000 entries and still sets `moreRows`, but
+that limit is the server's, not the client's, and z/OSMF ties 206 to a request
+that *contained* the header. A directory of more than 1000 entries listed
+without the header therefore answers 200 with `moreRows: true`.
+
+## Response Status
+
+| Status | Condition |
+|--------|-----------|
+| 200    | Complete listing (also a listing capped by the 1000-entry default) |
+| 206    | Listing cut short by `X-IBM-Max-Items` |
 
 ## Error Responses
 

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include <clibary.h>
 #include <clibwto.h>
 #include <cliblist.h>
@@ -1992,8 +1993,13 @@ int memberListHandler(Session *session)
 	   holds one 256-byte block, not a member array.  fopen() again rather than
 	   rewind() -- a backwards seek on a record-mode handle reopens the data set
 	   inside __fseek() anyway, by a DD name it reconstructs itself, so a second
-	   open is the same I/O with none of the guesswork. */
-	if (maxitems > 0) {
+	   open is the same I/O with none of the guesswork.
+
+	   The upper guard keeps maxitems + 1 from wrapping: a negative or absurd
+	   X-IBM-Max-Items arrives here as UINT_MAX, the bound would come out 0 --
+	   which member_scan() reads as "no bound" -- and both passes would then run
+	   the directory end to end.  No page that large can be truncated anyway. */
+	if (maxitems > 0 && maxitems < UINT_MAX) {
 		fp = fopen(dsname, "r,record");
 		if (!fp) {
 			rc = sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -934,6 +934,32 @@ dslist_cmp(const void *a, const void *b)
 	return strcmp((*pa)->dsn, (*pb)->dsn);
 }
 
+/* Does this entry belong to the page the client asked for?
+**
+** start= is inclusive: everything sorting before it belongs to a page the
+** client already has.  Unless the value did not fit -- then start_key is its
+** first 44 characters, no cataloged name can be the value itself, and strcmp()
+** puts a name equal to the prefix before it (the prefix ends in NUL, which
+** sorts below the character the value continues with).  Drop it too (#240).
+**
+** Both passes below ask this one question: the counting pass turns the answer
+** into the status code, the emit pass into the body.  A second copy of the rule
+** would let 206 and moreRows disagree on exactly the names #240 is about. */
+__asm__("\n&FUNC    SETC 'dslist_in_page'");
+static int
+dslist_in_page(const DSLIST *ds, const char *start_key, int have_start,
+               int start_after)
+{
+	int cmp;
+
+	if (!ds) return 0;
+	if (!have_start) return 1;
+
+	cmp = strcmp(ds->dsn, start_key);
+
+	return !(cmp < 0 || (start_after && cmp == 0));
+}
+
 int datasetListHandler(Session *session)
 {
 	unsigned	rc		= 0;
@@ -943,6 +969,7 @@ int datasetListHandler(Session *session)
 	unsigned	maxitems	= 0;
 	unsigned	emitted		= 0;
 	unsigned	eligible	= 0;
+	int		truncated	= 0;
 
 	char		*method		= NULL;
 	char		*path		= NULL;
@@ -1097,11 +1124,31 @@ int datasetListHandler(Session *session)
 	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
 	if (maxitems_str) maxitems = (unsigned) atoi(maxitems_str);
 
+	/* Count the page before writing the status line.  A listing cut short by
+	** X-IBM-Max-Items answers 206 Partial content, and the status is the one
+	** part of the response that cannot be corrected once the header is out --
+	** moreRows below is decided by the same numbers, but it is decided last
+	** (#249).  Only the entries at or after start= are still fetchable, so
+	** they are what "more to come" counts.  The array is in storage and
+	** sorted already: this pass costs no I/O. */
+	if (dslist) {
+		count = array_count(&dslist);
+
+		for (i = 0; i < count; i++) {
+			if (dslist_in_page(dslist[i], start_key, have_start,
+					start_after)) {
+				eligible++;
+			}
+		}
+	}
+
+	truncated = (maxitems > 0 && eligible > maxitems);
+
 	session->headers_sent = 1;
-	if ((rc = http_resp(session->httpc,200)) < 0) goto quit;
+	if ((rc = http_resp(session->httpc, truncated ? 206 : 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;	
+	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
@@ -1110,30 +1157,15 @@ int datasetListHandler(Session *session)
 
 	if (!dslist) goto end;
 
-	count = array_count(&dslist);
-
 	for(i=0; i < count; i++) {
 		DSLIST *ds = dslist[i];
 
-		if (!ds) continue;
+		if (!dslist_in_page(ds, start_key, have_start, start_after)) continue;
 
-		/* start= is inclusive: everything sorting before it belongs to a
-		** page the client already has.  Unless the value did not fit --
-		** then start_key is its first 44 characters, no cataloged name
-		** can be the value itself, and strcmp() puts a name equal to the
-		** prefix before it (the prefix ends in NUL, which sorts below the
-		** character the value continues with).  Drop it too (#240). */
-		if (have_start) {
-			int cmp = strcmp(ds->dsn, start_key);
-
-			if (cmp < 0 || (start_after && cmp == 0)) continue;
-		}
-
-		/* keep counting past the page limit -- moreRows has to tell "page
-		** full" from "list exhausted", and only the entries at or after
-		** start= are still fetchable */
-		eligible++;
-		if (maxitems > 0 && emitted >= maxitems) continue;
+		/* the page is full and the counting pass already knows what is
+		** left behind it, so there is nothing to be gained from walking
+		** the rest of the array */
+		if (maxitems > 0 && emitted >= maxitems) break;
 
 		if (first) {
 			/* first time we're printing this '{' so no ',' needed */
@@ -1714,21 +1746,170 @@ json_escape_member(const unsigned char *raw, unsigned rawlen,
 	out[o] = '\0';
 }
 
+/* Walk a PDS directory once, applying start= and pattern to every entry.
+**
+** The walk stops as soon as `bound` matching members have been seen (bound 0
+** means no limit) and returns that count, so a caller can learn "the page is
+** full and at least one member is behind it" without reading the 23000 entries
+** of SYS1.SMPCDS to find out.  With `emit` set the matches are written as JSON
+** objects on the way past and the count is what was written.  Returns -1 if a
+** write failed.
+**
+** Both passes of memberListHandler() come through here.  The counting pass
+** decides the status code and the emit pass decides the body, so the rules the
+** two apply -- the blank trim of #154, the start= prefix of #240, pattern
+** before cap -- have to be one set of rules.  Kept as two copies they would
+** drift, and 206 and moreRows would then disagree about exactly the entries
+** those issues are about. */
+__asm__("\n&FUNC    SETC 'member_scan'");
+static int
+member_scan(Session *session, FILE *fp, const char *start_key, int start_after,
+            const char *pattern_key, int have_pattern, unsigned bound, int emit)
+{
+	char		blk[PDS_DIR_BLKSIZE];
+	unsigned	seen		= 0;
+	unsigned	first		= 1;
+	int		skipping	= (start_key != NULL);
+	int		at_end		= 0;
+
+	while (!at_end) {
+		int	len;
+		int	used;
+		int	pos;
+
+		len = fread(blk, 1, sizeof(blk), fp);
+		if (len <= 0) break;
+
+		used = (int) *(unsigned short *) blk;
+
+		/* the block says how much of it is in use -- never take that at face
+		   value.  A short read or a damaged block would otherwise walk us off
+		   the end of blk[], the same class of defect as the MTT length in
+		   #176.  Clamp to what we actually read. */
+		if (used > len) used = len;
+
+		/* PDS_DIR_ENT_FIXED bytes must be present before the indicator byte
+		   at +11 can be read */
+		for (pos = 2; pos + PDS_DIR_ENT_FIXED <= used; ) {
+			int	size;
+			size_t	nlen;
+			char	member[MEMBER_ESC_SIZE];
+
+			if (memcmp(&blk[pos],
+			           "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8) == 0) {
+				at_end = 1;
+				break;
+			}
+
+			size = PDS_DIR_ENT_FIXED
+			     + ((blk[pos + 11] & PDS_DIR_UDATA_MASK) * 2);
+
+			/* The directory holds the name blank padded to eight
+			   bytes; z/OSMF reports it without the padding, and a
+			   client that builds "dsn(member)" from what it was
+			   given otherwise asks for a member with a trailing
+			   blank in its name (#154).  The trimmed length serves
+			   the pattern match as well -- a name is what the
+			   client sees, so both have to agree on where it ends.
+			   A directory may hold arbitrary bytes rather than a
+			   name, and one of those ending in 0x40 is trimmed
+			   too; such an entry is \uXXXX escaped and no client
+			   can address it either way. */
+			nlen = MAX_MEMBER_NAME;
+			while (nlen > 0 && blk[pos + nlen - 1] == ' ') {
+				nlen--;
+			}
+
+			/* Skip up to the start member.  This has to happen before
+			   the cap below: otherwise the skipped entries eat the
+			   page budget and the response is an empty items array with
+			   moreRows true -- a different-looking bug.  The directory
+			   is sorted, so once we are past the key there is nothing
+			   left to compare and the flag stays off.
+
+			   start= names the first member of the page, so the match
+			   is kept -- unless the value was too long for a member
+			   name and start_key is only its first eight characters.
+			   No member can then be the value itself, and the one
+			   equal to the prefix sorts before it: the eight name
+			   bytes run out and the value carries on, and every
+			   character a client can put there sorts above the blank
+			   the name is padded with.  So that one goes as well, and
+			   the page starts after the prefix rather than at it
+			   (#240). */
+			if (skipping) {
+				int cmp = memcmp(&blk[pos], start_key,
+						MAX_MEMBER_NAME);
+
+				if (cmp < 0 || (start_after && cmp == 0)) {
+					pos += size;
+					continue;
+				}
+				skipping = 0;
+			}
+
+			/* Filter, then cap -- for the same reason the skip above
+			   comes first: a member the client did not ask for must not
+			   consume a slot of the page, or a narrow pattern answers
+			   with an empty items array and moreRows true.  Ordering
+			   also means moreRows counts matches, not directory
+			   entries. */
+			if (have_pattern) {
+				if (!member_match(&blk[pos], nlen, pattern_key)) {
+					pos += size;
+					continue;
+				}
+			}
+
+			seen++;
+
+			if (emit) {
+				json_escape_member((const unsigned char *) &blk[pos],
+					(unsigned) nlen,
+					httpx->xlate_cp037->etoa, member, sizeof(member));
+
+				if (first) {
+					/* first time we're printing this '{' so no ',' needed */
+					if (http_printf(session->httpc, "    {\n") < 0) return -1;
+					first = 0;
+				} else {
+					/* all other times we need a ',' before the '{' */
+					if (http_printf(session->httpc, "   ,{\n") < 0) return -1;
+				}
+
+				// TODO: extract user data from the entry, if X-IBM-Attributes == base
+				if (http_printf(session->httpc, "      \"member\": \"%s\"\n", member) < 0) return -1;
+				if (http_printf(session->httpc, "    }\n") < 0) return -1;
+			}
+
+			/* the page is full: for the emit pass there is nothing more
+			   to write, and for the counting pass the one match past it
+			   is the whole answer */
+			if (bound > 0 && seen >= bound) {
+				at_end = 1;
+				break;
+			}
+
+			pos += size;
+		}
+	}
+
+	return (int) seen;
+}
+
 int memberListHandler(Session *session)
 {
 	unsigned	rc		= 0;
 	unsigned	emitted		= 0;
-	unsigned	first		= 1;
 	unsigned	maxitems	= 0;
-	int		more		= 0;
-	int		at_end		= 0;
+	int		truncated	= 0;
+	int		scanned		= 0;
 
 	char		*method		= NULL;
 	char		*path		= NULL;
 	char		*verb		= NULL;
 
 	FILE		*fp		= NULL;
-	char		blk[PDS_DIR_BLKSIZE];
 
 	char 		*dsname		= NULL;
 
@@ -1800,6 +1981,43 @@ int memberListHandler(Session *session)
 		goto quit;
 	}
 
+	/* Counting pass.  A listing cut short by X-IBM-Max-Items answers 206
+	   Partial content, and the status line is written before the first member
+	   is -- so whether the page is full has to be settled before the directory
+	   is walked for the client (#249).  The walk stops one match past the page,
+	   so what it costs is a page and not a directory, and it is only paid when
+	   the client asked for a limit at all.
+
+	   Reading the directory twice is affordable only because of #212: the walk
+	   holds one 256-byte block, not a member array.  fopen() again rather than
+	   rewind() -- a backwards seek on a record-mode handle reopens the data set
+	   inside __fseek() anyway, by a DD name it reconstructs itself, so a second
+	   open is the same I/O with none of the guesswork. */
+	if (maxitems > 0) {
+		fp = fopen(dsname, "r,record");
+		if (!fp) {
+			rc = sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+					CATEGORY_UNEXPECTED, RC_ERROR, REASON_DATASET_NOT_FOUND,
+					ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
+			goto quit;
+		}
+		session_register_file(session, fp);
+
+		scanned = member_scan(session, fp, skipping ? start_key : NULL,
+				start_after, pattern_key, have_pattern,
+				maxitems + 1, 0);
+
+		session_fclose(session, fp);
+		fp = NULL;
+
+		if (scanned < 0) {
+			rc = (unsigned) scanned;
+			goto quit;
+		}
+
+		truncated = ((unsigned) scanned > maxitems);
+	}
+
 	/* Walk the directory and emit as we go.  This used to call __listpd(),
 	   which builds the complete member array in storage first: on a data set
 	   like SYS1.SMPCDS (~23000 members) that exhausts the region, abends S878,
@@ -1824,138 +2042,32 @@ int memberListHandler(Session *session)
 	session_register_file(session, fp);
 
 	session->headers_sent = 1;
-	if ((rc = http_resp(session->httpc,200)) < 0) goto quit;
+	if ((rc = http_resp(session->httpc, truncated ? 206 : 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;	
+	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
 	if ((rc = http_printf(session->httpc, "{\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"items\": [\n")) < 0) goto quit;
 
-	while (!at_end) {
-		int	len;
-		int	used;
-		int	pos;
-
-		len = fread(blk, 1, sizeof(blk), fp);
-		if (len <= 0) break;
-
-		used = (int) *(unsigned short *) blk;
-
-		/* the block says how much of it is in use -- never take that at face
-		   value.  A short read or a damaged block would otherwise walk us off
-		   the end of blk[], the same class of defect as the MTT length in
-		   #176.  Clamp to what we actually read. */
-		if (used > len) used = len;
-
-		/* PDS_DIR_ENT_FIXED bytes must be present before the indicator byte
-		   at +11 can be read */
-		for (pos = 2; pos + PDS_DIR_ENT_FIXED <= used; ) {
-			int	size;
-			size_t	nlen;
-			char	member[MEMBER_ESC_SIZE];
-
-			if (memcmp(&blk[pos],
-			           "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8) == 0) {
-				at_end = 1;
-				break;
-			}
-
-			size = PDS_DIR_ENT_FIXED
-			     + ((blk[pos + 11] & PDS_DIR_UDATA_MASK) * 2);
-
-			/* The directory holds the name blank padded to eight
-			   bytes; z/OSMF reports it without the padding, and a
-			   client that builds "dsn(member)" from what it was
-			   given otherwise asks for a member with a trailing
-			   blank in its name (#154).  The trimmed length serves
-			   the pattern match as well -- a name is what the
-			   client sees, so both have to agree on where it ends.
-			   A directory may hold arbitrary bytes rather than a
-			   name, and one of those ending in 0x40 is trimmed
-			   too; such an entry is \uXXXX escaped and no client
-			   can address it either way. */
-			nlen = MAX_MEMBER_NAME;
-			while (nlen > 0 && blk[pos + nlen - 1] == ' ') {
-				nlen--;
-			}
-
-			/* Skip up to the start member.  This has to happen before
-			   the maxitems check: otherwise the skipped entries eat the
-			   page budget and the response is an empty items array with
-			   moreRows true -- a different-looking bug.  The directory
-			   is sorted, so once we are past the key there is nothing
-			   left to compare and the flag stays off.
-
-			   start= names the first member of the page, so the match
-			   is kept -- unless the value was too long for a member
-			   name and start_key is only its first eight characters.
-			   No member can then be the value itself, and the one
-			   equal to the prefix sorts before it: the eight name
-			   bytes run out and the value carries on, and every
-			   character a client can put there sorts above the blank
-			   the name is padded with.  So that one goes as well, and
-			   the page starts after the prefix rather than at it
-			   (#240). */
-			if (skipping) {
-				int cmp = memcmp(&blk[pos], start_key,
-						sizeof(start_key));
-
-				if (cmp < 0 || (start_after && cmp == 0)) {
-					pos += size;
-					continue;
-				}
-				skipping = 0;
-			}
-
-			/* Filter, then cap -- for the same reason the skip above
-			   comes first: a member the client did not ask for must not
-			   consume a slot of the page, or a narrow pattern answers
-			   with an empty items array and moreRows true.  Ordering
-			   also means moreRows counts matches, not directory
-			   entries. */
-			if (have_pattern) {
-				if (!member_match(&blk[pos], nlen, pattern_key)) {
-					pos += size;
-					continue;
-				}
-			}
-
-			if (maxitems > 0 && emitted >= maxitems) {
-				more = 1;
-				at_end = 1;
-				break;
-			}
-
-			json_escape_member((const unsigned char *) &blk[pos],
-				(unsigned) nlen,
-				httpx->xlate_cp037->etoa, member, sizeof(member));
-
-			if (first) {
-				/* first time we're printing this '{' so no ',' needed */
-				if ((rc = http_printf(session->httpc, "    {\n")) < 0) goto quit;
-				first = 0;
-			} else {
-				/* all other times we need a ',' before the '{' */
-				if ((rc = http_printf(session->httpc, "   ,{\n")) < 0) goto quit;
-			}
-
-			// TODO: extract user data from the entry, if X-IBM-Attributes == base
-			if ((rc = http_printf(session->httpc, "      \"member\": \"%s\"\n", member)) < 0) goto quit;
-			if ((rc = http_printf(session->httpc, "    }\n")) < 0) goto quit;
-
-			emitted++;
-			pos += size;
-		}
+	scanned = member_scan(session, fp, skipping ? start_key : NULL,
+			start_after, pattern_key, have_pattern, maxitems, 1);
+	if (scanned < 0) {
+		rc = (unsigned) scanned;
+		goto quit;
 	}
+	emitted = (unsigned) scanned;
 
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", emitted)) < 0) goto quit;
 	// TODO: add totalRows if X-IBM-Attributes has ',total'
+	/* the counting pass, not this one: the two walks are seconds apart on a
+	   large directory and a member added in between must not leave the body
+	   contradicting the status line */
 	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
-		more ? "true" : "false")) < 0) goto quit;
+		truncated ? "true" : "false")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;
 

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <time.h>
 #include <clibwto.h>
 #include <libufs.h>
@@ -338,8 +339,12 @@ int ussListHandler(Session *session)
 	   Only when the client set the header.  USS_LIST_DEFAULT_MAX_ITEMS
 	   truncates too, but that limit is ours, not the client's, and z/OSMF ties
 	   206 to "the request contained the X-IBM-Max-Items header".  Leaving the
-	   default alone also keeps every plain listing at one walk. */
-	if (have_maxitems && maxitems > 0) {
+	   default alone also keeps every plain listing at one walk.
+
+	   A negative or absurd value arrives here as UINT_MAX, which no directory
+	   can exceed: the counting pass could only walk the whole thing to prove
+	   nothing was truncated, so skip it. */
+	if (have_maxitems && maxitems > 0 && maxitems < UINT_MAX) {
 		while ((entry = ufs_dirread(dd)) != NULL) {
 			if (strcmp(entry->name, ".") == 0 ||
 				strcmp(entry->name, "..") == 0) {

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -293,6 +293,10 @@ int ussListHandler(Session *session)
 	unsigned maxitems = USS_LIST_DEFAULT_MAX_ITEMS;
 	unsigned emitted = 0;
 	unsigned total = 0;
+	unsigned counted = 0;
+	int have_maxitems = 0;
+	int truncated = 0;
+	int more = 0;
 	char *path = NULL;
 	char *maxitems_str = NULL;
 	UFS *ufs = NULL;
@@ -310,6 +314,7 @@ int ussListHandler(Session *session)
 	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
 	if (maxitems_str) {
 		maxitems = (unsigned) atoi(maxitems_str);
+		have_maxitems = 1;
 	}
 
 	// Open UFS session
@@ -324,9 +329,41 @@ int ussListHandler(Session *session)
 		return uss_stat_file(session, ufs, path);
 	}
 
+	/* Counting pass.  A listing cut short by X-IBM-Max-Items answers 206
+	   Partial content, and the status line goes out before the first entry is
+	   written -- so the page has to be measured up front (#249).  The walk
+	   stops one entry past the page and there is no ufs_dirrewind(), so it
+	   costs a close and a second open.
+
+	   Only when the client set the header.  USS_LIST_DEFAULT_MAX_ITEMS
+	   truncates too, but that limit is ours, not the client's, and z/OSMF ties
+	   206 to "the request contained the X-IBM-Max-Items header".  Leaving the
+	   default alone also keeps every plain listing at one walk. */
+	if (have_maxitems && maxitems > 0) {
+		while ((entry = ufs_dirread(dd)) != NULL) {
+			if (strcmp(entry->name, ".") == 0 ||
+				strcmp(entry->name, "..") == 0) {
+				continue;
+			}
+
+			counted++;
+			if (counted > maxitems) break;
+		}
+
+		truncated = (counted > maxitems);
+
+		ufs_dirclose(&dd);
+
+		// same fallback as the first open: the path may have become a file
+		dd = ufs_diropen(ufs, path, NULL);
+		if (!dd) {
+			return uss_stat_file(session, ufs, path);
+		}
+	}
+
 	// Directory listing — send response headers (streaming JSON)
 	session->headers_sent = 1;
-	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
+	if ((rc = http_resp(session->httpc, truncated ? 206 : 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
@@ -393,8 +430,14 @@ int ussListHandler(Session *session)
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %u,\n", emitted)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"totalRows\": %u,\n", total)) < 0) goto quit;
+	/* With the header in play the status line has already committed to an
+	   answer, so the body repeats it rather than recomputing it: the two walks
+	   are apart in time, and an entry created in between would otherwise leave
+	   a 206 standing next to moreRows false.  Without the header nothing was
+	   committed and this walk's own count is the better value. */
+	more = have_maxitems ? truncated : (maxitems > 0 && emitted < total);
 	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
-		(maxitems > 0 && emitted < total) ? "true" : "false")) < 0) goto quit;
+		more ? "true" : "false")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "}\n")) < 0) goto quit;
 

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -361,7 +361,10 @@ BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
-assert_http_status "200" "$HTTP_CODE" "list datasets (max-items=1)"
+# a listing cut short by X-IBM-Max-Items is partial content, not a complete
+# answer: a client keying off the status could not otherwise tell the two
+# apart (#249)
+assert_http_status "206" "$HTTP_CODE" "list datasets (max-items=1)"
 
 RETURNED=$(echo "$CONTENT" | jq '.returnedRows' 2>/dev/null) || RETURNED=0
 if [ "$RETURNED" -eq 1 ] 2>/dev/null; then
@@ -375,6 +378,22 @@ if [ "$MORE_ROWS" = "true" ]; then
 	pass "moreRows=true when truncated"
 else
 	fail "moreRows=true when truncated" "expected true, got $MORE_ROWS"
+fi
+
+# The other half of #249, and the half a "send 206 when max-items is set"
+# implementation would get wrong: the header alone does not make a response
+# partial. A limit nothing reaches is a complete listing and stays 200.
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
+	-H "X-IBM-Max-Items: 1000" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+if [ "$HTTP_CODE" = "200" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
+	pass "max-items above the row count stays 200"
+else
+	fail "max-items above the row count stays 200" \
+		"got HTTP $HTTP_CODE moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
 fi
 
 # --- List datasets (start=) ---
@@ -640,7 +659,7 @@ HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
 LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null)
 
-if [ "$HTTP_CODE" = "200" ] &&
+if [ "$HTTP_CODE" = "206" ] &&
    [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "2" ] &&
    [ "$(echo "$LIST" | head -1)" = "MBRC" ] &&
    [ "$(echo "$LIST" | sed -n 2p)" = "MBRF1" ] &&
@@ -717,7 +736,7 @@ CONTENT=$(echo "$BODY" | sed '$d')
 LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null |
 	tr '\n' ' ' | sed 's/ *$//')
 
-if [ "$HTTP_CODE" = "200" ] && [ "$LIST" = "MBRA MBRB" ] &&
+if [ "$HTTP_CODE" = "206" ] && [ "$LIST" = "MBRA MBRB" ] &&
    [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "2" ] &&
    [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "true" ]; then
 	pass "pattern= with max-items=2 fills the page with matches only"
@@ -843,7 +862,7 @@ else
 	HTTP_CODE=$(echo "$BODY" | tail -1)
 	CONTENT=$(echo "$BODY" | sed '$d')
 
-	if [ "$HTTP_CODE" = "200" ] &&
+	if [ "$HTTP_CODE" = "206" ] &&
 	   [ "$(echo "$CONTENT" | jq -r '.returnedRows')" = "10" ] &&
 	   [ "$(echo "$CONTENT" | jq -r '.items | length')" = "10" ] &&
 	   [ "$(echo "$CONTENT" | jq -r '.moreRows')" = "true" ]; then
@@ -851,6 +870,25 @@ else
 	else
 		fail "max-items=10 on ${BIG_PDS}" \
 			"got HTTP $HTTP_CODE returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows') moreRows=$(echo "$CONTENT" | jq -r '.moreRows')"
+	fi
+
+	# The counting pass walks the directory a second time, so this is where a
+	# large directory would show it: the page must still be the first 10
+	# members and the walk must still stop one match past them, not read
+	# 23000 entries twice. A timeout here is the regression.
+	START=$(date +%s)
+	BODY=$(curl -s -w '\n%{http_code}' -m 180 -u "$AUTH" -H 'X-IBM-Max-Items: 10' \
+		"${BASE_URL}/zosmf/restfiles/ds/${BIG_PDS}/member?start=A")
+	ELAPSED=$(( $(date +%s) - START ))
+	HTTP_CODE=$(echo "$BODY" | tail -1)
+	CONTENT=$(echo "$BODY" | sed '$d')
+
+	if [ "$HTTP_CODE" = "206" ] &&
+	   [ "$(echo "$CONTENT" | jq -r '.returnedRows')" = "10" ]; then
+		pass "max-items=10 with start= on ${BIG_PDS} (${ELAPSED}s)"
+	else
+		fail "max-items=10 with start= on ${BIG_PDS}" \
+			"got HTTP $HTTP_CODE returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows') after ${ELAPSED}s"
 	fi
 
 	# the regression: is MVSMF still loadable at all?

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -182,6 +182,9 @@ RESP=$(curl -s -w '\n%{http_code}' \
 HTTP_CODE=$(echo "$RESP" | tail -1)
 BODY=$(echo "$RESP" | sed '$d')
 
+# No X-IBM-Max-Items, so this is a complete listing and stays 200 even though
+# the handler applies a default cap of its own -- 206 answers the client's
+# limit, not ours (#249). See the max-items block below for the truncated case.
 assert_http_status "200" "$HTTP_CODE" "list directory ${TEST_DIR}"
 assert_json_field_exists "$BODY" ".items" "list: items array present"
 assert_json_field_exists "$BODY" ".returnedRows" "list: returnedRows present"
@@ -213,8 +216,6 @@ RESP=$(curl -s -w '\n%{http_code}' \
 HTTP_CODE=$(echo "$RESP" | tail -1)
 BODY=$(echo "$RESP" | sed '$d')
 
-assert_http_status "200" "$HTTP_CODE" "list with max-items=2"
-
 RETURNED=$(echo "$BODY" | jq -r '.returnedRows' 2>/dev/null)
 TOTAL_ROWS=$(echo "$BODY" | jq -r '.totalRows' 2>/dev/null)
 if [ -n "$RETURNED" ] && [ "$RETURNED" -le 2 ] 2>/dev/null; then
@@ -223,9 +224,28 @@ else
 	fail "list max-items: returnedRows" "expected <= 2, got '$RETURNED'"
 fi
 
-if [ -n "$TOTAL_ROWS" ] && [ -n "$RETURNED" ] && [ "$TOTAL_ROWS" -gt 2 ] 2>/dev/null; then
+# Whether this directory has more than two entries decides both the status and
+# moreRows, and the point of asserting them together is that they must agree:
+# a 206 next to moreRows false (or the reverse) is the failure #249 is about.
+if [ -n "$TOTAL_ROWS" ] && [ "$TOTAL_ROWS" -gt 2 ] 2>/dev/null; then
+	assert_http_status "206" "$HTTP_CODE" "list with max-items=2 (truncated)"
 	assert_json_field "$BODY" ".moreRows" "true" "list max-items: moreRows is true when truncated"
+else
+	assert_http_status "200" "$HTTP_CODE" "list with max-items=2 (not truncated)"
+	assert_json_field "$BODY" ".moreRows" "false" "list max-items: moreRows is false when complete"
 fi
+
+# a limit nothing reaches is a complete listing: the header being present is
+# not what makes a response partial
+RESP=$(curl -s -w '\n%{http_code}' \
+	-u "$AUTH" \
+	-H "X-IBM-Max-Items: 10000" \
+	"${BASE_URL}/zosmf/restfiles/fs?path=${TEST_DIR}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+
+assert_http_status "200" "$HTTP_CODE" "list with max-items above the entry count"
+assert_json_field "$BODY" ".moreRows" "false" "list max-items=10000: moreRows is false"
 
 echo ""
 echo "--- List with X-IBM-Max-Items: 0 ---"

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -373,6 +373,51 @@ if [ "$MEMBER_WRITE_OK" -eq 1 ]; then
 	else
 		fail "member names are returned unpadded" "got: $NAMES"
 	fi
+
+	# A truncated member list answers 206 rather than 200 (#249), and the
+	# assertion that matters is that Zowe still treats it as success: the
+	# status is what its RestClient decides on, so a client that rejected 206
+	# would fail here with the body perfectly well-formed. The dataset list
+	# above covers the same ground for the other handler.
+	#
+	# A second member has to exist first. With only TESTMBR in the directory
+	# max-items=1 is not a truncation at all, the response is a plain 200, and
+	# the case would pass without ever reaching the code it is meant to cover.
+	#
+	# Not TESTMBR2: the rename test below renames TESTMBR to that name and
+	# would fail against an existing member. This one is deleted again as soon
+	# as the two assertions are done, so the directory the later tests see is
+	# the one they expect.
+	PAGEFILE=$(mktemp)
+	printf 'SECOND MEMBER\n' > "$PAGEFILE"
+	run_zowe files upload ftds "$PAGEFILE" "${TEST_PDS}(PAGEMBR)" >/dev/null 2>&1
+	rm -f "$PAGEFILE"
+
+	RC=0
+	OUTPUT=$(run_zowe_json files list am "$TEST_PDS" --max 1) || RC=$?
+	assert_rc 0 "$RC" "list PDS members (max-items=1, HTTP 206)"
+
+	ROWS=$(echo "$OUTPUT" | jq -r '.data.apiResponse.returnedRows' 2>/dev/null) || ROWS=0
+	MORE=$(echo "$OUTPUT" | jq -r '.data.apiResponse.moreRows' 2>/dev/null) || MORE=""
+	if [ "$ROWS" = "1" ] && [ "$MORE" = "true" ]; then
+		pass "member list max-items=1: one row and moreRows=true"
+	else
+		fail "member list max-items=1: one row and moreRows=true" \
+			"returnedRows=$ROWS moreRows=$MORE"
+	fi
+
+	# and the negative: a limit the directory does not reach is complete (200)
+	RC=0
+	OUTPUT=$(run_zowe_json files list am "$TEST_PDS" --max 100) || RC=$?
+	assert_rc 0 "$RC" "list PDS members (max-items=100, complete)"
+	MORE=$(echo "$OUTPUT" | jq -r '.data.apiResponse.moreRows' 2>/dev/null) || MORE=""
+	if [ "$MORE" = "false" ]; then
+		pass "member list max-items=100: moreRows=false"
+	else
+		fail "member list max-items=100: moreRows=false" "got '$MORE'"
+	fi
+
+	run_zowe files delete ds "${TEST_PDS}(PAGEMBR)" -f >/dev/null 2>&1
 fi
 
 # --- Read PDS member ---

--- a/tests/zowe-uss.sh
+++ b/tests/zowe-uss.sh
@@ -207,6 +207,20 @@ else
 	fail "list: testfile.txt present" "not found in listing"
 fi
 
+# A truncated listing answers 206 rather than 200 (#249). What is asserted here
+# is that Zowe still treats it as success -- the status is what its RestClient
+# decides on, so a client rejecting 206 fails here with a well-formed body.
+RC=0
+OUTPUT_MAX=$(run_zowe_json files list uss-files "${TEST_DIR}" --max 1) || RC=$?
+assert_rc 0 "$RC" "list USS directory (max-items=1, HTTP 206)"
+
+MORE=$(echo "$OUTPUT_MAX" | jq -r '.data.apiResponse.moreRows' 2>/dev/null) || MORE=""
+if [ "$MORE" = "true" ]; then
+	pass "USS list max-items=1: moreRows=true"
+else
+	fail "USS list max-items=1: moreRows=true" "got '$MORE'"
+fi
+
 # Check that subdir appears in listing
 HAS_DIR=$(echo "$OUTPUT" | jq '[.data.apiResponse.items[].name] | index("subdir") != null' 2>/dev/null)
 if [ "$HAS_DIR" = "true" ]; then


### PR DESCRIPTION
Fixes #249.

z/OSMF defines **206 Partial content** for a listing cut short by
`X-IBM-Max-Items`; mvsMF answered 200. `moreRows` was already correct, so the
body carried the fact and the status contradicted it — a client keying off the
status could not tell a page from a complete list.

## The actual work isn't `200` → `206`

All three list handlers stream: `http_resp()` runs *before* the walk that
discovers the truncation. `moreRows` can be decided last, the status cannot. So
each handler now measures the page up front.

| Handler | How |
|---|---|
| `datasetListHandler` | counts the already-sorted array in storage — no I/O |
| `memberListHandler` | second directory walk, stopping one match past the page, only when the client set a limit |
| `ussListHandler` | same, via a close and a second `ufs_diropen()` — there is no `ufs_dirrewind()` |

Two pieces of duplication were removed rather than created: the member walk is
now one function (`member_scan`) that both passes call, and the dataset `start=`
predicate is `dslist_in_page()`. The counting pass decides the status and the
emit pass decides the body, so rules kept in duplicate would drift until 206 and
`moreRows` disagreed about exactly the entries #154, #232 and #240 are about.

`fopen()` again rather than `rewind()`: a backwards seek on a record-mode handle
reopens the data set inside `__fseek()` anyway, by a DD name it reconstructs
itself — same I/O, none of the guesswork. Reading twice is affordable only
because of #212, where the walk stopped materialising a member array.

## USS keeps its default at 200

`USS_LIST_DEFAULT_MAX_ITEMS` (1000) truncates too, but that limit is the
server's, not the client's, and z/OSMF ties 206 to a request that *contained*
the header. That also keeps every plain listing at a single walk — the counting
pass is opt-in by the client.

## Verified live, not assumed

- `SYS1.MACLIB` members with max-items 3 → **206** with the correct *first*
  three (an unrepositioned second pass would return none); unlimited → 742
  members, **200**.
- `SYS1.SMPCDS` (~23000 members) with `start=` and max-items 10 → **1s**, so the
  counting pass early-exits rather than reading the directory twice.
- **Zowe CLI 8.32.2 accepts 206** on all three listings (`files list ds`/`am`/
  `uss-files` with `--max`): `success: true`, exit 0. This was checked rather
  than recalled — the whole change rests on it.
- Suites: curl datasets 159/159, curl USS 66/66, curl jobs 98/98, Zowe datasets
  50/50, Zowe USS 25/25.

New cases include the two negatives that a naive implementation would get
wrong: a limit nothing reaches stays **200**, and a USS listing truncated by the
*default* stays **200**. The member Zowe case needed a second member in the
directory first — with one member, max-items=1 is not a truncation and the
assertion would pass without reaching the code it covers.

## Deliberately not in scope

- **Job list.** It caps with the `max-jobs` query parameter, not this header,
  and emits no `moreRows` at all. Out of scope under the same rule that keeps
  the USS default at 200.
- **204 for empty listings** (the "Related" note on #249). 204 forbids a body
  and every Zowe list path parses JSON from one, so it is a client-visible break
  with a different blast radius from a status-only change on truncation. Filed
  separately.

## Noted, not touched

`rc` is declared `unsigned` in both list handlers, which makes every
`if ((rc = http_printf(...)) < 0)` check dead. Pre-existing and left alone —
but worth its own issue, since it silently disables send-error detection across
both handlers.