### PR TITLE
uss: report the real error when an open returns NULL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,10 +258,11 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
   value). On USS the precondition also runs *before* the truncating `"w"` open,
   which is why a directory is probed with `ufs_stat()` and falls through to the
   write path rather than being reported as a stale 412 — adding `If-Match` must
-  not change how a non-file path is answered. That answer is **404**, not the
-  400 the `UFSD_RC_ISDIR` row below promises: `ufs_fopen()` returns NULL for a
-  directory in either mode, so there is no ISDIR to map. Measured on the stand;
-  open as #269.
+  not change how a non-file path is answered. That answer is the **400 ISDIR**
+  the row below promises — since #269, and it stays `ufs_stat()` here on
+  purpose: the write path may read its diagnosis off `ufs_last_rc()`, but a
+  stale value in *this* check would skip a precondition silently, which is the
+  one failure the feature exists to prevent.
 - **jobsapi.c**: Jobs REST API handlers — submit JCL, list/status/purge jobs, read spool files. Uses JES2 interfaces.
 - **ussapi.c**: USS file REST API handlers — list, read, write, create, delete for UNIX files/directories via libufs/UFSD. Includes chtag utility stub.
 - **consapi.c**: Console services handlers — issue command (SVC 34/MGCR), collect response, detect unsolicited keyword, hardcopy log. Reads console data from the Master Trace Table (libc370 `clibmtt`).

--- a/docs/endpoints/uss/get.md
+++ b/docs/endpoints/uss/get.md
@@ -71,6 +71,8 @@ endpoints have it (#263), USS is a follow-up.
 |--------|-----------|
 | 400    | Missing filepath or path is a directory |
 | 404    | File not found |
+| 414    | Path name too long |
+| 500    | I/O error |
 | 503    | UFSD subsystem not available |
 
 ## Max File Size

--- a/docs/endpoints/uss/put.md
+++ b/docs/endpoints/uss/put.md
@@ -97,17 +97,18 @@ the opposite ordering from a GET, where a missing path is **404** before any
 conditional header is looked at, because the more specific answer wins.
 
 A path that *is* a directory answers exactly as it would without `If-Match`:
-**404**. Adding a precondition does not change how a non-file path is reported.
-That 404 is itself a deviation from the `UFSD_RC_ISDIR` → 400 row of the error
-mapping — `ufs_fopen()` returns NULL for a directory in either mode, so the
-handler has no ISDIR to report — tracked separately as issue #269.
+**400** (`UFSD_RC_ISDIR`). Adding a precondition does not change how a non-file
+path is reported. It was 404 on both sides until issue #269 — `ufs_fopen()`
+returns NULL for a directory in either mode, and the diagnosis has to be read
+off the UFS session rather than off the (absent) file handle.
 
 ## Error Responses
 
 | Status | Condition |
 |--------|-----------|
-| 400    | Missing filepath or invalid utility request |
-| 404    | Cannot open file for writing (parent directory not found, or the path is a directory — see #269) |
+| 400    | Missing filepath, invalid utility request, or the path is a directory |
+| 403    | Read-only file system (not a z/OSMF status — the `UFSD_RC_ROFS` row is open as #248) |
+| 404    | Parent directory not found |
 | 412    | `If-Match` was supplied and the file no longer matches it — including a file that no longer exists |
 | 414    | Path name too long |
 | 500    | No space left on device or I/O error (64 KB limit) |

--- a/docs/uss-spec.md
+++ b/docs/uss-spec.md
@@ -626,6 +626,14 @@ Alle offenen Fragen sind beantwortet. Diese Sektion dient als verbindliche Refer
 
 Vollständig definiert in `ufsd.h`. Verbindliches Mapping für alle Handler:
 
+> **Historisch.** Die Spalten *HTTP Status* und *z/OSMF Category* geben den
+> Entwurfsstand wieder, nicht die Implementierung. Umgesetzt wurde eine andere
+> Zuordnung: 409/507/414 sind nicht in der z/OSMF-Statusliste (#102), und die
+> Kategorien weichen ab — ISDIR ist 400/**2**, nicht 400/6. Maßgeblich ist die
+> Tabelle in `CLAUDE.md` bzw. `ufsd_rc_to_http()` / `ufsd_rc_to_category()` in
+> `src/ussapi.c`. Bis #269 war der Unterschied folgenlos, weil ein Open die
+> Zuordnung überhaupt nicht erreichte; seitdem sieht ein Client sie.
+
 | RC | UFSD Konstante | HTTP Status | z/OSMF Category | Bedeutung |
 |----|---------------|-------------|-----------------|-----------|
 | 0 | `UFSD_RC_OK` | 200/201/204 | — | Erfolg |

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -92,6 +92,37 @@ ufsd_rc_message(int rc)
 }
 
 //
+// uss_open_rc — the diagnosis for a ufs_fopen() that returned NULL (issue #269)
+//
+// A failed open reports through the UFS session, not through the file handle:
+// libufs stores the server's rc in the UFS handle and returns NULL, so the
+// `fp->error` check that follows every open in this file only ever sees an
+// error on a handle that was opened successfully — which is none.
+//
+// A directory is the case that made this visible. UFSD answers ISDIR for an
+// open of one in either mode (ufsd#fil.c, read and write alike), so the whole
+// mapping table above was unreachable from an open and every failure came back
+// as 404 "not found" — including ROFS, NOSPACE and NOINODES.
+//
+// ufs_fopen() has two NULL returns that never reach the server and so leave
+// last_rc at whatever an earlier call put there: a path too long for the
+// request block, and a reply too short to hold a descriptor. Neither is
+// distinguishable from here. Only the "nothing was recorded" case is caught —
+// it keeps the 404 this code answered before — so a stale value can still name
+// the wrong error on a request that was failing either way. The path that
+// leads there is a name of 252 characters or more; see uss_build_path().
+//
+
+__asm__("\n&FUNC    SETC 'uss_open_rc'");
+static int
+uss_open_rc(UFS *ufs)
+{
+	int urc = ufs_last_rc(ufs);
+
+	return (urc == UFSD_RC_OK) ? UFSD_RC_NOFILE : urc;
+}
+
+//
 // UFS session helper — uses HTTPD-managed session via http_get_ufs()
 //
 
@@ -247,13 +278,14 @@ uss_etag(UFS *ufs, const char *path, char *out, size_t outlen, int *ufs_rc)
 //
 // A directory is the exception, and it falls through instead. Adding If-Match
 // to a request must not change how a path that is not a file is answered, and
-// this check runs before the open that answers it. Note that answer is 404,
-// not the 400 the UFSD mapping table would suggest: ufs_fopen() returns NULL
-// for a directory in either mode, with no ISDIR to report. Measured, not
-// assumed -- see issue #269.
+// this check runs before the open that answers it. That answer is 400 ISDIR
+// since #269; whatever it becomes, it is the write path's to give.
 //
-// The probe is ufs_stat(), which reads metadata without an open. If it cannot
-// answer, the precondition fails: 412 and no write is the safe direction.
+// The probe is ufs_stat(), which reads metadata without an open. Deliberately
+// not ufs_last_rc(): the open here failed for its own reasons, and a stale rc
+// would silently skip a precondition rather than merely misname an error. If
+// the probe cannot answer, the precondition fails: 412 and no write is the
+// safe direction.
 //
 
 __asm__("\n&FUNC    SETC 'uss_ck_ifmatch'");
@@ -652,11 +684,14 @@ int ussGetHandler(Session *session)
 		}
 	}
 
-	// Open file for reading
+	// Open file for reading. A NULL handle carries no error of its own —
+	// the diagnosis is on the session (issue #269).
 	fp = ufs_fopen(ufs, abspath, "r");
 	if (!fp) {
-		rc = sendErrorResponse(session, 404, 6, 8, 1,
-			"File not found or is a directory", NULL, 0);
+		int urc = uss_open_rc(ufs);
+		rc = sendErrorResponse(session,
+			ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
+			ufsd_rc_message(urc), NULL, 0);
 		return rc;
 	}
 
@@ -900,11 +935,14 @@ int ussPutHandler(Session *session)
 		return 0;
 	}
 
-	// Open file for writing (creates if not exists)
+	// Open file for writing (creates if not exists). A NULL handle carries no
+	// error of its own — the diagnosis is on the session (issue #269).
 	fp = ufs_fopen(ufs, abspath, "w");
 	if (!fp) {
-		rc = sendErrorResponse(session, 404, 6, 8, 1,
-			"Cannot open file for writing", NULL, 0);
+		int urc = uss_open_rc(ufs);
+		rc = sendErrorResponse(session,
+			ufsd_rc_to_http(urc), ufsd_rc_to_category(urc), 8, 1,
+			ufsd_rc_message(urc), NULL, 0);
 		goto quit;
 	}
 

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -346,16 +346,11 @@ if [ -n "$TEST_FILE_EXISTS" ]; then
 
 	assert_http_status "404" "$HTTP_CODE" "read non-existent file returns 404"
 
-	RESP=$(curl -s -w '\n%{http_code}' \
-		-u "$AUTH" \
-		"${BASE_URL}/zosmf/restfiles/fs${TEST_DIR}")
-	HTTP_CODE=$(echo "$RESP" | tail -1)
-
-	if [ "$HTTP_CODE" = "400" ] || [ "$HTTP_CODE" = "404" ]; then
-		pass "read directory as file returns error (HTTP $HTTP_CODE)"
-	else
-		fail "read directory as file" "expected HTTP 400 or 404, got $HTTP_CODE"
-	fi
+	# Reading a directory as a file is asserted in the "Directory as a file
+	# path" block below, not here: this section needs USS_TEST_FILE to be
+	# present on the target, and the directory case needs only a fixture it
+	# makes itself. Aiming it at TEST_DIR was what hid issue #269 -- see the
+	# comment there.
 else
 	echo ""
 	echo "--- Read file tests ---"
@@ -496,7 +491,7 @@ if [ -n "$TEST_FILE" ]; then
 	echo "--- Write file error cases ---"
 
 	echo ""
-	echo "--- Write to directory path ---"
+	echo "--- Directory as a file path ---"
 
 	# Its own directory, not TEST_DIR. TEST_DIR defaults to "/", which the
 	# wildcard captures as the empty string -- the handler's missing-path
@@ -517,12 +512,35 @@ if [ -n "$TEST_FILE" ]; then
 		-d "some data!" \
 		"${BASE_URL}/zosmf/restfiles/fs${DIR_FIXTURE}")
 
-	# 404, not the 400 the UFSD_RC_ISDIR row of the mapping table in
-	# CLAUDE.md promises: ufs_fopen() returns NULL for a directory, so the
-	# handler has no ISDIR to report and falls into its "cannot open"
-	# branch. Tracked as issue #269 -- asserted here as it actually behaves,
-	# so the day it is fixed this test says so.
-	assert_http_status "404" "$HTTP_CODE" "write to directory returns 404"
+	# 400 ISDIR, the row the mapping table in CLAUDE.md always promised.
+	# Answered 404 until issue #269: ufs_fopen() returns NULL for a directory
+	# rather than a handle carrying the error, so the diagnosis has to be
+	# read off the session with ufs_last_rc(), not off the handle.
+	assert_http_status "400" "$HTTP_CODE" "write to directory returns 400 (ISDIR)"
+
+	# The GET side of the same NULL open, on the same fixture. It lives here
+	# rather than with the read tests because those need USS_TEST_FILE to be
+	# present on the target and this needs only a directory it makes itself.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/fs${DIR_FIXTURE}")
+
+	assert_http_status "400" "$HTTP_CODE" "read directory as file returns 400 (ISDIR)"
+
+	# Neither answer may swallow a genuine 404: a path that is simply absent
+	# is still not found, on both verbs.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/fs${DIR_FIXTURE}.nosuch")
+
+	assert_http_status "404" "$HTTP_CODE" "read a missing path still returns 404"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-d "x" \
+		"${BASE_URL}/zosmf/restfiles/fs${DIR_FIXTURE}.nosuch/file.txt")
+
+	assert_http_status "404" "$HTTP_CODE" "write below a missing parent still returns 404"
 
 	# The empty path is a different 400, and worth holding separately so the
 	# two cannot be confused again.
@@ -719,8 +737,10 @@ if [ -n "$TEST_FILE" ]; then
 		"etag: the refused write created nothing"
 
 	# Adding If-Match must not change how a directory is answered: the same
-	# 404 as the unconditional write above, not 412. Needs a real directory
-	# -- see the write-to-directory block above for why TEST_DIR will not do.
+	# 400 ISDIR as the unconditional write above, not 412. Needs a real
+	# directory -- see the write-to-directory block for why TEST_DIR will not
+	# do. It was 404 on both sides before issue #269; what matters here is
+	# that the two stay identical, whatever the write path answers.
 	ETAG_DIR="${TEST_FILE}.etagdir"
 	cleanup_recursive "$ETAG_DIR"
 	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
@@ -735,7 +755,7 @@ if [ -n "$TEST_FILE" ]; then
 		-H "If-Match: *" \
 		-d "some data!" \
 		"${BASE_URL}/zosmf/restfiles/fs${ETAG_DIR}")
-	assert_http_status "404" "$HTTP_CODE" \
+	assert_http_status "400" "$HTTP_CODE" \
 		"etag: If-Match on a directory answers as the plain write does"
 
 	cleanup_recursive "$ETAG_DIR"


### PR DESCRIPTION
Fixes #269

## The diagnosis is available — just not where the handler looks

The issue proposes a `ufs_stat()` probe on the assumption that a NULL
`ufs_fopen()` carries no ISDIR to map. It carries one; it is on the session
rather than on the (absent) handle:

- `ufsd/src/ufsd#fil.c:728` (write mode) and `:780` (read mode) both
  `return UFSD_RC_ISDIR` for a directory.
- `ufsd/client/libufs.c:735-738` stores that rc in `ufs->last_rc` before
  returning NULL. Identical at the `v1.2.0` tag `mbt.lock` pins.

So `ufs_last_rc()` answers it, which is what `ussCreateHandler` (`ussapi.c:1160`)
already does for its own NULL open — this follows the in-file convention rather
than adding a second mechanism. Three reasons it beats the stat probe:

- No second SSOB round-trip. A stat-on-NULL-open would add one to **every**
  ordinary 404, not just the directory case.
- It reports what the server actually said about *this* open.
- It fixes ROFS / NOSPACE / NOINODES on the write path at the same time; those
  were flattened to 404 "Cannot open file for writing" by the same bug.

The guard keeps it monotone — a session with nothing recorded falls back to the
404 the code answered before, so no status can regress:

```c
int urc = ufs_last_rc(ufs);
return (urc == UFSD_RC_OK) ? UFSD_RC_NOFILE : urc;
```

Known hole, noted in the helper's comment and deliberately not built around:
`ufs_fopen()` has two NULL returns that never reach the server and leave
`last_rc` stale — a path of 252+ characters (`4 + len + 1 > UFSREQ_MAX_INLINE`)
and a short reply. `UFSREQ_MAX_INLINE` lives in ufsd's private `ufsd.h`, not in
the staged `libufs.h`, so bounding `uss_build_path()` to it would couple mvsMF
to a dependency internal that can drift silently. The residual damage is a wrong
error *string* on a request that was failing anyway.

## GET too

The issue asks whether `ussGetHandler` should be split the same way — yes. Both
opens fail NULL for the same reason, and our own table says ISDIR → 400/2, which
is in the z/OSMF status list. One helper, both call sites.

## What is deliberately unchanged

`uss_check_if_match()` keeps its `ufs_stat()` probe. A stale `last_rc` there
would cause a precondition to be **silently skipped**, which is the one failure
#264 exists to prevent — worse than misnaming an error. Only its comment changed
(it asserted the 404 as measured fact).

## Why the suite did not catch it

`tests/curl-uss.sh` asserted the 404 and aimed its read-directory case at
`TEST_DIR`, which defaults to `/`: the wildcard captures the empty string and
the handler's missing-path guard answers 400 before UFSD is reached, so it
passed without testing a directory at all. Both verbs now run against a real
directory fixture, in one block, next to the missing-path cases they must not
swallow. It sits in the write section because the read section needs
`USS_TEST_FILE` to exist on the target and this needs only a fixture it makes
itself.

## Measured on mvsdev

Deployed, activated via `tests/jcl/mvsmfact.jcl`, then:

```
GET  /zosmf/restfiles/fs/tmp/i269probe        -> 400 {"category":2,"message":"Is a directory"}
GET  /zosmf/restfiles/fs/tmp/i269nosuch       -> 404 {"category":6,"message":"File or directory not found"}
PUT  /zosmf/restfiles/fs/tmp/i269probe        -> 400 {"category":2,"message":"Is a directory"}
PUT  /zosmf/restfiles/fs/tmp/i269nodir/f.txt  -> 404 {"category":6,"message":"File or directory not found"}
```

`tests/curl-uss.sh`: **91 passed, 0 failed, 1 skipped** (the skip is the
configured `USS_TEST_FILE` being absent on this stand, unrelated).

## Note for review

PUT to a read-only file system now answers **403** instead of 404. 403 is not in
the z/OSMF status list — that deviation is the existing `UFSD_RC_ROFS` row,
already open as #248; this change only makes it reachable from the write path.
Flagged in `docs/endpoints/uss/put.md`.

Also updated: the `etag.c` bullet in `CLAUDE.md`, which stated the old 404 as a
measured fact.