### PR TITLE
datasets: If-None-Match / 304 for conditional reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,10 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
 - **router.c**: HTTP routing framework. Pattern-based URL matching with `{param-name}` path parameters, percent-decoding, middleware chain execution.
 - **dsapi.c**: Dataset REST API handlers — list, read, write, create, delete for sequential datasets and PDS members. Largest file by complexity.
 - **etag.c**: The ETag stamp and `If-Match` parsing behind the optimistic
-  locking on data sets and members (#152). Deliberately free of MVS services so
+  locking on data sets and members (#152), and the same predicate answering
+  `If-None-Match` on the read side (#263 — a match means 412 on a write, 304 on
+  a read, wildcard included; there is no inverted variant).
+  Deliberately free of MVS services so
   it unit-tests on the host (`TSTETAG`); the record reading lives in `dsapi.c`
   as `dataset_etag()`, next to the DCB knowledge it needs. Three rules that are
   load-bearing and all fail silently if broken: the stamp is computed over the

--- a/docs/endpoints/datasets/get.md
+++ b/docs/endpoints/datasets/get.md
@@ -24,9 +24,13 @@ or with explicit volume:
 - `X-IBM-Return-Etag` (optional): `true` returns an `ETag` for the dataset, for
   use as `If-Match` on a later write. Identical in behaviour to the member
   endpoint — see [members-get.md](members-get.md#etag).
+- `If-None-Match` (optional): makes the read conditional — a dataset that still
+  holds the stamped state is answered 304 (Not Modified) with the `ETag` and no
+  body. Same header forms and same wildcard rule as the member endpoint, see
+  [Conditional reads](members-get.md#conditional-reads-if-none-match).
 
 ## Response
-On successful completion, this request returns HTTP status code 200 (OK) with the dataset content.
+On successful completion, this request returns HTTP status code 200 (OK) with the dataset content, or 304 (Not Modified) when `If-None-Match` still holds.
 
 - **Text mode**: Each record is sent after EBCDIC-to-ASCII conversion. For F/FB datasets, trailing space padding (added by MVS to fill each record to LRECL) is stripped so the output matches VB-style line endings.
 - **Binary mode**: Raw record data without conversion. For FB datasets, the exact record count is calculated from VTOC (DSCB1/DSCB4) to avoid reading past logical end-of-data.

--- a/docs/endpoints/datasets/members-get.md
+++ b/docs/endpoints/datasets/members-get.md
@@ -83,9 +83,12 @@ semantic of a PUT, which this endpoint does not implement.)
 
 Two consequences worth knowing:
 
-- **The 304 always carries the `ETag`**, even without `X-IBM-Return-Etag: true`.
-  That is not a hole in the opt-in: a client sending `If-None-Match` is already
-  speaking the protocol, and the stamp had to be computed to answer at all.
+- **A request carrying `If-None-Match` gets the `ETag` back either way** —
+  on the 304 and on the 200 that follows a change — without
+  `X-IBM-Return-Etag: true`. That is not a hole in the opt-in: the stamp had to
+  be computed to answer at all, and a reader polling on `If-None-Match` alone
+  would otherwise receive the changed content with no validator to ask about the
+  next change.
 - **A 304 saves the transfer, not the read.** The stamp is computed by reading
   the member, so the server does the same I/O either way. A cheaper freshness
   check would need a modification time, and MVS keeps one per data set, not per

--- a/docs/endpoints/datasets/members-get.md
+++ b/docs/endpoints/datasets/members-get.md
@@ -24,9 +24,15 @@ or with explicit volume:
     - `record`: Like binary, but each record prefixed with 4-byte big-endian length, Content-Type: `application/octet-stream`
 - `X-IBM-Return-Etag` (optional): `true` returns an `ETag` for the member. Any
   other value, or an absent header, returns none.
+- `If-None-Match` (optional): makes the read conditional — a member that still
+  holds the stamped state is answered 304 without a body. See
+  [Conditional reads](#conditional-reads-if-none-match).
 
 ## Response
 On successful completion, this request returns HTTP status code 200 (OK) with the member content. In text mode, trailing space padding on F/FB records is stripped so the output matches VB-style line endings.
+
+With `If-None-Match`, a member that still holds the stamped state is answered
+304 (Not Modified) with the `ETag` header and no body.
 
 ## ETag
 
@@ -50,6 +56,43 @@ without the header are unaffected.
 
 The header is emitted unquoted, the way z/OSMF emits it. `Access-Control-Expose-Headers: ETag`
 accompanies it so a cross-origin client can read the value at all.
+
+## Conditional reads (If-None-Match)
+
+Sending the stamp back as `If-None-Match` makes the read conditional. If the
+member still holds that state, the answer is **304 Not Modified** with no body;
+otherwise the request proceeds exactly as it would without the header.
+
+```bash
+# Read once, keep the stamp
+ETAG=$(curl -sD - -o member.txt -H "X-IBM-Return-Etag: true" \
+  http://mvs:1080/zosmf/restfiles/ds/MIKE.TEST.JCL\(MYJOB\) \
+  | grep -i '^ETag:' | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//')
+
+# Later: 304 while unchanged, 200 with the new content once it changes
+curl -s -o member.txt -w '%{http_code}\n' -H "If-None-Match: ${ETAG}" \
+  http://mvs:1080/zosmf/restfiles/ds/MIKE.TEST.JCL\(MYJOB\)
+```
+
+Accepted forms are the ones `If-Match` takes: bare, quoted, weak (`W/"…"`), a
+comma-separated list, and `*`. **`*` answers 304 for any member that exists** —
+per RFC 9110 the wildcard fails the `If-None-Match` condition whenever a
+representation is there, and a failed condition on a GET is a 304. (The
+opposite reading, "only if it does not exist", is the conditional-*create*
+semantic of a PUT, which this endpoint does not implement.)
+
+Two consequences worth knowing:
+
+- **The 304 always carries the `ETag`**, even without `X-IBM-Return-Etag: true`.
+  That is not a hole in the opt-in: a client sending `If-None-Match` is already
+  speaking the protocol, and the stamp had to be computed to answer at all.
+- **A 304 saves the transfer, not the read.** The stamp is computed by reading
+  the member, so the server does the same I/O either way. A cheaper freshness
+  check would need a modification time, and MVS keeps one per data set, not per
+  member.
+
+A member that cannot be read gets no 304 — the open then produces the real
+diagnosis (404, or 500 on an I/O error), which is the more specific answer.
 
 ## Error Responses
 - HTTP 404 (Not Found)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -191,9 +191,10 @@ curl -s -o local.txt -w '%{http_code}\n' -u $USER:$PASS \
   "$BASE/zosmf/restfiles/ds/IBMUSER.TEST.PDS(TESTMBR)"
 ```
 
-`*` matches any member that exists, so it answers 304 rather than 200. The 304
-carries the `ETag` even without `X-IBM-Return-Etag`. What it saves is the
-transfer, not the read: the stamp is computed by reading the member either way.
+`*` matches any member that exists, so it answers 304 rather than 200. Both
+answers carry the `ETag` even without `X-IBM-Return-Etag`, so a poll can keep
+running off its own responses. What it saves is the transfer, not the read: the
+stamp is computed by reading the member either way.
 Details in
 [endpoints/datasets/members-get.md](endpoints/datasets/members-get.md#conditional-reads-if-none-match).
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -177,6 +177,26 @@ sequential endpoint. Details in
 
 The Zowe CLI exposes no flag for either header; the SDK does.
 
+### Re-read a member only if it changed
+`GET` with `If-None-Match`
+
+Hand the stamp back on the next read and an unchanged member answers 304 with
+no body — useful for a poller or a client that caches content between sessions.
+
+```bash
+# 304 while it still holds the state $ETAG describes, 200 with the content once
+# it does not
+curl -s -o local.txt -w '%{http_code}\n' -u $USER:$PASS \
+  -H "If-None-Match: $ETAG" \
+  "$BASE/zosmf/restfiles/ds/IBMUSER.TEST.PDS(TESTMBR)"
+```
+
+`*` matches any member that exists, so it answers 304 rather than 200. The 304
+carries the `ETag` even without `X-IBM-Return-Etag`. What it saves is the
+transfer, not the read: the stamp is computed by reading the member either way.
+Details in
+[endpoints/datasets/members-get.md](endpoints/datasets/members-get.md#conditional-reads-if-none-match).
+
 ### Delete a member
 `DELETE /zosmf/restfiles/ds/{dataset-name}({member-name})`
 

--- a/include/common.h
+++ b/include/common.h
@@ -38,6 +38,7 @@
 #define HTTP_STATUS_OK 200                    /**< Success */
 #define HTTP_STATUS_CREATED 201               /**< Resource created */
 #define HTTP_STATUS_ACCEPTED 202              /**< Request accepted */
+#define HTTP_STATUS_NOT_MODIFIED 304          /**< If-None-Match still current */
 #define HTTP_STATUS_BAD_REQUEST 400           /**< Invalid parameters */
 #define HTTP_STATUS_UNAUTHORIZED 401          /**< Unauthorized */
 #define HTTP_STATUS_FORBIDDEN 403             /**< Forbidden */

--- a/project.toml
+++ b/project.toml
@@ -89,7 +89,8 @@ norent = true
 
 # TSTETAG: #152 — the ETag stamp must change on every content change (including
 # a same-length edit and a re-split record boundary) and stay stable otherwise,
-# and If-Match must accept bare, quoted, weak and list forms. Portable C
+# and If-Match must accept bare, quoted, weak and list forms. #263 adds the read
+# half: the same predicate answers If-None-Match, wildcard included. Portable C
 # (test-host); the TU #includes src/etag.c so it drives the real stamp dsapi.c
 # uses — do not list etag.c here.
 [[test]]

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -53,6 +53,7 @@ static int dataset_etag(Session *session, const char *dataset,
                         long max_records, char *out, size_t outlen);
 static int check_if_match(Session *session, const char *dataset,
                           long max_records);
+static int send_not_modified(Session *session, const char *etag);
 
 // Helper functions for memory management
 static void cleanup_resources(char* buffer, FILE* fp) {
@@ -379,6 +380,42 @@ check_if_match(Session *session, const char *dataset, long max_records)
 	}
 
 	return 0;
+}
+
+/* Answer a conditional read whose If-None-Match still holds (issue #263).
+ *
+ * No body and no Content-Type: the client keeps the representation it already
+ * has, and a 304 that described a payload it is not sending would only invite
+ * a client to believe there is one. The other headers mirror what the 200
+ * would have carried, which is what RFC 9110 asks a 304 to do.
+ *
+ * The ETag goes out even when the request did not ask for one with
+ * X-IBM-Return-Etag. That looks like it contradicts the opt-in, and does not:
+ * a client sending If-None-Match is already speaking the ETag protocol, and
+ * the stamp had to be computed to answer at all. Withholding it would only
+ * cost the client its confirmation of which state it is now holding.
+ */
+__asm__("\n&FUNC    SETC 'send_notmod'");
+static int
+send_not_modified(Session *session, const char *etag)
+{
+	int rc;
+
+	session->headers_sent = 1;
+	if ((rc = http_resp(session->httpc,
+			HTTP_STATUS_NOT_MODIFIED)) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Cache-Control: no-store\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Pragma: no-cache\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Access-Control-Allow-Origin: *\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag)) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Access-Control-Expose-Headers: ETag\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc, "\r\n")) < 0) return rc;
+
+	return rc;
 }
 
 // Helper function for error handling
@@ -1242,6 +1279,8 @@ int datasetGetHandler(Session *session)
     long max_records = -1;
     char etag[ETAG_SIZE] = {0};
     const char *etag_hdr = NULL;
+    const char *if_none_match = NULL;
+    int want_etag = 0;
     FILE *fp = NULL;
 
     // Validate parameters
@@ -1264,11 +1303,25 @@ int datasetGetHandler(Session *session)
 
     /* Hash pass first, before any DCB for the body is open. It always uses
        the FB record count, even when the body will be read as text: the
-       stamp must not depend on the mode the client happens to read in. */
-    if (etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"))) {
+       stamp must not depend on the mode the client happens to read in.
+
+       One pass serves both halves of the protocol -- the value returned for
+       X-IBM-Return-Etag (#152) and the comparison for If-None-Match (#263).
+       Hashing twice would be two chances for the two answers to disagree. A
+       data set that cannot be read gets neither: the open below then produces
+       the real diagnosis, which is the more specific answer than a 304. */
+    if_none_match = getHeaderParam(session, "If-None-Match");
+    want_etag = etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"));
+
+    if (if_none_match || want_etag) {
         if (dataset_etag(session, dsname, get_fb_record_count(dsname),
                 etag, sizeof(etag)) == 0) {
-            etag_hdr = etag;
+            if (if_none_match && etag_matches(if_none_match, etag)) {
+                return send_not_modified(session, etag);
+            }
+            if (want_etag) {
+                etag_hdr = etag;
+            }
         }
     }
 
@@ -2095,6 +2148,8 @@ int memberGetHandler(Session *session)
     char dataset[MAX_QUALIFIED_DSN] = {0};
     char etag[ETAG_SIZE] = {0};
     const char *etag_hdr = NULL;
+    const char *if_none_match = NULL;
+    int want_etag = 0;
     FILE *fp = NULL;
 
     // Validate parameters
@@ -2121,10 +2176,23 @@ int memberGetHandler(Session *session)
     /* The ETag has to be known before the first response byte goes out, so
        the hash pass runs before the member is opened for the body -- never
        two DCBs on the same member at once. A member with no readable content
-       simply gets no ETag; the open below then produces the real diagnosis. */
-    if (etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"))) {
+       simply gets no ETag; the open below then produces the real diagnosis.
+
+       The bound is -1, read to EOF: a member has a real end of data, unlike
+       the sequential path, which has to stop at get_fb_record_count(). The
+       two must not be swapped -- see dataset_etag(). One pass answers both
+       X-IBM-Return-Etag (#152) and If-None-Match (#263). */
+    if_none_match = getHeaderParam(session, "If-None-Match");
+    want_etag = etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"));
+
+    if (if_none_match || want_etag) {
         if (dataset_etag(session, dataset, -1, etag, sizeof(etag)) == 0) {
-            etag_hdr = etag;
+            if (if_none_match && etag_matches(if_none_match, etag)) {
+                return send_not_modified(session, etag);
+            }
+            if (want_etag) {
+                etag_hdr = etag;
+            }
         }
     }
 

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1319,9 +1319,12 @@ int datasetGetHandler(Session *session)
             if (if_none_match && etag_matches(if_none_match, etag)) {
                 return send_not_modified(session, etag);
             }
-            if (want_etag) {
-                etag_hdr = etag;
-            }
+            /* Either header means the client wants the validator, and this
+               branch is only reached when one of them was sent -- so the
+               stamp goes out on the miss too. Without it a reader polling on
+               If-None-Match alone would get the changed content and no way to
+               ask about the next change. */
+            etag_hdr = etag;
         }
     }
 
@@ -2190,9 +2193,9 @@ int memberGetHandler(Session *session)
             if (if_none_match && etag_matches(if_none_match, etag)) {
                 return send_not_modified(session, etag);
             }
-            if (want_etag) {
-                etag_hdr = etag;
-            }
+            /* See datasetGetHandler: the stamp goes out on the miss as well,
+               so a client polling on If-None-Match alone can carry on. */
+            etag_hdr = etag;
         }
     }
 

--- a/test/host/tstetag.c
+++ b/test/host/tstetag.c
@@ -159,6 +159,28 @@ main(void)
 		CHECK_EQ(etag_matches(e, NULL), 0, "a NULL etag never matches");
 	}
 
+	printf("\n--- #263: If-None-Match reads the same predicate ---\n");
+	{
+		const char *e = "1234567890ABCDEF";
+
+		/* One predicate serves both headers: etag_matches() answers "a
+		   listed validator matches", which the write path turns into 412
+		   and the read path into 304. No inverted variant is needed.
+
+		   RFC 9110 13.1.2 makes that true of the wildcard as well: for
+		   If-None-Match, "*" fails the condition when a current
+		   representation exists -- and one the caller could stamp does --
+		   so "*" answers 304, not 200. The opposite reading ("only if it
+		   does not exist") belongs to a conditional create, which this
+		   endpoint does not implement. */
+		check_match("*", e, 1);
+		check_match(e, e, 1);
+		check_match("\"AAAAAAAAAAAAAAAA\", \"1234567890ABCDEF\"", e, 1);
+
+		/* A stale validator leaves the condition true: send the body. */
+		check_match("AAAAAAAAAAAAAAAA", e, 0);
+	}
+
 	printf("\n--- #152: X-IBM-Return-Etag is opt-in ---\n");
 	{
 		CHECK_EQ(etag_requested("true"), 1, "true asks for an ETag");

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -1782,6 +1782,131 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_ETAGSEQ}")
 assert_http_status "204" "$HTTP_CODE" "etag: sequential second save with the returned stamp"
 
+# --- ETag: conditional reads (issue #263) ---
+echo ""
+echo "--- ETag: conditional reads / If-None-Match (issue #263) ---"
+
+# One value drives every check below: the stamp the member returns right now.
+# The read half computes its own stamp for the comparison, so if that pass ever
+# drifted from the one behind X-IBM-Return-Etag, it would surface here as a 200
+# where a 304 was asked for -- which is why the two are hashed in one pass.
+curl -s -D /tmp/curl_ds_c1.txt -o /dev/null -u "$AUTH" \
+	-H "X-IBM-Return-Etag: true" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)"
+CETAG=$(get_etag /tmp/curl_ds_c1.txt)
+
+HTTP_CODE=$(curl -s -w '%{http_code}' \
+	-D /tmp/curl_ds_c2.txt -o /tmp/curl_ds_c2.body \
+	-u "$AUTH" -H "If-None-Match: ${CETAG}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
+assert_http_status "304" "$HTTP_CODE" "cond: a current If-None-Match is 304"
+
+# A body is the one thing the status promises not to send.
+if [ ! -s /tmp/curl_ds_c2.body ]; then
+	pass "cond: the 304 carries no body"
+else
+	fail "cond: the 304 carries no body" \
+		"got $(wc -c < /tmp/curl_ds_c2.body) bytes"
+fi
+
+# The ETag rides along without X-IBM-Return-Etag being sent: a client on
+# If-None-Match is already speaking the protocol, and the stamp had to be
+# computed to answer at all.
+if [ "$(get_etag /tmp/curl_ds_c2.txt)" = "$CETAG" ]; then
+	pass "cond: the 304 carries the ETag it confirmed"
+else
+	fail "cond: the 304 carries the ETag it confirmed" \
+		"got '$(get_etag /tmp/curl_ds_c2.txt)', expected '$CETAG'"
+fi
+
+# The forms clients send, and the wildcard. "*" fails the If-None-Match
+# condition whenever a representation exists (RFC 9110 13.1.2), and a failed
+# condition on a GET is a 304 -- the opposite reading, "only if it does not
+# exist", is the conditional-create semantic of a PUT.
+for FORM in "\"${CETAG}\"" "W/\"${CETAG}\"" \
+	"\"0000000000000000\", \"${CETAG}\"" "*"; do
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		-H "If-None-Match: ${FORM}" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
+	assert_http_status "304" "$HTTP_CODE" \
+		"cond: If-None-Match ${FORM} is 304"
+done
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /tmp/curl_ds_c3.body -u "$AUTH" \
+	-H "If-None-Match: 0000000000000000" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
+assert_http_status "200" "$HTTP_CODE" "cond: a stale If-None-Match is 200"
+
+if [ -s /tmp/curl_ds_c3.body ]; then
+	pass "cond: the 200 still carries the content"
+else
+	fail "cond: the 200 still carries the content" "empty body"
+fi
+
+# 304 has to be a statement about the current content, not about the header
+# having been seen once. Change the member and the same stamp must stop matching.
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+	-X PUT -u "$AUTH" \
+	-H "Content-Type: text/plain" \
+	--data-binary @/tmp/curl_ds_etag.txt \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
+assert_http_status "204" "$HTTP_CODE" "cond: rewrite the member"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	-H "If-None-Match: ${CETAG}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
+assert_http_status "200" "$HTTP_CODE" "cond: a changed member is 200 again"
+
+# Nothing to be fresh about: the 404 is the more specific answer and wins.
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	-H "If-None-Match: *" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGNON)")
+assert_http_status "404" "$HTTP_CODE" "cond: a missing member is 404, not 304"
+
+# A bodiless response is framed by its header block alone. If that framing were
+# wrong the next request on the same connection would hang or read the previous
+# response's tail -- curl reuses the connection when both URLs are given in one
+# invocation, so a second 304 here is the evidence.
+curl -s -D /tmp/curl_ds_c4.txt -o /dev/null -u "$AUTH" \
+	-H "X-IBM-Return-Etag: true" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)"
+CETAG2=$(get_etag /tmp/curl_ds_c4.txt)
+CODES=$(curl -s --max-time 30 -o /dev/null -w '%{http_code} ' -u "$AUTH" \
+	-H "If-None-Match: ${CETAG2}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
+if [ "$CODES" = "304 304 " ]; then
+	pass "cond: a second request on the same connection still answers"
+else
+	fail "cond: a second request on the same connection still answers" \
+		"got '$CODES', expected '304 304 '"
+fi
+
+# The sequential path, where the hash pass is bounded by get_fb_record_count()
+# rather than reading to EOF. A bound copied from the member path would hash
+# the residue of the last block as well, and this 304 would come back 200.
+curl -s -D /tmp/curl_ds_c5.txt -o /dev/null -u "$AUTH" \
+	-H "X-IBM-Return-Etag: true" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_ETAGSEQ}"
+SETAG=$(get_etag /tmp/curl_ds_c5.txt)
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	-H "If-None-Match: ${SETAG}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_ETAGSEQ}")
+assert_http_status "304" "$HTTP_CODE" "cond: sequential current stamp is 304"
+
+# The stamp does not depend on X-IBM-Data-Type, so neither does the 304.
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	-H "X-IBM-Data-Type: binary" \
+	-H "If-None-Match: ${SETAG}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_ETAGSEQ}")
+assert_http_status "304" "$HTTP_CODE" "cond: sequential binary read is 304 too"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /tmp/curl_ds_c6.body -u "$AUTH" \
+	-H "If-None-Match: 0000000000000000" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_ETAGSEQ}")
+assert_http_status "200" "$HTTP_CODE" "cond: sequential stale stamp is 200"
+
 curl -s -X DELETE -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)" >/dev/null 2>&1 || true
 curl -s -X DELETE -u "$AUTH" \
@@ -1789,7 +1914,10 @@ curl -s -X DELETE -u "$AUTH" \
 rm -f /tmp/curl_ds_etag.txt /tmp/curl_ds_etag2.txt /tmp/curl_ds_after412.txt \
 	/tmp/curl_ds_h1.txt /tmp/curl_ds_h2.txt /tmp/curl_ds_h3.txt \
 	/tmp/curl_ds_h4.txt /tmp/curl_ds_h5.txt /tmp/curl_ds_h6.txt \
-	/tmp/curl_ds_h7.txt /tmp/curl_ds_h8.txt /tmp/curl_ds_h9.txt
+	/tmp/curl_ds_h7.txt /tmp/curl_ds_h8.txt /tmp/curl_ds_h9.txt \
+	/tmp/curl_ds_c1.txt /tmp/curl_ds_c2.txt /tmp/curl_ds_c2.body \
+	/tmp/curl_ds_c3.body /tmp/curl_ds_c4.txt /tmp/curl_ds_c5.txt \
+	/tmp/curl_ds_c6.body
 
 # --- Cleanup: delete PDS ---
 echo ""

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -1832,7 +1832,8 @@ for FORM in "\"${CETAG}\"" "W/\"${CETAG}\"" \
 		"cond: If-None-Match ${FORM} is 304"
 done
 
-HTTP_CODE=$(curl -s -w '%{http_code}' -o /tmp/curl_ds_c3.body -u "$AUTH" \
+HTTP_CODE=$(curl -s -w '%{http_code}' \
+	-D /tmp/curl_ds_c3.txt -o /tmp/curl_ds_c3.body -u "$AUTH" \
 	-H "If-None-Match: 0000000000000000" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
 assert_http_status "200" "$HTTP_CODE" "cond: a stale If-None-Match is 200"
@@ -1841,6 +1842,16 @@ if [ -s /tmp/curl_ds_c3.body ]; then
 	pass "cond: the 200 still carries the content"
 else
 	fail "cond: the 200 still carries the content" "empty body"
+fi
+
+# The miss carries the stamp as well, without X-IBM-Return-Etag being sent.
+# A reader polling on If-None-Match alone would otherwise receive the changed
+# content and no validator to ask about the next change with.
+if [ "$(get_etag /tmp/curl_ds_c3.txt)" = "$CETAG" ]; then
+	pass "cond: the 200 carries the current ETag too"
+else
+	fail "cond: the 200 carries the current ETag too" \
+		"got '$(get_etag /tmp/curl_ds_c3.txt)', expected '$CETAG'"
 fi
 
 # 304 has to be a statement about the current content, not about the header
@@ -1852,10 +1863,20 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
 assert_http_status "204" "$HTTP_CODE" "cond: rewrite the member"
 
-HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
-	-H "If-None-Match: ${CETAG}" \
+HTTP_CODE=$(curl -s -w '%{http_code}' -D /tmp/curl_ds_c7.txt -o /dev/null \
+	-u "$AUTH" -H "If-None-Match: ${CETAG}" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ETAGT)")
 assert_http_status "200" "$HTTP_CODE" "cond: a changed member is 200 again"
+
+# ... and the stamp it hands back is the new one, which is what lets the poll
+# continue from here without a second request.
+CETAGNEW=$(get_etag /tmp/curl_ds_c7.txt)
+if [ -n "$CETAGNEW" ] && [ "$CETAGNEW" != "$CETAG" ]; then
+	pass "cond: the 200 after a change carries the new stamp ($CETAGNEW)"
+else
+	fail "cond: the 200 after a change carries the new stamp" \
+		"got '$CETAGNEW', was '$CETAG'"
+fi
 
 # Nothing to be fresh about: the 404 is the more specific answer and wins.
 HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
@@ -1916,8 +1937,8 @@ rm -f /tmp/curl_ds_etag.txt /tmp/curl_ds_etag2.txt /tmp/curl_ds_after412.txt \
 	/tmp/curl_ds_h4.txt /tmp/curl_ds_h5.txt /tmp/curl_ds_h6.txt \
 	/tmp/curl_ds_h7.txt /tmp/curl_ds_h8.txt /tmp/curl_ds_h9.txt \
 	/tmp/curl_ds_c1.txt /tmp/curl_ds_c2.txt /tmp/curl_ds_c2.body \
-	/tmp/curl_ds_c3.body /tmp/curl_ds_c4.txt /tmp/curl_ds_c5.txt \
-	/tmp/curl_ds_c6.body
+	/tmp/curl_ds_c3.txt /tmp/curl_ds_c3.body /tmp/curl_ds_c4.txt \
+	/tmp/curl_ds_c5.txt /tmp/curl_ds_c6.body /tmp/curl_ds_c7.txt
 
 # --- Cleanup: delete PDS ---
 echo ""

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -599,6 +599,10 @@ echo "--- ETag: optimistic locking (issue #152) ---"
 # the gap stays visible if a later CLI version does expose it.
 skip "etag: X-IBM-Return-Etag / If-Match (no Zowe CLI flag — see curl-datasets.sh)"
 
+# The read half (#263) is further out of reach: the SDK has no If-None-Match
+# option at all, so a 304 cannot be provoked through the CLI even indirectly.
+skip "etag: If-None-Match / 304 (no Zowe CLI or SDK option — see curl-datasets.sh)"
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"


### PR DESCRIPTION
Fixes #263 — the read half of the ETag protocol. `If-None-Match` on a GET was
ignored, so a client already holding the current content still got the whole
body back.

## What changed

`datasetGetHandler` and `memberGetHandler` read `If-None-Match` and compute the
stamp **in the same pass that already serves `X-IBM-Return-Etag`**. One pass,
one value: hashing separately would give the returned ETag and the comparison
two chances to disagree. A match answers 304 with the `ETag` and no body;
anything else proceeds exactly as before. `src/etag.c` is untouched.

The bound stays the one the send path uses — `get_fb_record_count()` for the
sequential data set, `-1` for a member. That is where this breaks silently: a
copied `-1` on the sequential path hashes the residue of the last block, still
returns a plausible ETag, and drifts from both the returned value and the PUT's
`check_if_match()`.

## The wildcard: the issue's original scope was wrong, and it is corrected there

`*` needs no second branch. RFC 9110 §13.1.2 has `If-None-Match: *` **fail** the
condition whenever a current representation exists, and §13.2.2 turns a failed
condition on a GET into 304 — so `etag_matches()`, which returns 1 exactly when
the condition is false, answers both headers unchanged. The reading in the
original issue text ("only if it does not exist") is the conditional-*create*
semantic of a PUT, which this endpoint does not implement. Pinned in `TSTETAG`
so it is executable rather than a comment.

## Deliberate: a conditional request gets the ETag back either way

On the 304 **and** on the 200 that follows a change, without
`X-IBM-Return-Etag: true`. Not a hole in the opt-in — the stamp had to be
computed to answer at all, and returning it only on the 304 would break the very
consumer this exists for: a reader polling on `If-None-Match` alone would get
the changed content and no validator to ask about the next change with.
Documented where it would otherwise be rediscovered as a bug.

## Tests

- `TSTETAG` (host): +4 assertions, 39 pass. `make test-host`: 166 assertions, 0 fail.
- `tests/curl-datasets.sh`: 304 on **both** endpoints, empty body, ETag without
  `X-IBM-Return-Etag` on the hit *and* on both misses, every header form incl.
  `*`, stale stamp → 200, rewritten member → 200 carrying the new stamp, missing
  member → 404 (not 304), binary read → same 304, and two requests on one
  connection — the only way to tell a correctly framed bodiless response from a
  broken one.
- `tests/zowe-datasets.sh`: second skip; the SDK has no `If-None-Match` option,
  so the CLI cannot provoke a 304 even indirectly.

## Verify on the live system

`make` and `make test-host` pass on the host, and 304 is in httpd's status table
and in the z/OSMF status list — but neither proves the bodiless-304 framing and
keep-alive path. That needs a deploy + `tests/jcl/mvsmfact.jcl` and then:

```bash
ETAG=$(curl -sD - -o /dev/null -u U:P -H "X-IBM-Return-Etag: true" \
  "$BASE/zosmf/restfiles/ds/HLQ.TEST.PDS(MBR)" | grep -i '^ETag:' | tr -d '\r' | sed 's/^[^ ]* //')
curl -s -o /dev/null -w '%{http_code} ' -u U:P -H "If-None-Match: $ETAG" \
  "$BASE/zosmf/restfiles/ds/HLQ.TEST.PDS(MBR)" \
  "$BASE/zosmf/restfiles/ds/HLQ.TEST.PDS(MBR)"    # expect "304 304 ", no hang
```

`tests/curl-datasets.sh` covers the same ground as part of the suite.

## Note

`If-None-Match` is looked up through the same `getHeaderParam()` → httpd env
path as `If-Match`, so it inherits whatever header-name casing behaviour that
path has. Unchanged by this PR.

https://claude.ai/code/session_019TT2zwWGXK6rL6zMmV22j4
