### PR TITLE
ussapi: X-IBM-Return-Etag / If-Match for USS files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,17 +235,33 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
   locking on data sets and members (#152), and the same predicate answering
   `If-None-Match` on the read side (#263 — a match means 412 on a write, 304 on
   a read, wildcard included; there is no inverted variant).
+  It also carries the USS side (#264 — `X-IBM-Return-Etag` and `If-Match` on
+  `/restfiles/fs/{*filepath}`; no `If-None-Match` there yet).
   Deliberately free of MVS services so
-  it unit-tests on the host (`TSTETAG`); the record reading lives in `dsapi.c`
-  as `dataset_etag()`, next to the DCB knowledge it needs. Three rules that are
+  it unit-tests on the host (`TSTETAG`); the reading lives with the knowledge
+  it needs — `dataset_etag()` in `dsapi.c` next to the DCB handling,
+  `uss_etag()` in `ussapi.c` next to the UFS handling. Three rules that are
   load-bearing and all fail silently if broken: the stamp is computed over the
-  **stored records**, never over the bytes sent (those depend on
-  `X-IBM-Data-Type`); the hash pass takes the **same `max_records` bound** the
-  send path uses, i.e. `get_fb_record_count()` for a sequential data set and
-  `-1` for a member; and the ETag a PUT returns comes from **re-reading the
-  closed resource**, never from hashing the request body — the write and read
-  paths normalize in opposite directions, so a body-derived stamp makes every
-  second save fail its own precondition.
+  **stored bytes**, never over the bytes sent (those depend on
+  `X-IBM-Data-Type`, and on USS also on the IBM-1047 translation); the hash
+  pass takes the **same bound** the send path uses, i.e.
+  `get_fb_record_count()` for a sequential data set and `-1` for a member; and
+  the ETag a PUT returns comes from **re-reading the closed resource**, never
+  from hashing the request body — the write and read paths normalize in
+  opposite directions, so a body-derived stamp makes every second save fail its
+  own precondition.
+
+  The two resource kinds fold content in differently and must not be mixed:
+  `etag_update()` includes each record's length (data sets — the same bytes
+  re-split are a different resource), `etag_update_raw()` does not (USS — a
+  byte stream, where the read buffer size is an artefact and must not reach the
+  value). On USS the precondition also runs *before* the truncating `"w"` open,
+  which is why a directory is probed with `ufs_stat()` and falls through to the
+  write path rather than being reported as a stale 412 — adding `If-Match` must
+  not change how a non-file path is answered. That answer is **404**, not the
+  400 the `UFSD_RC_ISDIR` row below promises: `ufs_fopen()` returns NULL for a
+  directory in either mode, so there is no ISDIR to map. Measured on the stand;
+  open as #269.
 - **jobsapi.c**: Jobs REST API handlers — submit JCL, list/status/purge jobs, read spool files. Uses JES2 interfaces.
 - **ussapi.c**: USS file REST API handlers — list, read, write, create, delete for UNIX files/directories via libufs/UFSD. Includes chtag utility stub.
 - **consapi.c**: Console services handlers — issue command (SVC 34/MGCR), collect response, detect unsolicited keyword, hardcopy log. Reads console data from the Master Trace Table (libc370 `clibmtt`).

--- a/docs/endpoints/uss/get.md
+++ b/docs/endpoints/uss/get.md
@@ -16,22 +16,54 @@ GET /zosmf/restfiles/fs/{filepath}
 
 ### Headers
 
-| Header            | Required | Default | Description |
-|-------------------|----------|---------|-------------|
-| `X-IBM-Data-Type` | No       | `text`  | `text` or `binary` |
+| Header               | Required | Default | Description |
+|----------------------|----------|---------|-------------|
+| `X-IBM-Data-Type`    | No       | `text`  | `text` or `binary` |
+| `X-IBM-Return-Etag`  | No       | —       | `true` returns an `ETag` for the file, for use as `If-Match` on a later write |
 
 ## Response (200 OK)
 
 ### Text Mode (default)
 
 - Content-Type: `text/plain`
-- File content is converted from EBCDIC to ASCII via `mvsmf_etoa()`
+- File content is converted from EBCDIC to ASCII (IBM-1047) before it is sent
 - Streamed in 4 KB chunks
 
 ### Binary Mode
 
 - Content-Type: `application/octet-stream`
 - Raw bytes, no encoding conversion
+
+## ETag
+
+With `X-IBM-Return-Etag: true` the response carries an `ETag` header — a
+16-hex-digit stamp over the file's content as stored. Sending it back on a
+subsequent PUT as `If-Match` makes that write conditional: it succeeds only if
+the file still holds the state that was read. See
+[put.md](put.md) for the write half.
+
+```
+ETag: 3F5C1A9B0000002B
+Access-Control-Expose-Headers: ETag
+```
+
+Three properties worth relying on:
+
+- **The stamp is over the stored bytes**, not over what the response sends. A
+  text read and a binary read of the same file therefore return the *same*
+  ETag, even though their bodies differ by the codepage translation.
+- **It is a byte-stream stamp**, computed independently of how the file is
+  chunked while reading. Nothing about the buffer size or the UFS block layout
+  reaches the value.
+- **It is opt-in.** Computing it costs a second read pass over the file, so a
+  request without the header gets no `ETag` and pays nothing.
+
+`Access-Control-Expose-Headers` is sent alongside because `ETag` is not
+CORS-safelisted: without it a cross-origin client reads `null` and cannot tell
+that apart from a server with no ETag support.
+
+There is no `If-None-Match` / 304 support on this endpoint yet; the data set
+endpoints have it (#263), USS is a follow-up.
 
 ## Error Responses
 
@@ -75,7 +107,7 @@ zowe files download uf "/home/ibmuser/hello.txt" -f hello.txt
 - No `Content-Length` header in response (streamed without prior size calculation)
 - No `X-IBM-Intrdr-*` headers for record-mode reading
 - No `search` query parameter for in-file searching
-- No `If-None-Match` / ETag support
+- No `If-None-Match` conditional read (the `ETag` itself is supported)
 
 ## Handler
 

--- a/docs/endpoints/uss/put.md
+++ b/docs/endpoints/uss/put.md
@@ -18,9 +18,11 @@ PUT /zosmf/restfiles/fs/{filepath}
 
 | Header            | Required | Default | Description |
 |-------------------|----------|---------|-------------|
-| `Content-Length`  | Yes      | —       | Size of the request body in bytes |
-| `X-IBM-Data-Type` | No       | `text`  | `text` or `binary` |
-| `Content-Type`   | No       | —       | If `application/json`, returns 501 (Phase 2 utilities) |
+| `Content-Length`     | Yes      | —       | Size of the request body in bytes |
+| `X-IBM-Data-Type`    | No       | `text`  | `text` or `binary` |
+| `Content-Type`       | No       | —       | If `application/json`, dispatches to the USS utilities handler |
+| `If-Match`           | No       | —       | An `ETag` from an earlier read. The write proceeds only if the file still matches it; otherwise **412** and nothing is written |
+| `X-IBM-Return-Etag`  | No       | —       | `true` returns the `ETag` of the file as it stands after the write |
 
 ### Body
 
@@ -29,14 +31,15 @@ Raw file content to write.
 ## Encoding
 
 - **Text mode (default):** Request body is converted from ASCII to EBCDIC
-  via `mvsmf_atoe()` before writing to UFS
+  (IBM-1047) before writing to UFS
 - **Binary mode:** Raw bytes written with no conversion
 
 ## Response
 
 ### Success (204 No Content)
 
-No response body.
+No response body. Carries an `ETag` header when `X-IBM-Return-Etag: true` was
+sent.
 
 ### Content-Type Dispatch
 
@@ -64,12 +67,48 @@ utility request. The `"request"` field determines which utility to invoke.
 
 All other utility requests return **501 Not Implemented**.
 
+## Conditional writes (If-Match)
+
+Without `If-Match`, a PUT is last-write-wins: two clients editing the same file
+both get 204 and the later save silently discards the earlier one. Nothing in
+the response distinguishes that from a clean save.
+
+`If-Match` closes that hole. Read the file with `X-IBM-Return-Etag: true`, keep
+the `ETag`, and send it back when saving. The handler re-reads the file and
+compares before opening it for output; on a mismatch it answers **412
+Precondition Failed** and writes nothing.
+
+- **Take the next `If-Match` from the PUT response**, not from the value you
+  sent. The ETag in the PUT response is computed by re-reading the file after
+  the write, and is the one the next `If-Match` must carry. Reusing the
+  pre-save stamp fails.
+- **Accepted forms**: bare (`If-Match: 3F5C…`), quoted (`"3F5C…"`), weak
+  (`W/"3F5C…"`), and comma-separated lists of those. Comparison is
+  case-insensitive.
+- **`If-Match: *`** asserts only that the file exists.
+- Without `If-Match` nothing changes; existing clients are unaffected.
+
+### What a missing path answers
+
+A PUT creates the file if it is not there, so there is no 404 to compete with:
+when `If-Match` (including `*`) names a path that does not exist, the
+precondition has failed and the answer is **412** — nothing is created. This is
+the opposite ordering from a GET, where a missing path is **404** before any
+conditional header is looked at, because the more specific answer wins.
+
+A path that *is* a directory answers exactly as it would without `If-Match`:
+**404**. Adding a precondition does not change how a non-file path is reported.
+That 404 is itself a deviation from the `UFSD_RC_ISDIR` → 400 row of the error
+mapping — `ufs_fopen()` returns NULL for a directory in either mode, so the
+handler has no ISDIR to report — tracked separately as issue #269.
+
 ## Error Responses
 
 | Status | Condition |
 |--------|-----------|
-| 400    | Missing filepath, empty body, or invalid utility request |
-| 404    | Cannot open file for writing (parent directory not found) |
+| 400    | Missing filepath or invalid utility request |
+| 404    | Cannot open file for writing (parent directory not found, or the path is a directory — see #269) |
+| 412    | `If-Match` was supplied and the file no longer matches it — including a file that no longer exists |
 | 414    | Path name too long |
 | 500    | No space left on device or I/O error (64 KB limit) |
 | 501    | Unsupported USS utility (Content-Type: application/json with unknown request) |
@@ -104,6 +143,24 @@ curl -X PUT -u IBMUSER:sys1 \
 
 ```bash
 echo "Hello World!" | zowe files upload stdin-to-uf "/home/ibmuser/hello.txt"
+```
+
+### Save a file conditionally with curl
+
+```bash
+# Read, keeping the stamp
+ETAG=$(curl -s -o hello.txt -D - -u IBMUSER:sys1 \
+  -H "X-IBM-Return-Etag: true" \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/hello.txt" \
+  | grep -i '^ETag:' | tr -d '\r' | sed 's/^[^ ]* //')
+
+# Save it back only if nobody else changed it in the meantime
+curl -X PUT -u IBMUSER:sys1 \
+  -H "If-Match: ${ETAG}" \
+  -H "X-IBM-Return-Etag: true" \
+  --data-binary @hello.txt \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/hello.txt"
+# -> 204 and a new ETag, or 412 if the file changed in the meantime
 ```
 
 ### Query file tag with curl (chtag utility)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -321,6 +321,35 @@ curl -s -u $USER:$PASS -X PUT --data-binary @local.txt \
 zowe files upload ftu ./local.txt "/tmp/hello.txt"
 ```
 
+### Write a file without clobbering someone else's edit
+`GET` with `X-IBM-Return-Etag`, then `PUT` with `If-Match`
+
+The same optimistic locking the data set endpoints have, on USS files. A plain
+`PUT` is last-write-wins; sending the stamp back makes the write conditional.
+
+```bash
+# read, keeping the stamp
+ETAG=$(curl -s -D - -o local.txt -u $USER:$PASS \
+  -H "X-IBM-Return-Etag: true" \
+  "$BASE/zosmf/restfiles/fs/tmp/hello.txt" \
+  | grep -i '^ETag:' | tr -d '\r' | sed 's/^[^ ]* //')
+
+# ... edit local.txt ...
+
+# save only if nobody else did in the meantime
+curl -s -o /dev/null -w '%{http_code}\n' -u $USER:$PASS -X PUT \
+  -H "If-Match: $ETAG" -H "X-IBM-Return-Etag: true" \
+  --data-binary @local.txt \
+  "$BASE/zosmf/restfiles/fs/tmp/hello.txt"
+# 204 = saved, 412 = someone else changed it; reload and re-apply
+```
+
+Take the next `If-Match` from the PUT response's `ETag`, as on the data set
+side. A text read and a binary read of the same file give the same stamp — it
+is computed over the stored bytes, before any codepage translation. There is no
+`If-None-Match` on this endpoint yet. Details in
+[endpoints/uss/put.md](endpoints/uss/put.md#conditional-writes-if-match).
+
 ### Create a file or directory
 `POST /zosmf/restfiles/fs/{filepath}`
 

--- a/include/etag.h
+++ b/include/etag.h
@@ -3,27 +3,43 @@
 
 /**
  * @file etag.h
- * @brief ETag computation and If-Match parsing (issue #152)
+ * @brief ETag computation and If-Match parsing (issues #152, #264)
  *
- * An ETag is an opaque version stamp over the content of a data set or a
- * PDS member. It exists for one purpose: to let a client detect that the
- * resource changed between its read and its write, so a save cannot silently
- * discard someone else's edit ("lost update").
+ * An ETag is an opaque version stamp over the content of a data set, a PDS
+ * member or a USS file. It exists for one purpose: to let a client detect
+ * that the resource changed between its read and its write, so a save cannot
+ * silently discard someone else's edit ("lost update").
  *
- * The value is a CRC32 over the raw record stream plus the total byte count,
+ * The value is a CRC32 over the stored bytes plus the total byte count,
  * rendered as 16 hex digits. Deliberately *not* a hash of the bytes sent to
- * the client: those depend on X-IBM-Data-Type and on the trailing-blank
- * stripping the text path applies, so a client reading text and writing
- * binary would collide with itself. Hashing the records instead keeps one
- * stamp per resource state, whatever mode it is read in.
+ * the client: those depend on X-IBM-Data-Type, on the trailing-blank
+ * stripping the text path applies, and on the codepage translation the USS
+ * path applies, so a client reading text and writing binary would collide
+ * with itself. Hashing what is stored instead keeps one stamp per resource
+ * state, whatever mode it is read in.
+ *
+ * There are two ways to fold content in, and which one a caller uses is part
+ * of that resource's stamp definition:
+ *
+ *   - etag_update() adds each record's length alongside its data, so record
+ *     boundaries are part of the value. Data sets and members need this: the
+ *     same bytes re-split into different records are a different resource.
+ *   - etag_update_raw() folds bytes only. A USS file is a byte stream with no
+ *     record structure, so the reader's chunking is an artefact -- folding it
+ *     in would make the stamp depend on the buffer size and on where the file
+ *     happens to be split across UFS blocks.
+ *
+ * Both accumulate ctx->len, which etag_final() folds into the value, so the
+ * "a line was added or removed" case is caught either way.
  *
  * The CRC is computed table-free. A 1 KB lookup table would be read-only and
  * therefore RENT-safe, but at member sizes the bitwise loop costs nothing and
  * the question does not need asking.
  *
  * Nothing here touches MVS services or the FILE control block, so the module
- * compiles and unit-tests natively (test/host/tstetag.c). The record reading
- * itself lives in dsapi.c, next to the DCB knowledge it needs.
+ * compiles and unit-tests natively (test/host/tstetag.c). The reading itself
+ * lives with the knowledge it needs: dataset_etag() in dsapi.c next to the
+ * DCB handling, uss_etag() in ussapi.c next to the UFS handling.
  */
 
 #include <stddef.h>
@@ -64,6 +80,23 @@ void etag_init(ETAGCTX *ctx) asm("ETG0001");
  * @param len Record length in bytes
  */
 void etag_update(ETAGCTX *ctx, const void *buf, size_t len) asm("ETG0002");
+
+/**
+ * @brief Folds a run of bytes into a running ETag computation
+ *
+ * The byte-stream counterpart of etag_update(): the length is *not* folded
+ * in, so the result depends only on the bytes and their order, not on how the
+ * caller split them. Feeding a file as one buffer or as any sequence of
+ * chunks produces the same stamp -- which is what lets uss_etag() read with a
+ * small buffer without tying the value to that buffer's size.
+ *
+ * Do not mix the two functions within one computation.
+ *
+ * @param ctx Computation state
+ * @param buf Data
+ * @param len Length in bytes
+ */
+void etag_update_raw(ETAGCTX *ctx, const void *buf, size_t len) asm("ETG0006");
 
 /**
  * @brief Renders the finished ETag as a hex string

--- a/src/etag.c
+++ b/src/etag.c
@@ -1,9 +1,10 @@
 /* ETAG.C
-** ETag computation and If-Match parsing for the data set API (issue #152).
+** ETag computation and If-Match parsing for the data set API (issue #152)
+** and the USS file API (issue #264).
 **
 ** See include/etag.h for what an ETag is for and why it is computed over the
-** raw record stream. This file is deliberately free of MVS services and of
-** the FILE control block, so it builds and unit-tests on the host as well
+** stored bytes. This file is deliberately free of MVS services and of the
+** FILE control block, so it builds and unit-tests on the host as well
 ** (test/host/tstetag.c).
 */
 
@@ -84,6 +85,32 @@ etag_update(ETAGCTX *ctx, const void *buf, size_t len)
 	crc = etag_byte(crc, (unsigned char) ((n >> 8) & 0xFF));
 	crc = etag_byte(crc, (unsigned char) (n & 0xFF));
 
+	for (i = 0; i < len; i++) {
+		crc = etag_byte(crc, p[i]);
+	}
+
+	ctx->crc = crc;
+	ctx->len += (unsigned int) len;
+}
+
+void
+etag_update_raw(ETAGCTX *ctx, const void *buf, size_t len)
+{
+	const unsigned char	*p = (const unsigned char *) buf;
+	unsigned int		 crc;
+	size_t			 i;
+
+	if (!ctx || !buf) {
+		return;
+	}
+
+	crc = ctx->crc;
+
+	/* No length fold, deliberately -- see etag.h. A byte stream has no
+	   record boundaries to preserve, and folding the length of each chunk
+	   would make the stamp depend on how the reader happened to split the
+	   file rather than on its content. The total still reaches the value
+	   through ctx->len in etag_final(). */
 	for (i = 0; i < len; i++) {
 		crc = etag_byte(crc, p[i]);
 	}

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -9,11 +9,17 @@
 
 #include "ussapi.h"
 #include "common.h"
+#include "etag.h"
 #include "httpcgi.h"
 
 // Data type constants
 #define USS_DATA_TYPE_TEXT   1
 #define USS_DATA_TYPE_BINARY 2
+
+// Wording deliberately identical to the data set path (ERR_MSG_ETAG_MISMATCH
+// in dsapi_err.h): one condition, one message, whichever resource it is about.
+#define USS_MSG_ETAG_MISMATCH \
+	"The resource was modified since the supplied ETag was created"
 
 // Forward declarations
 static int uss_extract_json_string(const char *json, const char *key,
@@ -154,6 +160,136 @@ uss_build_path(char *buf, size_t bufsz, const char *captured)
 	return buf;
 }
 
+
+//
+// uss_etag — compute the ETag of a USS file (issue #264)
+//
+// One extra read pass, opened and closed here. Both callers go through this
+// function -- the GET before it sends its headers, the PUT before it opens for
+// output and again after the file is closed -- so there is one definition of
+// the stamp and no way for the read side and the write side to drift apart.
+//
+// Three properties this depends on:
+//
+//   - The bytes are hashed exactly as stored. No translation: the payload the
+//     GET sends is IBM-1047-translated in text mode and raw in binary mode, so
+//     stamping what goes on the wire would give one file two stamps. The same
+//     reason the PUT stamps by re-reading the closed file rather than by
+//     hashing the request body it has just translated.
+//
+//   - etag_update_raw(), not etag_update(). A USS file is a byte stream; the
+//     chunking below is the reader's business and must not reach the value.
+//     See etag.h.
+//
+//   - It never runs while the same file is open elsewhere in the handler.
+//     Open-hash-close, then open for the body.
+//
+// Returns 0 with out filled. On failure returns -1 and sets *ufs_rc to the
+// UFSD diagnosis, which the caller needs: a path that is a directory is a
+// different answer from a path that is not there (see uss_check_if_match).
+//
+
+#define USS_ETAG_BUFSZ 1024
+
+__asm__("\n&FUNC    SETC 'uss_etag'");
+static int
+uss_etag(UFS *ufs, const char *path, char *out, size_t outlen, int *ufs_rc)
+{
+	ETAGCTX  ctx;
+	UFSFILE *fp;
+	char     buf[USS_ETAG_BUFSZ];
+	UINT32   n;
+
+	*ufs_rc = UFSD_RC_NOFILE;
+
+	fp = ufs_fopen(ufs, path, "r");
+	if (!fp) {
+		return -1;
+	}
+
+	if (fp->error != UFSD_RC_OK) {
+		*ufs_rc = fp->error;
+		ufs_fclose(&fp);
+		return -1;
+	}
+
+	etag_init(&ctx);
+	while ((n = ufs_fread(buf, 1, sizeof(buf), fp)) > 0) {
+		etag_update_raw(&ctx, buf, n);
+	}
+
+	// A read that stopped short leaves a stamp over a prefix of the file,
+	// which would compare unequal to itself on the next attempt. Fail
+	// instead: no stamp is better than an unstable one.
+	if (ufs_ferror(fp)) {
+		*ufs_rc = (fp->error != UFSD_RC_OK) ? fp->error : UFSD_RC_IO;
+		ufs_fclose(&fp);
+		return -1;
+	}
+
+	*ufs_rc = UFSD_RC_OK;
+	ufs_fclose(&fp);
+
+	return etag_final(&ctx, out, outlen);
+}
+
+//
+// uss_check_if_match — enforce an If-Match precondition before a write (#264)
+//
+// Returns 0 when the write may proceed -- either no If-Match was sent, or it
+// still matches. Returns -1 when an error response has already been sent, in
+// which case the caller must return without writing anything.
+//
+// A file that cannot be read fails the precondition rather than falling
+// through to the write: the client is asserting "the state I read is still
+// there", and a file since deleted is exactly the case that assertion exists
+// to catch. That covers "If-Match: *" too -- the wildcard asserts existence.
+//
+// A directory is the exception, and it falls through instead. Adding If-Match
+// to a request must not change how a path that is not a file is answered, and
+// this check runs before the open that answers it. Note that answer is 404,
+// not the 400 the UFSD mapping table would suggest: ufs_fopen() returns NULL
+// for a directory in either mode, with no ISDIR to report. Measured, not
+// assumed -- see issue #269.
+//
+// The probe is ufs_stat(), which reads metadata without an open. If it cannot
+// answer, the precondition fails: 412 and no write is the safe direction.
+//
+
+__asm__("\n&FUNC    SETC 'uss_ck_ifmatch'");
+static int
+uss_check_if_match(Session *session, UFS *ufs, const char *path)
+{
+	const char *if_match;
+	char        current[ETAG_SIZE];
+	int         urc = UFSD_RC_OK;
+
+	if_match = getHeaderParam(session, "If-Match");
+	if (!if_match) {
+		return 0;
+	}
+
+	if (uss_etag(ufs, path, current, sizeof(current), &urc) < 0) {
+		UFSDLIST st;
+
+		memset(&st, 0, sizeof(st));
+		if (ufs_stat(ufs, path, &st) == UFSD_RC_OK && st.attr[0] == 'd') {
+			return 0;  /* let the write path answer it */
+		}
+
+		sendErrorResponse(session, 412, 4, 8, 1,
+			USS_MSG_ETAG_MISMATCH, NULL, 0);
+		return -1;
+	}
+
+	if (!etag_matches(if_match, current)) {
+		sendErrorResponse(session, 412, 4, 8, 1,
+			USS_MSG_ETAG_MISMATCH, NULL, 0);
+		return -1;
+	}
+
+	return 0;
+}
 
 //
 // Default max items for directory listing
@@ -477,6 +613,8 @@ int ussGetHandler(Session *session)
 	UFSFILE *fp = NULL;
 	char buf[USS_READ_BUFSZ];
 	UINT32 n;
+	char etag[ETAG_SIZE] = {0};
+	const char *etag_hdr = NULL;
 
 	// Get filepath from path variable and build absolute path
 	raw_path = getPathParam(session, "filepath");
@@ -497,6 +635,21 @@ int ussGetHandler(Session *session)
 	ufs = uss_get_ufs(session);
 	if (!ufs) {
 		return -1;
+	}
+
+	// ETag, if asked for (issue #264). Before the file is opened for the
+	// body: one handle on a path at a time, and the value has to be known
+	// before the first response byte goes out anyway. That costs a second
+	// read pass over the file, which is why it is opt-in.
+	//
+	// A file that cannot be hashed simply gets no ETag here; the open below
+	// then produces the real diagnosis rather than this pass guessing at one.
+	if (etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"))) {
+		int urc = UFSD_RC_OK;
+
+		if (uss_etag(ufs, abspath, etag, sizeof(etag), &urc) == 0) {
+			etag_hdr = etag;
+		}
 	}
 
 	// Open file for reading
@@ -528,6 +681,14 @@ int ussGetHandler(Session *session)
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", content_type)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
+	if (etag_hdr) {
+		if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag_hdr)) < 0) goto quit;
+		/* ETag is not a CORS-safelisted response header: without this a
+		   cross-origin client gets null from headers.get("ETag") and
+		   cannot tell that apart from a server with no ETag support. */
+		if ((rc = http_printf(session->httpc,
+			"Access-Control-Expose-Headers: ETag\r\n")) < 0) goto quit;
+	}
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
 	// Stream file content in chunks
@@ -683,6 +844,8 @@ int ussPutHandler(Session *session)
 	UFS *ufs = NULL;
 	UFSFILE *fp = NULL;
 	UINT32 written;
+	char etag[ETAG_SIZE] = {0};
+	const char *etag_hdr = NULL;
 
 	// Get filepath from path variable and build absolute path
 	raw_path = getPathParam(session, "filepath");
@@ -727,6 +890,16 @@ int ussPutHandler(Session *session)
 		return -1;
 	}
 
+	// If-Match, before the file is opened for output (issue #264). The "w"
+	// open truncates, so a precondition checked after it would already have
+	// destroyed the content it exists to protect. The body is read first
+	// regardless -- leaving it in the socket would break the connection for
+	// the next request on it.
+	if (uss_check_if_match(session, ufs, abspath) < 0) {
+		free(body);
+		return 0;
+	}
+
 	// Open file for writing (creates if not exists)
 	fp = ufs_fopen(ufs, abspath, "w");
 	if (!fp) {
@@ -764,8 +937,35 @@ int ussPutHandler(Session *session)
 		goto quit;
 	}
 
-	// Success — 204 No Content
-	rc = sendDefaultHeaders(session, 204, HTTP_CONTENT_TYPE_NONE, 0);
+	// Close before stamping: the write-behind buffer is only flushed here,
+	// so a stamp taken with the file still open would hash a stale tail.
+	ufs_fclose(&fp);
+	fp = NULL;
+
+	// ETag of the state just written (issue #264), from re-reading the closed
+	// file -- never from hashing the request body. The body has been
+	// translated in place by now, and one definition of the stamp is what
+	// makes the value a PUT returns usable as the next If-Match.
+	if (etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"))) {
+		int urc = UFSD_RC_OK;
+
+		if (uss_etag(ufs, abspath, etag, sizeof(etag), &urc) == 0) {
+			etag_hdr = etag;
+		}
+	}
+
+	// Success — 204 No Content. Hand-rolled rather than via
+	// sendDefaultHeaders(), which has nowhere to put the ETag.
+	session->headers_sent = 1;
+	if ((rc = http_resp(session->httpc, 204)) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
+	if (etag_hdr) {
+		if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag_hdr)) < 0) goto quit;
+		if ((rc = http_printf(session->httpc,
+			"Access-Control-Expose-Headers: ETag\r\n")) < 0) goto quit;
+	}
+	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
 quit:
 	if (fp) {

--- a/test/host/tstetag.c
+++ b/test/host/tstetag.c
@@ -113,6 +113,58 @@ main(void)
 		CHECK(strcmp(a, b) != 0, "AB|C and A|BC do not stamp alike");
 	}
 
+	printf("\n--- #264: a byte stream stamps independently of chunking ---\n");
+	{
+		/* uss_etag() reads a file with a fixed buffer, so the same content
+		   arrives as whatever chunks the size and the UFS block layout
+		   produce. etag_update_raw() must therefore fold bytes only: if the
+		   chunk lengths reached the CRC, one buffer size would stamp a file
+		   differently from another, and a client's If-Match would fail
+		   against content nobody changed. */
+		const char whole[] = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG";
+		size_t     len = sizeof(whole) - 1;
+		ETAGCTX    ctx;
+		size_t     off;
+		size_t     cut[] = { 7, 13, 23 };
+		int        i;
+
+		etag_init(&ctx);
+		etag_update_raw(&ctx, whole, len);
+		etag_final(&ctx, a, sizeof(a));
+
+		etag_init(&ctx);
+		off = 0;
+		for (i = 0; i < 3 && off < len; i++) {
+			size_t n = (cut[i] < len - off) ? cut[i] : len - off;
+			etag_update_raw(&ctx, whole + off, n);
+			off += n;
+		}
+		etag_update_raw(&ctx, whole + off, len - off);
+		etag_final(&ctx, b, sizeof(b));
+
+		CHECK(strcmp(a, b) == 0,
+			"one buffer and 7|13|23|rest stamp the same bytes alike");
+
+		/* Byte-for-byte, though, it must still be a content stamp. */
+		etag_init(&ctx);
+		etag_update_raw(&ctx, "THE QUICK BROWN FOX JUMPS OVER THE LAZY DO", len - 1);
+		etag_final(&ctx, b, sizeof(b));
+		CHECK(strcmp(a, b) != 0, "a byte removed changes the stamp");
+
+		etag_init(&ctx);
+		etag_update_raw(&ctx, "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOD", len);
+		etag_final(&ctx, b, sizeof(b));
+		CHECK(strcmp(a, b) != 0, "a byte changed changes the stamp");
+
+		/* The two folds are different definitions on purpose -- mixing them
+		   within one computation would silently produce a third. */
+		etag_init(&ctx);
+		etag_update(&ctx, whole, len);
+		etag_final(&ctx, b, sizeof(b));
+		CHECK(strcmp(a, b) != 0,
+			"the record fold and the raw fold are distinct stamps");
+	}
+
 	printf("\n--- #152: an empty resource still stamps ---\n");
 	{
 		ETAGCTX ctx;

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -498,16 +498,260 @@ if [ -n "$TEST_FILE" ]; then
 	echo ""
 	echo "--- Write to directory path ---"
 
+	# Its own directory, not TEST_DIR. TEST_DIR defaults to "/", which the
+	# wildcard captures as the empty string -- the handler's missing-path
+	# guard then answers 400 before ever reaching UFSD, so the assertion
+	# passed without testing ISDIR at all.
+	DIR_FIXTURE="${TEST_FILE}.dirtest"
+	cleanup_recursive "$DIR_FIXTURE"
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X POST -u "$AUTH" \
+		-H "Content-Type: application/json" \
+		-d '{"type":"directory"}' \
+		"${BASE_URL}/zosmf/restfiles/fs${DIR_FIXTURE}")
+	assert_http_status "201" "$HTTP_CODE" "write-to-dir: create the fixture"
+
 	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 		-X PUT -u "$AUTH" \
 		-H "Content-Length: 10" \
 		-d "some data!" \
-		"${BASE_URL}/zosmf/restfiles/fs${TEST_DIR}")
+		"${BASE_URL}/zosmf/restfiles/fs${DIR_FIXTURE}")
 
-	assert_http_status "400" "$HTTP_CODE" "write to directory returns 400 (ISDIR)"
+	# 404, not the 400 the UFSD_RC_ISDIR row of the mapping table in
+	# CLAUDE.md promises: ufs_fopen() returns NULL for a directory, so the
+	# handler has no ISDIR to report and falls into its "cannot open"
+	# branch. Tracked as issue #269 -- asserted here as it actually behaves,
+	# so the day it is fixed this test says so.
+	assert_http_status "404" "$HTTP_CODE" "write to directory returns 404"
+
+	# The empty path is a different 400, and worth holding separately so the
+	# two cannot be confused again.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-d "some data!" \
+		"${BASE_URL}/zosmf/restfiles/fs/")
+
+	assert_http_status "400" "$HTTP_CODE" "write to an empty path returns 400"
 
 	# Cleanup
 	cleanup "$WRITE_FILE"
+	cleanup_recursive "$DIR_FIXTURE"
+
+	# -----------------------------------------------------------------
+	# ETag / optimistic locking (issue #264)
+	#
+	# Its own file: the section rewrites the content several times and
+	# compares stamps across those writes, so sharing WRITE_FILE with the
+	# blocks above would make a failure here look like a write failure there.
+	# -----------------------------------------------------------------
+
+	echo ""
+	echo "--- ETag: optimistic locking (issue #264) ---"
+
+	ETAG_FILE="${TEST_FILE}.etagtest"
+	cleanup "$ETAG_FILE"
+
+	# Pull the ETag out of a response header dump. Case-insensitive, CR
+	# stripped: curl writes the header block verbatim, MVS sends CRLF.
+	get_etag() {
+		grep -i '^ETag:' "$1" | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]:[ ]*//'
+	}
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-d "LINE ONE AND LINE TWO" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" "etag: seed the file"
+
+	# An ETag costs an extra read pass, so it is opt-in: no header, no ETag.
+	curl -s -o /dev/null -D /tmp/curl_uss_h1.txt -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	if [ -z "$(get_etag /tmp/curl_uss_h1.txt)" ]; then
+		pass "etag: a plain GET returns no ETag"
+	else
+		fail "etag: a plain GET returns no ETag" \
+			"got $(get_etag /tmp/curl_uss_h1.txt)"
+	fi
+
+	curl -s -o /dev/null -D /tmp/curl_uss_h1.txt -u "$AUTH" \
+		-H "X-IBM-Return-Etag: true" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	ETAG1=$(get_etag /tmp/curl_uss_h1.txt)
+	if [ -n "$ETAG1" ]; then
+		pass "etag: X-IBM-Return-Etag returns one ($ETAG1)"
+	else
+		fail "etag: X-IBM-Return-Etag returns one" "no ETag header in response"
+	fi
+
+	if echo "$ETAG1" | grep -qE '^[0-9A-F]{16}$'; then
+		pass "etag: the value is 16 uppercase hex digits"
+	else
+		fail "etag: the value is 16 uppercase hex digits" "got '$ETAG1'"
+	fi
+
+	# Stability: an unstable stamp 412s saves that should have succeeded.
+	curl -s -o /dev/null -D /tmp/curl_uss_h2.txt -u "$AUTH" \
+		-H "X-IBM-Return-Etag: true" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	ETAG2=$(get_etag /tmp/curl_uss_h2.txt)
+	if [ "$ETAG1" = "$ETAG2" ]; then
+		pass "etag: an unchanged file stamps the same twice"
+	else
+		fail "etag: an unchanged file stamps the same twice" "$ETAG1 vs $ETAG2"
+	fi
+
+	# The stamp is over the stored bytes, so the read mode cannot change it.
+	# Text and binary differ in the codepage translation on the way out; if
+	# that reached the hash, a client reading text could not write binary.
+	curl -s -o /dev/null -D /tmp/curl_uss_h3.txt -u "$AUTH" \
+		-H "X-IBM-Return-Etag: true" \
+		-H "X-IBM-Data-Type: binary" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	ETAG3=$(get_etag /tmp/curl_uss_h3.txt)
+	if [ "$ETAG1" = "$ETAG3" ]; then
+		pass "etag: text and binary reads stamp alike"
+	else
+		fail "etag: text and binary reads stamp alike" "$ETAG1 vs $ETAG3"
+	fi
+
+	# A stale If-Match must be refused, and must not have written anything.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: 0000000000000000" \
+		-d "OVERWRITTEN" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "412" "$HTTP_CODE" "etag: a stale If-Match is refused"
+
+	BODY=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	if echo "$BODY" | grep -q "LINE ONE AND LINE TWO"; then
+		pass "etag: the refused write left the file untouched"
+	else
+		fail "etag: the refused write left the file untouched" \
+			"content is now '$BODY'"
+	fi
+
+	# The current stamp is accepted, and the PUT hands back the new one.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-D /tmp/curl_uss_h4.txt \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: ${ETAG1}" \
+		-H "X-IBM-Return-Etag: true" \
+		-d "LINE ONE AND LINE TWO CHANGED" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" "etag: a current If-Match is accepted"
+
+	ETAG4=$(get_etag /tmp/curl_uss_h4.txt)
+	if [ -n "$ETAG4" ] && [ "$ETAG4" != "$ETAG1" ]; then
+		pass "etag: the PUT returns the new stamp ($ETAG4)"
+	else
+		fail "etag: the PUT returns the new stamp" "got '$ETAG4', was '$ETAG1'"
+	fi
+
+	# The PUT stamp comes from re-reading the closed file, so it must equal
+	# what the next GET computes. If it did not, every second save would 412.
+	curl -s -o /dev/null -D /tmp/curl_uss_h5.txt -u "$AUTH" \
+		-H "X-IBM-Return-Etag: true" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	ETAG5=$(get_etag /tmp/curl_uss_h5.txt)
+	if [ "$ETAG4" = "$ETAG5" ]; then
+		pass "etag: the PUT stamp matches the next GET stamp"
+	else
+		fail "etag: the PUT stamp matches the next GET stamp" "$ETAG4 vs $ETAG5"
+	fi
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: ${ETAG4}" \
+		-d "LINE ONE AND LINE TWO" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" \
+		"etag: a second save with the returned stamp"
+
+	# The forms clients actually send: quoted and weak validators.
+	curl -s -o /dev/null -D /tmp/curl_uss_h6.txt -u "$AUTH" \
+		-H "X-IBM-Return-Etag: true" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	ETAG6=$(get_etag /tmp/curl_uss_h6.txt)
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: \"${ETAG6}\"" \
+		-d "QUOTED FORM" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" "etag: a quoted If-Match is accepted"
+
+	curl -s -o /dev/null -D /tmp/curl_uss_h7.txt -u "$AUTH" \
+		-H "X-IBM-Return-Etag: true" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	ETAG7=$(get_etag /tmp/curl_uss_h7.txt)
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: W/\"${ETAG7}\"" \
+		-d "WEAK FORM" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" "etag: a weak If-Match is accepted"
+
+	# "*" asserts only that the file exists.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: *" \
+		-d "WILDCARD FORM" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" \
+		"etag: If-Match: * on an existing file is accepted"
+
+	# ... and on a path that is not there it fails. A PUT creates, so there
+	# is no 404 to compete with: the precondition is the whole answer.
+	MISSING_FILE="${TEST_FILE}.etagmissing"
+	cleanup "$MISSING_FILE"
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: *" \
+		-d "SHOULD NOT BE CREATED" \
+		"${BASE_URL}/zosmf/restfiles/fs${MISSING_FILE}")
+	assert_http_status "412" "$HTTP_CODE" \
+		"etag: If-Match: * on a missing file is refused"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/fs${MISSING_FILE}")
+	assert_http_status "404" "$HTTP_CODE" \
+		"etag: the refused write created nothing"
+
+	# Adding If-Match must not change how a directory is answered: the same
+	# 404 as the unconditional write above, not 412. Needs a real directory
+	# -- see the write-to-directory block above for why TEST_DIR will not do.
+	ETAG_DIR="${TEST_FILE}.etagdir"
+	cleanup_recursive "$ETAG_DIR"
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X POST -u "$AUTH" \
+		-H "Content-Type: application/json" \
+		-d '{"type":"directory"}' \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_DIR}")
+	assert_http_status "201" "$HTTP_CODE" "etag: create the directory fixture"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-H "If-Match: *" \
+		-d "some data!" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_DIR}")
+	assert_http_status "404" "$HTTP_CODE" \
+		"etag: If-Match on a directory answers as the plain write does"
+
+	cleanup_recursive "$ETAG_DIR"
+
+	# A write with no If-Match is unconditional, as before the feature.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-d "UNCONDITIONAL" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" \
+		"etag: a write without If-Match is unconditional"
+
+	cleanup "$ETAG_FILE"
+	rm -f /tmp/curl_uss_h1.txt /tmp/curl_uss_h2.txt /tmp/curl_uss_h3.txt \
+		/tmp/curl_uss_h4.txt /tmp/curl_uss_h5.txt /tmp/curl_uss_h6.txt \
+		/tmp/curl_uss_h7.txt
 else
 	echo ""
 	echo "--- Write file tests ---"

--- a/tests/zowe-uss.sh
+++ b/tests/zowe-uss.sh
@@ -384,6 +384,18 @@ else
 	fail "deleted directory is gone" "expected non-zero rc, got 0"
 fi
 
+# --- ETag / optimistic locking (issue #264) ---
+echo ""
+echo "--- ETag: optimistic locking (issue #264) ---"
+
+# Same gap as on the data set side: the z/OSMF SDK carries an ETag through its
+# USS upload/download options, but the CLI exposes no flag for either, so
+# `zowe files upload ftu` cannot be given an If-Match and `zowe files download
+# uss-file` cannot be asked for an ETag. The coverage lives in
+# tests/curl-uss.sh instead. Recorded as a skip rather than left out, so the
+# gap stays visible if a later CLI version does expose it.
+skip "etag: X-IBM-Return-Etag / If-Match (no Zowe CLI flag — see curl-uss.sh)"
+
 # =========================================================================
 # Cleanup
 # =========================================================================


### PR DESCRIPTION
Fixes #264.

Brings the optimistic locking of #152 to `/zosmf/restfiles/fs`. `GET` with
`X-IBM-Return-Etag: true` returns an `ETag`; `PUT` with `If-Match` answers 412
and writes nothing when the file no longer matches.

## The stamp

`etag.c` gains `etag_update_raw()`, a second fold that omits the record length
`etag_update()` mixes in. A USS file is a byte stream, so the read chunking is
an artefact — folding each chunk's length in would tie the value to the buffer
size and to the file's UFS block layout. `etag_final()` still folds the total,
so a line added or removed is caught either way. TSTETAG pins both properties:
one buffer and `7|13|23|rest` stamp alike, and the two folds stay distinct.

`uss_etag()` hashes the **stored** bytes with no translation. Text mode sends
IBM-1047 and binary mode sends raw, so stamping the wire bytes would give one
file two stamps; this way a text read and a binary read agree. The PUT's
returned stamp comes from re-reading the closed file, not from the request body
it has just translated in place.

The precondition runs **before** the truncating `"w"` open — checked after it,
it would already have destroyed what it protects.

## One thing this deliberately does not change

A directory used to be diagnosed by that open, and the precondition check now
runs first. It probes with `ufs_stat()` and falls through rather than answering
412: adding `If-Match` must not change how a non-file path is reported.

That answer is **404**, not the 400 the `UFSD_RC_ISDIR` row of the mapping table
promises — `ufs_fopen()` returns NULL for a directory with no rc to map. That is
pre-existing and filed separately as #269. The old test claimed 400 and passed,
but aimed at `TEST_DIR` (default `/`), where the wildcard captures the empty
string and the missing-path guard answers 400 before UFSD is reached. It now
creates a real directory and asserts what actually happens.

## Not in scope

`If-None-Match` / 304 for USS (the read half of #263). `send_not_modified()` is
`static` in `dsapi.c`; hoisting it is a structural change that belongs in its
own issue. Noted in the docs as a gap.

## Verified on mvsdev

Deployed and activated via `tests/jcl/mvsmfact.jcl`, then:

- `tests/curl-uss.sh` — **88 passed, 0 failed, 1 skipped**
- `tests/curl-datasets.sh` — **177 passed, 0 failed** (no regression from the
  shared `etag.c`)
- `make test-host` — 170 assertions, TSTETAG at 43

Three assumptions about libufs were measurements, not guesses, and all three
held: `ufs_fclose()` flushes before the reopen (so the PUT stamp equals the next
GET stamp, and a second save with the returned stamp succeeds), `ufs_fread()`
streams the whole file, and no translation reaches the hash. The one assumption
that did **not** hold was `fp->error == UFSD_RC_ISDIR` for a directory, which is
what produced #269 and the fall-through above.

Note the deployed module reports build `814dc85` — it was built before these
commits existed, so `buildid.h` still carried the previous HEAD. The ETag
response itself was the liveness check.