### PR TITLE
uss: answer 400 where the code was outside the z/OSMF status list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,26 +524,24 @@ int ussXxxHandler(Session *session) {
 Use the `ufsd_rc_to_http()`, `ufsd_rc_to_category()`, and `ufsd_rc_message()` mapping functions
 in `ussapi.c`. ALWAYS call `sendErrorResponse()` with the mapped values.
 
-**Note:** most of the table below is correct as it stands — see **HTTP Status
-Codes** above. EXIST/NOTEMPTY map to 400 and NOSPACE/NOINODES to 500 not because
-httpd lacks 409/507 (it has both), but because the z/OSMF status list does not
-contain them. The same holds for NAMETOOLONG → 400: the two
-`sendErrorResponse(..., 414, ...)` calls still in `ussapi.c` are the deviation,
-not the mapping.
+**Note:** the table below is correct as it stands — see **HTTP Status Codes**
+above. EXIST/NOTEMPTY map to 400 and NOSPACE/NOINODES to 500 not because httpd
+lacks 409/507 (it has both), but because the z/OSMF status list does not contain
+them. Same for NAMETOOLONG → 400, and since #248 every handler agrees with it:
+the 414s that used to sit in `ussGetHandler` and `ussPutHandler` are gone, as is
+the 501 for an unsupported USS utility (now 400 — the service offers one
+utility, so naming another is an incorrect parameter).
 
-**One row is unresolved:** `UFSD_RC_ROFS → 403`. 403 is not in the z/OSMF list
-either, and neither is the 201 this codebase returns for created resources
-(`dsapi.c:2597`, `ussapi.c:960`). Both are open in #248.
+**201 for a created resource is correct** (`dsapi.c:2597`, `ussapi.c:960`),
+even though it is absent from the enumerated list. Measured against a real
+z/OSMF: `POST /zosmf/restfiles/ds/<new PDS>` answers **201** with an empty body.
+The list bounds which codes are permitted, it does not mandate one per
+condition — see **Checking behaviour against a real z/OSMF**.
 
-The open question there was whether the enumerated list is exhaustive for the
-whole API or whether the per-service reference pages add codes. For the
-files/data set service that is now answered: **its own status list is identical
-to the general one** — same thirteen codes, no 201, no 403. So the
-"per-service pages add codes" escape hatch does not apply here, and both values
-are deviations by the same reasoning that keeps 409/414/507 out. What that page
-does not settle on its own is whether a per-*endpoint* success table may still
-document 201 for a create; 201 is also client-visible in a way an error code is
-not, so decide it separately from ROFS.
+**One row is still unresolved:** `UFSD_RC_ROFS → 403`, open in #248. It cannot
+be settled the same way: a read-only file system is a UFSD condition, so there
+is nothing on the reference implementation to measure it against without
+mounting one. Decide it on its own terms.
 
 | UFSD RC | Constant | HTTP | Category | Description |
 |---------|----------|------|----------|-------------|

--- a/docs/endpoints/uss/get.md
+++ b/docs/endpoints/uss/get.md
@@ -114,7 +114,7 @@ read of the same unchanged file.
 |--------|-----------|
 | 400    | Missing filepath or path is a directory |
 | 404    | File not found |
-| 414    | Path name too long |
+| 400    | Path name too long |
 | 500    | I/O error |
 | 503    | UFSD subsystem not available |
 

--- a/docs/endpoints/uss/put.md
+++ b/docs/endpoints/uss/put.md
@@ -65,7 +65,9 @@ utility request. The `"request"` field determines which utility to invoke.
 | `set`    | Accepted as no-op (200, no body) |
 | `remove` | Accepted as no-op (200, no body) |
 
-All other utility requests return **501 Not Implemented**.
+All other utility requests return **400 Bad Request**: the service offers
+exactly one utility, so naming another is an incorrect parameter, and 501 is
+not one of the statuses z/OSMF uses (issue #248).
 
 ## Conditional writes (If-Match)
 
@@ -110,9 +112,9 @@ off the UFS session rather than off the (absent) file handle.
 | 403    | Read-only file system (not a z/OSMF status — the `UFSD_RC_ROFS` row is open as #248) |
 | 404    | Parent directory not found |
 | 412    | `If-Match` was supplied and the file no longer matches it — including a file that no longer exists |
-| 414    | Path name too long |
+| 400    | Path name too long |
 | 500    | No space left on device or I/O error (64 KB limit) |
-| 501    | Unsupported USS utility (Content-Type: application/json with unknown request) |
+| 400    | Unsupported USS utility (Content-Type: application/json with unknown request) |
 | 503    | UFSD subsystem not available |
 
 ## Max File Size
@@ -176,7 +178,7 @@ curl -X PUT -u IBMUSER:sys1 \
 ## Limitations vs Real z/OSMF
 
 - No `Transfer-Encoding: chunked` on response (request chunked encoding is supported)
-- USS utilities limited to `chtag` — `chmod`, `chown`, `extattr` return 501
+- USS utilities limited to `chtag` — `chmod`, `chown`, `extattr` return 400
 
 ## Handler
 

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -28,6 +28,20 @@ static int uss_extract_json_string(const char *json, const char *key,
 //
 // UFSD RC → HTTP status mapping
 //
+// Several rows below answer with a status that is not the most precise one HTTP
+// offers. That is deliberate and it is not an httpd limitation: httpd learned
+// 409, 414 and 507 in httpd#28/PR#56, and a live probe confirmed a CGI-set 414
+// reaches the client unchanged. The constraint is z/OSMF, which enumerates the
+// status codes its API uses -- 200, 204, 206, 304, 400, 401, 404, 405, 412,
+// 413, 429, 500, 503 -- and mvsMF is a clone of it. "Already exists" and "not
+// empty" are therefore 400 rather than 409, "no space" and "no inodes" are 500
+// rather than 507, and "name too long" is 400 rather than 414. Closed as
+// won't-do in #102; do not re-open it from the httpd side alone.
+//
+// UFSD_RC_ROFS -> 403 is the one row still outside that list, and it is open in
+// #248: there is no read-only file system on the reference implementation to
+// measure it against, so it needs deciding on its own terms.
+//
 
 __asm__("\n&FUNC    SETC 'ufsd_rc_to_http'");
 static int
@@ -36,16 +50,16 @@ ufsd_rc_to_http(int rc)
 	switch (rc) {
 	case UFSD_RC_OK:          return 200;
 	case UFSD_RC_NOFILE:      return 404;
-	case UFSD_RC_EXIST:       return 400;  /* 409 not supported by HTTPD */
+	case UFSD_RC_EXIST:       return 400;  /* not 409: not a z/OSMF status */
 	case UFSD_RC_NOTDIR:      return 400;
 	case UFSD_RC_ISDIR:       return 400;
-	case UFSD_RC_NOSPACE:     return 500;  /* 507 not supported by HTTPD */
-	case UFSD_RC_NOINODES:    return 500;  /* 507 not supported by HTTPD */
+	case UFSD_RC_NOSPACE:     return 500;  /* not 507: not a z/OSMF status */
+	case UFSD_RC_NOINODES:    return 500;  /* not 507: not a z/OSMF status */
 	case UFSD_RC_IO:          return 500;
 	case UFSD_RC_BADFD:       return 500;
-	case UFSD_RC_NOTEMPTY:    return 400;  /* 409 not supported by HTTPD */
-	case UFSD_RC_NAMETOOLONG: return 400;  /* 414 not supported by HTTPD */
-	case UFSD_RC_ROFS:        return 403;
+	case UFSD_RC_NOTEMPTY:    return 400;  /* not 409: not a z/OSMF status */
+	case UFSD_RC_NAMETOOLONG: return 400;  /* not 414: not a z/OSMF status */
+	case UFSD_RC_ROFS:        return 403;  /* outside the list too -- #248 */
 	default:                  return 500;
 	}
 }
@@ -658,7 +672,7 @@ int ussGetHandler(Session *session)
 	}
 
 	if (!uss_build_path(abspath, sizeof(abspath), raw_path)) {
-		return sendErrorResponse(session, 414, 2, 8, 1,
+		return sendErrorResponse(session, 400, 2, 8, 1,
 			"Path name too long", NULL, 0);
 	}
 
@@ -827,7 +841,7 @@ uss_handle_chtag(Session *session, const char *filepath, const char *body)
 //
 // USS utilities dispatcher — called when PUT has Content-Type: application/json.
 // Dispatches by the "request" field in the JSON body.
-// Currently only "chtag" is implemented; all others return 501.
+// Currently only "chtag" is implemented; any other utility is a 400.
 //
 
 __asm__("\n&FUNC    SETC 'uss_utilities'");
@@ -873,10 +887,13 @@ uss_handle_utilities(Session *session, const char *filepath)
 		return rc;
 	}
 
-	// All other utilities: not implemented
+	// Any other utility: 400, not 501. The service offers exactly one utility,
+	// so a request naming another one is an incorrect parameter -- and 501 is
+	// not a z/OSMF status in any case (see ufsd_rc_to_http above). Category 2
+	// for the same reason the other bad requests in this function use it.
 	if (free_body) free(body);
-	return sendErrorResponse(session, 501, 10, 8, 1,
-		"USS utility not implemented", NULL, 0);
+	return sendErrorResponse(session, 400, 2, 8, 1,
+		"Unsupported utility request", NULL, 0);
 }
 
 //
@@ -912,7 +929,7 @@ int ussPutHandler(Session *session)
 	}
 
 	if (!uss_build_path(abspath, sizeof(abspath), raw_path)) {
-		return sendErrorResponse(session, 414, 2, 8, 1,
+		return sendErrorResponse(session, 400, 2, 8, 1,
 			"Path name too long", NULL, 0);
 	}
 

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -485,7 +485,9 @@ if [ -n "$TEST_FILE" ]; then
 		-d '{"request":"chmod","action":"set","mode":"0755"}' \
 		"${BASE_URL}/zosmf/restfiles/fs${WRITE_FILE}")
 
-	assert_http_status "501" "$HTTP_CODE" "chmod returns 501 (not implemented)"
+	# 400, not 501: the service offers one utility, so naming another is an
+	# incorrect parameter -- and 501 is not a z/OSMF status (issue #248).
+	assert_http_status "400" "$HTTP_CODE" "an unsupported utility returns 400"
 
 	echo ""
 	echo "--- Write file error cases ---"
@@ -1317,6 +1319,44 @@ else
 	echo "--- Integration tests ---"
 	skip "integration: USS_TEST_FILE not set in .env, skipping integration tests"
 fi
+
+# =========================================================================
+# Path name too long: the same condition on every verb (issue #248)
+# =========================================================================
+# uss_build_path() overflows at UFS_PATH_MAX (256), and all four handlers hit
+# it identically. GET and PUT used to answer 414 here while POST and DELETE
+# answered 400, so a client special-casing the code saw the same failure
+# differently depending on the verb -- and 414 is not a z/OSMF status at all.
+#
+# The body assertion is not decoration: httpd emits a 414 of its own when the
+# request line overruns its buffer (httpin.c), and that one carries a
+# text/plain page. Only the JSON error report proves the request reached the
+# CGI and that this is mvsMF's answer rather than the server's.
+echo ""
+echo "--- Path name too long is 400 on every verb (issue #248) ---"
+
+USS_LONG_PATH=$(printf 'a%.0s' $(seq 1 300))
+
+for USS_M in GET PUT POST DELETE; do
+	if [ "$USS_M" = "PUT" ]; then
+		BODY=$(curl -s -w '\n%{http_code}' -X PUT -u "$AUTH" -H "Expect:" \
+			--data-binary 'hello' \
+			"${BASE_URL}/zosmf/restfiles/fs/${USS_LONG_PATH}")
+	else
+		BODY=$(curl -s -w '\n%{http_code}' -X "$USS_M" -u "$AUTH" -H "Expect:" \
+			"${BASE_URL}/zosmf/restfiles/fs/${USS_LONG_PATH}")
+	fi
+	HTTP_CODE=$(echo "$BODY" | tail -1)
+	CONTENT=$(echo "$BODY" | sed '$d')
+
+	assert_http_status "400" "$HTTP_CODE" "${USS_M}: an over-long path is 400"
+	if echo "$CONTENT" | grep -q "Path name too long"; then
+		pass "${USS_M}: the answer is mvsMF's, naming the reason"
+	else
+		fail "${USS_M}: the answer is mvsMF's, naming the reason" \
+			"got: $(echo "$CONTENT" | head -c 120)"
+	fi
+done
 
 # =========================================================================
 # Summary


### PR DESCRIPTION
Addresses the three deviations in #248. **The `UFSD_RC_ROFS → 403` row stays
open** — see below.

## 1. Path name too long answered differently per verb

One overflow of `uss_build_path()`, four handlers hitting it identically, two
different answers. Measured on the deployed build *before* the change, the same
300-character path on each verb:

```
GET    414   PUT    414   POST   400   DELETE 400
```

A client special-casing the code saw the same failure differently depending on
which verb it used, and 414 is not a z/OSMF status at all. After:

```
GET    400   PUT    400   POST   400   DELETE 400
```

All four now agree with `ufsd_rc_to_http()`, which has always mapped
`UFSD_RC_NAMETOOLONG` to 400 — so the handlers and the mapping table no longer
contradict each other either.

## 2. Unsupported USS utility answered 501

The service offers exactly one utility (`chtag`), so a request naming another is
an incorrect parameter rather than a gap in the server — and 501 is not a z/OSMF
status. Now **400** with category 2, matching the other bad requests in that
function. Measured live: `{"rc":8,"category":2,"reason":1,"message":"Unsupported utility request"}`.

## 3. The comments were actively misleading

`ufsd_rc_to_http()` carried `/* 409 not supported by HTTPD */` and friends.
httpd supports 409, 414 and 507 (httpd#28/PR#56) — we decline to use them
because z/OSMF does not enumerate them. **The values are unchanged**, the
reasoning is now recorded correctly, with the #102 won't-do noted so it is not
re-opened from the httpd side alone.

## Not in scope, deliberately

`UFSD_RC_ROFS → 403` is outside the list too, but it cannot be settled the way
the others were: a read-only file system is a UFSD condition, so there is
nothing on the reference implementation to measure it against without mounting
one. Left open in #248 and marked as such in the code.

The other half of that issue — **201 for a created resource — is already
resolved and needs no change**: measured against a real z/OSMF,
`POST /zosmf/restfiles/ds/<new PDS>` answers **201** with an empty body, so
mvsMF matches the reference. `CLAUDE.md` is corrected accordingly; it previously
listed 201 as an open deviation.

## Verification

Deployed and activated, build id confirmed live (`3de44a0`) before measuring.

`tests/curl-uss.sh`: **118 passed, 0 failed, 1 skipped** (the skip is
pre-existing — `USS_TEST_FILE` is unset in `.env`).

The suite had **no path-too-long coverage at all**, which is exactly how the
414/400 split went unnoticed. It now exercises every verb, and asserts the
**body** as well as the status — httpd emits a 414 of its own when the request
line overruns its buffer (`httpin.c`), and only the JSON error report proves the
answer came from the CGI rather than from the server. Without that assertion the
test would pass against the wrong layer.

`docs/endpoints/uss/get.md` and `put.md` status tables updated; `CLAUDE.md`'s
UFSD mapping section no longer claims the two 414 call sites exist.

Refs #248.

https://claude.ai/code/session_019TT2zwWGXK6rL6zMmV22j4