### PR TITLE
uss: answer a conditional read with 304 when If-None-Match holds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,9 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
   `If-None-Match` on the read side (#263 — a match means 412 on a write, 304 on
   a read, wildcard included; there is no inverted variant).
   It also carries the USS side (#264 — `X-IBM-Return-Etag` and `If-Match` on
-  `/restfiles/fs/{*filepath}`; no `If-None-Match` there yet).
+  `/restfiles/fs/{*filepath}` — and #271, which brought `If-None-Match` there
+  too; the 304 response itself is `send_not_modified()` in `common.c`, hoisted
+  out of `dsapi.c` when USS became its second caller).
   Deliberately free of MVS services so
   it unit-tests on the host (`TSTETAG`); the reading lives with the knowledge
   it needs — `dataset_etag()` in `dsapi.c` next to the DCB handling,
@@ -263,6 +265,12 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
   purpose: the write path may read its diagnosis off `ufs_last_rc()`, but a
   stale value in *this* check would skip a precondition silently, which is the
   one failure the feature exists to prevent.
+
+  The **read** side needs no such probe and must not grow one: a failed hash
+  there already means "no ETag, let the open below diagnose it", so a directory
+  reaches the same 400 ISDIR it would without the header, and a missing file
+  the same 404. That is what keeps `If-None-Match: *` — which is a 304 for any
+  file that exists — from turning either of them into a 304.
 - **jobsapi.c**: Jobs REST API handlers — submit JCL, list/status/purge jobs, read spool files. Uses JES2 interfaces.
 - **ussapi.c**: USS file REST API handlers — list, read, write, create, delete for UNIX files/directories via libufs/UFSD. Includes chtag utility stub.
 - **consapi.c**: Console services handlers — issue command (SVC 34/MGCR), collect response, detect unsolicited keyword, hardcopy log. Reads console data from the Master Trace Table (libc370 `clibmtt`).

--- a/docs/endpoints/uss/get.md
+++ b/docs/endpoints/uss/get.md
@@ -20,6 +20,7 @@ GET /zosmf/restfiles/fs/{filepath}
 |----------------------|----------|---------|-------------|
 | `X-IBM-Data-Type`    | No       | `text`  | `text` or `binary` |
 | `X-IBM-Return-Etag`  | No       | —       | `true` returns an `ETag` for the file, for use as `If-Match` on a later write |
+| `If-None-Match`      | No       | —       | Makes the read conditional — a file that still holds the stamped state is answered 304 (Not Modified) with the `ETag` and no body |
 
 ## Response (200 OK)
 
@@ -62,8 +63,50 @@ Three properties worth relying on:
 CORS-safelisted: without it a cross-origin client reads `null` and cannot tell
 that apart from a server with no ETag support.
 
-There is no `If-None-Match` / 304 support on this endpoint yet; the data set
-endpoints have it (#263), USS is a follow-up.
+## Conditional reads (If-None-Match)
+
+Sending the stamp back as `If-None-Match` makes the read conditional. If the
+file still holds that state, the answer is **304 Not Modified** with no body;
+otherwise it is the normal 200 with the content.
+
+```bash
+# First read: keep the stamp
+ETAG=$(curl -s -D - -o hello.txt -u IBMUSER:sys1 \
+  -H "X-IBM-Return-Etag: true" \
+  "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/hello.txt" \
+  | grep -i '^ETag:' | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//')
+
+# Later: 304 while unchanged, 200 with the new content once it changes
+curl -s -o hello.txt -w '%{http_code}\n' -H "If-None-Match: ${ETAG}" \
+  -u IBMUSER:sys1 "http://mvs:1080/zosmf/restfiles/fs/home/ibmuser/hello.txt"
+```
+
+The header takes the same forms as `If-Match`: a bare stamp, a quoted one, a
+weak one (`W/"…"`), a comma-separated list, and `*`. **`*` answers 304 for any
+file that exists** — per RFC 9110 the wildcard fails the `If-None-Match`
+condition whenever a representation is there, and a failed condition on a GET
+is a 304. (The opposite reading, "only if it does not exist", is the
+conditional-create semantic of a PUT, which this endpoint does not implement.)
+
+Two things it does not do:
+
+- **A request carrying `If-None-Match` gets the `ETag` back either way** — on
+  the 304 and on the 200 that follows a change — without `X-IBM-Return-Etag`
+  being sent. The stamp had to be computed to answer at all, and a reader
+  polling on `If-None-Match` alone would otherwise have no validator to ask
+  about the next change with.
+- **A 304 saves the transfer, not the read.** The stamp is computed by reading
+  the file, so the server does the same work either way; what the client is
+  spared is the body on the wire.
+
+A file that cannot be read gets no 304 — the open then produces the real
+diagnosis, which is the more specific answer. So a missing file is **404**, and
+a directory is **400** (`Is a directory`), exactly as an unconditional read of
+either would be.
+
+Since the stamp is over the stored bytes, it does not depend on
+`X-IBM-Data-Type`: a stamp taken from a text read still answers 304 on a binary
+read of the same unchanged file.
 
 ## Error Responses
 
@@ -109,7 +152,6 @@ zowe files download uf "/home/ibmuser/hello.txt" -f hello.txt
 - No `Content-Length` header in response (streamed without prior size calculation)
 - No `X-IBM-Intrdr-*` headers for record-mode reading
 - No `search` query parameter for in-file searching
-- No `If-None-Match` conditional read (the `ETag` itself is supported)
 
 ## Handler
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -346,9 +346,25 @@ curl -s -o /dev/null -w '%{http_code}\n' -u $USER:$PASS -X PUT \
 
 Take the next `If-Match` from the PUT response's `ETag`, as on the data set
 side. A text read and a binary read of the same file give the same stamp — it
-is computed over the stored bytes, before any codepage translation. There is no
-`If-None-Match` on this endpoint yet. Details in
+is computed over the stored bytes, before any codepage translation. Details in
 [endpoints/uss/put.md](endpoints/uss/put.md#conditional-writes-if-match).
+
+### Re-read a USS file only if it changed
+`GET` with `If-None-Match`
+
+```bash
+# 304 while it still holds the state $ETAG describes, 200 with the content once
+# it does not
+curl -s -o local.txt -w '%{http_code}\n' -u $USER:$PASS \
+  -H "If-None-Match: $ETAG" \
+  "$BASE/zosmf/restfiles/fs/tmp/hello.txt"
+```
+
+As on the data set side: `*` matches any file that exists and so answers 304,
+both answers carry the `ETag` even without `X-IBM-Return-Etag`, and what it
+saves is the transfer rather than the read. A missing path is still 404 and a
+directory still 400 — the more specific answer wins. Details in
+[endpoints/uss/get.md](endpoints/uss/get.md#conditional-reads-if-none-match).
 
 ### Create a file or directory
 `POST /zosmf/restfiles/fs/{filepath}`

--- a/include/common.h
+++ b/include/common.h
@@ -164,6 +164,30 @@ int sendErrorResponse(Session *session, int status, int category, int rc,
                      int details_count) asm("CMN0012");
 
 /**
+ * @brief Answers a conditional read whose If-None-Match still holds
+ *
+ * No body and no Content-Type: the client keeps the representation it already
+ * has, and a 304 that described a payload it is not sending would only invite
+ * a client to believe there is one. The other headers mirror what the 200
+ * would have carried, which is what RFC 9110 asks a 304 to do.
+ *
+ * The ETag goes out even when the request did not ask for one with
+ * X-IBM-Return-Etag. That looks like it contradicts the opt-in, and does not:
+ * a client sending If-None-Match is already speaking the ETag protocol, and
+ * the stamp had to be computed to answer at all. Withholding it would only
+ * cost the client its confirmation of which state it is now holding.
+ *
+ * Resource-agnostic on purpose — data sets and members answer with it (#263)
+ * and so do USS files (#271). Anything specific to one of them belongs in the
+ * caller, not here.
+ *
+ * @param session Current session context
+ * @param etag The stamp the request's If-None-Match matched
+ * @return 0 on success, negative value on error
+ */
+int send_not_modified(Session *session, const char *etag) asm("CMN0013");
+
+/**
  * @brief Reads the full request body into a malloc'd buffer
  *
  * Supports both Content-Length and Transfer-Encoding: chunked.

--- a/src/common.c
+++ b/src/common.c
@@ -202,6 +202,28 @@ quit:
 	return irc;
 }
 
+int
+send_not_modified(Session *session, const char *etag)
+{
+	int rc;
+
+	session->headers_sent = 1;
+	if ((rc = http_resp(session->httpc,
+			HTTP_STATUS_NOT_MODIFIED)) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Cache-Control: no-store\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Pragma: no-cache\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Access-Control-Allow-Origin: *\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag)) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Access-Control-Expose-Headers: ETag\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc, "\r\n")) < 0) return rc;
+
+	return rc;
+}
+
 //
 // Read raw data from socket, one byte at a time.
 // Works around the MVS 3.8j TCP/IP ring buffer bug that corrupts data

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -53,7 +53,6 @@ static int dataset_etag(Session *session, const char *dataset,
                         long max_records, char *out, size_t outlen);
 static int check_if_match(Session *session, const char *dataset,
                           long max_records);
-static int send_not_modified(Session *session, const char *etag);
 
 // Helper functions for memory management
 static void cleanup_resources(char* buffer, FILE* fp) {
@@ -380,42 +379,6 @@ check_if_match(Session *session, const char *dataset, long max_records)
 	}
 
 	return 0;
-}
-
-/* Answer a conditional read whose If-None-Match still holds (issue #263).
- *
- * No body and no Content-Type: the client keeps the representation it already
- * has, and a 304 that described a payload it is not sending would only invite
- * a client to believe there is one. The other headers mirror what the 200
- * would have carried, which is what RFC 9110 asks a 304 to do.
- *
- * The ETag goes out even when the request did not ask for one with
- * X-IBM-Return-Etag. That looks like it contradicts the opt-in, and does not:
- * a client sending If-None-Match is already speaking the ETag protocol, and
- * the stamp had to be computed to answer at all. Withholding it would only
- * cost the client its confirmation of which state it is now holding.
- */
-__asm__("\n&FUNC    SETC 'send_notmod'");
-static int
-send_not_modified(Session *session, const char *etag)
-{
-	int rc;
-
-	session->headers_sent = 1;
-	if ((rc = http_resp(session->httpc,
-			HTTP_STATUS_NOT_MODIFIED)) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Cache-Control: no-store\r\n")) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Pragma: no-cache\r\n")) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Access-Control-Allow-Origin: *\r\n")) < 0) return rc;
-	if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag)) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Access-Control-Expose-Headers: ETag\r\n")) < 0) return rc;
-	if ((rc = http_printf(session->httpc, "\r\n")) < 0) return rc;
-
-	return rc;
 }
 
 // Helper function for error handling

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -647,6 +647,8 @@ int ussGetHandler(Session *session)
 	UINT32 n;
 	char etag[ETAG_SIZE] = {0};
 	const char *etag_hdr = NULL;
+	const char *if_none_match;
+	int want_etag;
 
 	// Get filepath from path variable and build absolute path
 	raw_path = getPathParam(session, "filepath");
@@ -674,12 +676,32 @@ int ussGetHandler(Session *session)
 	// before the first response byte goes out anyway. That costs a second
 	// read pass over the file, which is why it is opt-in.
 	//
+	// One pass serves both halves of the protocol -- the value returned for
+	// X-IBM-Return-Etag and the comparison for If-None-Match (issue #271).
+	// Hashing twice would be two chances for the two answers to disagree.
+	//
 	// A file that cannot be hashed simply gets no ETag here; the open below
 	// then produces the real diagnosis rather than this pass guessing at one.
-	if (etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"))) {
+	// That is what keeps a directory answering 400 ISDIR instead of taking the
+	// 304 branch on "If-None-Match: *" -- uss_etag() fails on it, so there is
+	// no stamp to match. Deliberately no ufs_stat() probe like the write side
+	// has (uss_check_if_match): there a failed hash means 412, so the probe is
+	// load-bearing; here it already means "no ETag, let the open diagnose it".
+	if_none_match = getHeaderParam(session, "If-None-Match");
+	want_etag = etag_requested(getHeaderParam(session, "X-IBM-Return-Etag"));
+
+	if (if_none_match || want_etag) {
 		int urc = UFSD_RC_OK;
 
 		if (uss_etag(ufs, abspath, etag, sizeof(etag), &urc) == 0) {
+			if (if_none_match && etag_matches(if_none_match, etag)) {
+				return send_not_modified(session, etag);
+			}
+			// Either header means the client wants the validator, and this
+			// branch is only reached when one of them was sent -- so the
+			// stamp goes out on the miss too. Without it a reader polling on
+			// If-None-Match alone would get the changed content and no way to
+			// ask about the next change.
 			etag_hdr = etag;
 		}
 	}

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -768,10 +768,173 @@ if [ -n "$TEST_FILE" ]; then
 	assert_http_status "204" "$HTTP_CODE" \
 		"etag: a write without If-Match is unconditional"
 
+	# -----------------------------------------------------------------
+	# ETag: conditional reads / If-None-Match (issue #271)
+	#
+	# The read half of the same stamp. Shares ETAG_FILE with the block
+	# above deliberately: the value a write returns and the value a read
+	# compares against have to be the same one, and a section of its own
+	# would hide a drift between them behind a fresh fixture.
+	# -----------------------------------------------------------------
+
+	echo ""
+	echo "--- ETag: conditional reads / If-None-Match (issue #271) ---"
+
+	# One value drives every check below: the stamp the file returns right
+	# now. The read half computes its own stamp for the comparison, so if
+	# that pass ever drifted from the one behind X-IBM-Return-Etag, it would
+	# surface here as a 200 where a 304 was asked for -- which is why the two
+	# are hashed in one pass.
+	curl -s -D /tmp/curl_uss_c1.txt -o /dev/null -u "$AUTH" \
+		-H "X-IBM-Return-Etag: true" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}"
+	CETAG=$(get_etag /tmp/curl_uss_c1.txt)
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' \
+		-D /tmp/curl_uss_c2.txt -o /tmp/curl_uss_c2.body \
+		-u "$AUTH" -H "If-None-Match: ${CETAG}" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "304" "$HTTP_CODE" "cond: a current If-None-Match is 304"
+
+	# A body is the one thing the status promises not to send.
+	if [ ! -s /tmp/curl_uss_c2.body ]; then
+		pass "cond: the 304 carries no body"
+	else
+		fail "cond: the 304 carries no body" \
+			"got $(wc -c < /tmp/curl_uss_c2.body) bytes"
+	fi
+
+	# The ETag rides along without X-IBM-Return-Etag being sent: a client on
+	# If-None-Match is already speaking the protocol, and the stamp had to be
+	# computed to answer at all.
+	if [ "$(get_etag /tmp/curl_uss_c2.txt)" = "$CETAG" ]; then
+		pass "cond: the 304 carries the ETag it confirmed"
+	else
+		fail "cond: the 304 carries the ETag it confirmed" \
+			"got '$(get_etag /tmp/curl_uss_c2.txt)', expected '$CETAG'"
+	fi
+
+	# The forms clients send, and the wildcard. "*" fails the If-None-Match
+	# condition whenever a representation exists (RFC 9110 13.1.2), and a
+	# failed condition on a GET is a 304 -- the opposite reading, "only if it
+	# does not exist", is the conditional-create semantic of a PUT.
+	for FORM in "\"${CETAG}\"" "W/\"${CETAG}\"" \
+		"\"0000000000000000\", \"${CETAG}\"" "*"; do
+		HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+			-H "If-None-Match: ${FORM}" \
+			"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+		assert_http_status "304" "$HTTP_CODE" \
+			"cond: If-None-Match ${FORM} is 304"
+	done
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' \
+		-D /tmp/curl_uss_c3.txt -o /tmp/curl_uss_c3.body -u "$AUTH" \
+		-H "If-None-Match: 0000000000000000" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "200" "$HTTP_CODE" "cond: a stale If-None-Match is 200"
+
+	if [ -s /tmp/curl_uss_c3.body ]; then
+		pass "cond: the 200 still carries the content"
+	else
+		fail "cond: the 200 still carries the content" "empty body"
+	fi
+
+	# The miss carries the stamp as well, without X-IBM-Return-Etag being
+	# sent -- If-None-Match alone now widens the pass that computes it. A
+	# reader polling on that header would otherwise receive the changed
+	# content and no validator to ask about the next change with.
+	if [ "$(get_etag /tmp/curl_uss_c3.txt)" = "$CETAG" ]; then
+		pass "cond: the 200 carries the current ETag too"
+	else
+		fail "cond: the 200 carries the current ETag too" \
+			"got '$(get_etag /tmp/curl_uss_c3.txt)', expected '$CETAG'"
+	fi
+
+	# The stamp is over the stored bytes, so it does not depend on
+	# X-IBM-Data-Type -- and neither does the 304 it answers. The stamp above
+	# came from a text read; this one asks in binary.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		-H "X-IBM-Data-Type: binary" \
+		-H "If-None-Match: ${CETAG}" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "304" "$HTTP_CODE" "cond: a binary read is 304 too"
+
+	# 304 has to be a statement about the current content, not about the
+	# header having been seen once. Change the file and the same stamp must
+	# stop matching.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X PUT -u "$AUTH" \
+		-d "CHANGED UNDERNEATH THE POLL" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "204" "$HTTP_CODE" "cond: rewrite the file"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -D /tmp/curl_uss_c4.txt -o /dev/null \
+		-u "$AUTH" -H "If-None-Match: ${CETAG}" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "200" "$HTTP_CODE" "cond: a changed file is 200 again"
+
+	# ... and the stamp it hands back is the new one, which is what lets the
+	# poll continue from here without a second request.
+	CETAGNEW=$(get_etag /tmp/curl_uss_c4.txt)
+	if [ -n "$CETAGNEW" ] && [ "$CETAGNEW" != "$CETAG" ]; then
+		pass "cond: the 200 after a change carries the new stamp ($CETAGNEW)"
+	else
+		fail "cond: the 200 after a change carries the new stamp" \
+			"got '$CETAGNEW', was '$CETAG'"
+	fi
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		-H "If-None-Match: ${CETAGNEW}" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	assert_http_status "304" "$HTTP_CODE" "cond: the new stamp is 304 in turn"
+
+	# Nothing to be fresh about: the 404 is the more specific answer and wins.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		-H "If-None-Match: *" \
+		"${BASE_URL}/zosmf/restfiles/fs${MISSING_FILE}")
+	assert_http_status "404" "$HTTP_CODE" "cond: a missing file is 404, not 304"
+
+	# A directory is the case where the plain wildcard reading gives the wrong
+	# answer: it exists, so "*" would be 304 -- but a directory has no
+	# representation to hand back and the unconditional GET answers 400 ISDIR
+	# (issue #269). Adding If-None-Match must not change that.
+	cleanup_recursive "$ETAG_DIR"
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
+		-X POST -u "$AUTH" \
+		-H "Content-Type: application/json" \
+		-d '{"type":"directory"}' \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_DIR}")
+	assert_http_status "201" "$HTTP_CODE" "cond: create the directory fixture"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		-H "If-None-Match: *" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_DIR}")
+	assert_http_status "400" "$HTTP_CODE" \
+		"cond: If-None-Match on a directory answers as the plain read does"
+
+	cleanup_recursive "$ETAG_DIR"
+
+	# A bodiless response is framed by its header block alone. If that framing
+	# were wrong the next request on the same connection would hang or read the
+	# previous response's tail -- curl reuses the connection when both URLs are
+	# given in one invocation, so a second 304 here is the evidence.
+	CODES=$(curl -s --max-time 30 -o /dev/null -w '%{http_code} ' -u "$AUTH" \
+		-H "If-None-Match: ${CETAGNEW}" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}" \
+		"${BASE_URL}/zosmf/restfiles/fs${ETAG_FILE}")
+	if [ "$CODES" = "304 304 " ]; then
+		pass "cond: a second request on the same connection still answers"
+	else
+		fail "cond: a second request on the same connection still answers" \
+			"got '$CODES', expected '304 304 '"
+	fi
+
 	cleanup "$ETAG_FILE"
 	rm -f /tmp/curl_uss_h1.txt /tmp/curl_uss_h2.txt /tmp/curl_uss_h3.txt \
 		/tmp/curl_uss_h4.txt /tmp/curl_uss_h5.txt /tmp/curl_uss_h6.txt \
-		/tmp/curl_uss_h7.txt
+		/tmp/curl_uss_h7.txt /tmp/curl_uss_c1.txt /tmp/curl_uss_c2.txt \
+		/tmp/curl_uss_c2.body /tmp/curl_uss_c3.txt /tmp/curl_uss_c3.body \
+		/tmp/curl_uss_c4.txt
 else
 	echo ""
 	echo "--- Write file tests ---"

--- a/tests/zowe-uss.sh
+++ b/tests/zowe-uss.sh
@@ -396,6 +396,10 @@ echo "--- ETag: optimistic locking (issue #264) ---"
 # gap stays visible if a later CLI version does expose it.
 skip "etag: X-IBM-Return-Etag / If-Match (no Zowe CLI flag — see curl-uss.sh)"
 
+# The read half (#271) is further out of reach: the SDK has no If-None-Match
+# option at all, so a 304 cannot be provoked through the CLI even indirectly.
+skip "etag: If-None-Match / 304 (no Zowe CLI or SDK option — see curl-uss.sh)"
+
 # =========================================================================
 # Cleanup
 # =========================================================================


### PR DESCRIPTION
Fixes #271.

The data set endpoints have answered `If-None-Match` since #263; USS files did
not, so a client polling an unchanged file re-transferred it every time.
`ussGetHandler` now compares the stamp it already computes and answers **304 Not
Modified** with the `ETag` and no body when it still holds.

## What changed

**One pass, both headers.** The comparison rides on the pass that was already
there for `X-IBM-Return-Etag` rather than hashing a second time — two passes
would be two chances for the returned value and the compared value to disagree.
That widens the guard from `etag_requested(...)` to `if_none_match || want_etag`,
which is a behaviour change beyond the 304: a request carrying only a *stale*
`If-None-Match` now gets its `ETag` back too. Without it a reader polling on that
header alone would receive the changed content and no validator to ask about the
next change with. Covered by its own assertion.

**`send_not_modified()` moves to `common.c` (`CMN0013`).** It was `static` in
`dsapi.c`; reaching it from `ussapi.c` meant duplicating or hoisting, and it was
already written resource-agnostic — status, `Cache-Control`, `Pragma`, CORS,
`ETag`, `Access-Control-Expose-Headers`, no `Content-Type` and no body. USS is
the second caller at which one definition starts to matter. The body is
unchanged; the file-local `&FUNC SETC 'send_notmod'` is replaced by the
`asm("CMN0013")` on the declaration.

**A path that cannot be hashed still gets no stamp** and falls through to the
open, which is what keeps the more specific answer: a missing file is 404 and a
directory 400 ISDIR, not the 304 that `If-None-Match: *` gives anything that
exists. Deliberately **no `ufs_stat()` probe** like the write side has — there a
failed hash means 412, so the probe is load-bearing; here it already means "let
the open diagnose it", and a probe would be dead code inviting the reader to
think the two paths are symmetric.

## Verification

Deployed to `mvsdev` and activated into the running httpd STEPLIB
(`HTTPD.LINKLIB`, read off the ACTIVE STC, not guessed).

- `tests/curl-uss.sh` — **110 passed, 0 failed, 1 skipped**, including the new
  conditional-read block: current stamp → 304, empty body, `ETag` on the 304,
  all four header forms plus `*`, stale → 200 with content and stamp, a binary
  read of a text-derived stamp → 304, a change invalidating the stamp and the
  new one taking over, missing → 404, directory → 400, and two 304s on one
  connection (framing after a bodiless response).
- `tests/curl-datasets.sh` — the hoist's regression surface: all **18 `cond:`**
  and **26 `etag:`** assertions pass. Two unrelated failures in the run
  (`create VB dataset with LRECL 4004`, `create PDS with LRECL 4004`) were
  leftover fixtures from an earlier run aborted mid-flight; both return 201
  against a clean name, and their own downstream assertions passed.
- `make test-host` — 170 assertions, 0 fail (`TSTETAG` 43/43; the predicate is
  unchanged, so no new case).
- `make` clean under `-Wall -Werror`.

Note for anyone re-running the documented post-activation check: the deployed
module reports build `b6ce2b1` because it was deployed before the commit was
made. The suite results above are the evidence that the new code is live — the
304 assertions cannot pass on the previous module.

## Docs

`docs/endpoints/uss/get.md` gains the header row and a "Conditional reads"
section modelled on `members-get.md`, and loses the paragraph and Limitations
bullet that stated the gap. `docs/examples.md` gains the USS re-read recipe and
loses the "no `If-None-Match` on this endpoint yet" line. The `etag.c` bullet in
`CLAUDE.md` records the hoist and the read side's deliberate lack of a stat
probe. `tests/zowe-uss.sh` records a skip — the SDK has no `If-None-Match`
option, so a 304 cannot be provoked through the CLI even indirectly.