### PR TITLE
Answer a truncated listing 200 with moreRows, not 206

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,11 +322,21 @@ Two codes turn on this:
   z/OSMF answers **200 with an empty `items` array** in every one of those
   cases, including a partitioned data set with zero members. Empty listings stay
   200 (#266, measured, closed won't-do).
-- **206 is the unresolved twin.** #249/PR#265 adopted it for a listing truncated
-  by `X-IBM-Max-Items`, on the same documented wording — but real z/OSMF answers
-  **200 with `moreRows: true`** there, and emits no 206 on the files service at
-  all. mvsMF and its reference currently disagree; open as **#274**. Do not cite
-  #249 as settled precedent.
+- **206 went the same way, after briefly going the other.** #249/PR#265 adopted
+  it for a listing truncated by `X-IBM-Max-Items`, on the documented wording —
+  and #274 took it back out: real z/OSMF answers **200 with `moreRows: true`**
+  there and emits no 206 on the files service at all, not even for a
+  record-range read. Truncation is carried in `moreRows` and nowhere else, so
+  **mvsMF emits no 206 anywhere**. Do not cite #249; it was measured wrong.
+
+  The removal also deleted work rather than only adjusting it: the status was
+  the sole reason `memberListHandler` and `ussListHandler` measured the page
+  before the header went out, so both second walks went with it. What is left
+  of that shape is load-bearing — `member_scan()` walks one match *past* the
+  page and emits only up to it, because a walk bounded at the page returns the
+  limit whether or not anything follows, and a directory holding exactly as
+  many members as the limit would then report `moreRows: true`. That failure is
+  silent and its test is the equal-to-the-count case in `curl-datasets.sh`.
 
 Two further consequences that keep getting rediscovered:
 
@@ -347,7 +357,9 @@ Two further consequences that keep getting rediscovered:
   `reason` and `message`, where it costs no conformance; `REASON_SPOOL_GONE` is
   the worked example.
 - **206, 412 and 429 reach the wire now — but only because httpd was re-cut and
-  redeployed.** They were added to `src/httpstat.c` by httpd#181/PR#183 (commit
+  redeployed** (206 is emittable, and unused since #274; the entry is about what
+  httpd can send, not about what mvsMF sends). They were added to
+  `src/httpstat.c` by httpd#181/PR#183 (commit
   `623f6a6`), which landed *after* the original `v4.0.0-dev` artifact; that tag
   has since been re-cut and the STC redeployed, and 412 was measured going out
   correctly (#152). The mechanism is the part to remember: `http_resp()`

--- a/docs/endpoints/datasets/list.md
+++ b/docs/endpoints/datasets/list.md
@@ -19,17 +19,15 @@ GET
   itself, and one equal to the prefix sorts before it (issue #240).
 
 ## Request Headers
-- `X-IBM-Max-Items` (optional): Maximum number of items to return. Value `0` means unlimited (default behavior). When the result set is truncated, `moreRows` is set to `true` and the status is **206** rather than 200.
+- `X-IBM-Max-Items` (optional): Maximum number of items to return. Value `0` means unlimited (default behavior). When the result set is truncated, `moreRows` is set to `true`.
 
 ## Response
-A complete listing returns HTTP status code 200 (OK). A listing cut short by
-`X-IBM-Max-Items` returns **206 (Partial content)** — the body is identical in
-shape, so a client that reads `moreRows` needs no change, but one that keys off
-the status can now tell a page from a whole list. The header being present is
-not what makes the response partial: a limit no listing reaches is a complete
-answer and stays 200.
+HTTP status code 200 (OK), whether the listing is complete or was cut short by
+`X-IBM-Max-Items` — the truncation is carried in `moreRows` and nowhere else.
+That is what real z/OSMF does; it emits no 206 on the files service at all
+(issue #274).
 
-Both carry a JSON object:
+The body is a JSON object:
 
 ```json
 {

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -38,13 +38,12 @@ or with explicit volume:
 - `X-IBM-Max-Items` (optional): Maximum number of members to return. Omitted or `0` returns all of them.
 
 ## Response
-A complete listing returns HTTP status code 200 (OK). A listing cut short by
-`X-IBM-Max-Items` returns **206 (Partial content)** — same body, so a client
-reading `moreRows` needs no change, but the status alone now distinguishes a
-page from a whole directory. A limit no directory reaches is a complete answer
-and stays 200.
+HTTP status code 200 (OK), whether the listing is complete or was cut short by
+`X-IBM-Max-Items` — the truncation is carried in `moreRows` and nowhere else.
+That is what real z/OSMF does; it emits no 206 on the files service at all
+(issue #274).
 
-Both carry a JSON object:
+The body is a JSON object:
 
 ```json
 {

--- a/docs/endpoints/uss/list.md
+++ b/docs/endpoints/uss/list.md
@@ -22,7 +22,7 @@ GET /zosmf/restfiles/fs?path=<filepath>
 |-------------------|----------|---------|-------------|
 | `X-IBM-Max-Items` | No       | 1000    | Maximum items to return. 0 = unlimited |
 
-## Response (200 OK, or 206 when truncated by `X-IBM-Max-Items`)
+## Response (200 OK)
 
 ```json
 {
@@ -64,23 +64,19 @@ When `X-IBM-Max-Items` is set and the directory contains more entries:
 - `returnedRows` = number of items in the response
 - `totalRows` = total entries in the directory (excluding `.` and `..`)
 - `moreRows` = `true` when results were truncated
-- the status is **206 (Partial content)** rather than 200
 
-A limit no directory reaches is a complete listing and stays 200 — the header
-being present is not what makes the response partial.
+**The status is 200 either way** — a truncated listing is carried in `moreRows`
+and nowhere else. That is what real z/OSMF does; it emits no 206 on the files
+service at all (issue #274).
 
-**The default limit does not produce 206.** With no `X-IBM-Max-Items` the
-handler still caps the listing at 1000 entries and still sets `moreRows`, but
-that limit is the server's, not the client's, and z/OSMF ties 206 to a request
-that *contained* the header. A directory of more than 1000 entries listed
-without the header therefore answers 200 with `moreRows: true`.
+The 1000-entry default cap works the same way: a directory larger than that,
+listed without the header, answers 200 with `moreRows: true`.
 
 ## Response Status
 
 | Status | Condition |
 |--------|-----------|
-| 200    | Complete listing (also a listing capped by the 1000-entry default) |
-| 206    | Listing cut short by `X-IBM-Max-Items` |
+| 200    | Listing returned — complete or truncated, see `moreRows` |
 
 ## Error Responses
 

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1034,7 +1034,6 @@ int datasetListHandler(Session *session)
 	unsigned	maxitems	= 0;
 	unsigned	emitted		= 0;
 	unsigned	eligible	= 0;
-	int		truncated	= 0;
 
 	char		*method		= NULL;
 	char		*path		= NULL;
@@ -1189,13 +1188,11 @@ int datasetListHandler(Session *session)
 	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
 	if (maxitems_str) maxitems = (unsigned) atoi(maxitems_str);
 
-	/* Count the page before writing the status line.  A listing cut short by
-	** X-IBM-Max-Items answers 206 Partial content, and the status is the one
-	** part of the response that cannot be corrected once the header is out --
-	** moreRows below is decided by the same numbers, but it is decided last
-	** (#249).  Only the entries at or after start= are still fetchable, so
-	** they are what "more to come" counts.  The array is in storage and
-	** sorted already: this pass costs no I/O. */
+	/* Count what the client could still fetch.  The emit loop below stops at
+	** the page and would otherwise have nothing to compare against: only the
+	** entries at or after start= are reachable, so they are what "more to
+	** come" counts.  The array is in storage and sorted already, so this pass
+	** costs no I/O. */
 	if (dslist) {
 		count = array_count(&dslist);
 
@@ -1207,10 +1204,11 @@ int datasetListHandler(Session *session)
 		}
 	}
 
-	truncated = (maxitems > 0 && eligible > maxitems);
-
+	/* A listing cut short by X-IBM-Max-Items stays 200 and says so in
+	** moreRows -- measured against z/OSMF 29, which answers 200 for every
+	** truncation and emits no 206 on the files service at all (#274). */
 	session->headers_sent = 1;
-	if ((rc = http_resp(session->httpc, truncated ? 206 : 200)) < 0) goto quit;
+	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
@@ -1841,31 +1839,37 @@ json_escape_member(const unsigned char *raw, unsigned rawlen,
 	out[o] = '\0';
 }
 
-/* Walk a PDS directory once, applying start= and pattern to every entry.
+/* Walk a PDS directory once, applying start= and pattern to every entry, and
+** write the matches out as JSON objects on the way past.
 **
-** The walk stops as soon as `bound` matching members have been seen (bound 0
-** means no limit) and returns that count, so a caller can learn "the page is
-** full and at least one member is behind it" without reading the 23000 entries
-** of SYS1.SMPCDS to find out.  With `emit` set the matches are written as JSON
-** objects on the way past and the count is what was written.  Returns -1 if a
-** write failed.
+** `page` is what the client asked for (0 means no limit): that many matches are
+** written, and the walk then looks one further before it stops.  So the return
+** value is up to page + 1, and a caller reading page + 1 knows the page is full
+** and at least one member is behind it -- without reading the 23000 entries of
+** SYS1.SMPCDS to find out.  Returns -1 if a write failed.
 **
-** Both passes of memberListHandler() come through here.  The counting pass
-** decides the status code and the emit pass decides the body, so the rules the
-** two apply -- the blank trim of #154, the start= prefix of #240, pattern
-** before cap -- have to be one set of rules.  Kept as two copies they would
-** drift, and 206 and moreRows would then disagree about exactly the entries
-** those issues are about. */
+** Looking one past the page is the whole trick, and dropping it fails silently:
+** a walk bounded at `page` returns `page` whether or not anything follows, so a
+** directory holding exactly as many members as the limit would report moreRows
+** true.  The extra match is counted and deliberately not emitted. */
 __asm__("\n&FUNC    SETC 'member_scan'");
 static int
 member_scan(Session *session, FILE *fp, const char *start_key, int start_after,
-            const char *pattern_key, int have_pattern, unsigned bound, int emit)
+            const char *pattern_key, int have_pattern, unsigned page)
 {
 	char		blk[PDS_DIR_BLKSIZE];
 	unsigned	seen		= 0;
 	unsigned	first		= 1;
+	unsigned	bound		= 0;	/* 0 = walk the whole directory */
 	int		skipping	= (start_key != NULL);
 	int		at_end		= 0;
+
+	/* The upper guard keeps page + 1 from wrapping: a negative or absurd
+	   X-IBM-Max-Items arrives here as UINT_MAX, the bound would come out 0 --
+	   which the loop reads as "no bound" -- and the walk would stop at the
+	   first member.  No page that large can be truncated anyway, so walking it
+	   all is the right answer for that value. */
+	if (page > 0 && page < UINT_MAX) bound = page + 1;
 
 	while (!at_end) {
 		int	len;
@@ -1958,7 +1962,10 @@ member_scan(Session *session, FILE *fp, const char *start_key, int start_after,
 
 			seen++;
 
-			if (emit) {
+			/* Everything up to the page goes out; the one match past
+			   it is counted and not written -- it is what tells the
+			   caller more members follow. */
+			if (page == 0 || seen <= page) {
 				json_escape_member((const unsigned char *) &blk[pos],
 					(unsigned) nlen,
 					httpx->xlate_cp037->etoa, member, sizeof(member));
@@ -1977,9 +1984,8 @@ member_scan(Session *session, FILE *fp, const char *start_key, int start_after,
 				if (http_printf(session->httpc, "    }\n") < 0) return -1;
 			}
 
-			/* the page is full: for the emit pass there is nothing more
-			   to write, and for the counting pass the one match past it
-			   is the whole answer */
+			/* the page is full and one match past it has been seen:
+			   nothing left to write, and nothing left to learn */
 			if (bound > 0 && seen >= bound) {
 				at_end = 1;
 				break;
@@ -2076,48 +2082,6 @@ int memberListHandler(Session *session)
 		goto quit;
 	}
 
-	/* Counting pass.  A listing cut short by X-IBM-Max-Items answers 206
-	   Partial content, and the status line is written before the first member
-	   is -- so whether the page is full has to be settled before the directory
-	   is walked for the client (#249).  The walk stops one match past the page,
-	   so what it costs is a page and not a directory, and it is only paid when
-	   the client asked for a limit at all.
-
-	   Reading the directory twice is affordable only because of #212: the walk
-	   holds one 256-byte block, not a member array.  fopen() again rather than
-	   rewind() -- a backwards seek on a record-mode handle reopens the data set
-	   inside __fseek() anyway, by a DD name it reconstructs itself, so a second
-	   open is the same I/O with none of the guesswork.
-
-	   The upper guard keeps maxitems + 1 from wrapping: a negative or absurd
-	   X-IBM-Max-Items arrives here as UINT_MAX, the bound would come out 0 --
-	   which member_scan() reads as "no bound" -- and both passes would then run
-	   the directory end to end.  No page that large can be truncated anyway. */
-	if (maxitems > 0 && maxitems < UINT_MAX) {
-		fp = fopen(dsname, "r,record");
-		if (!fp) {
-			rc = sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
-					CATEGORY_UNEXPECTED, RC_ERROR, REASON_DATASET_NOT_FOUND,
-					ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
-			goto quit;
-		}
-		session_register_file(session, fp);
-
-		scanned = member_scan(session, fp, skipping ? start_key : NULL,
-				start_after, pattern_key, have_pattern,
-				maxitems + 1, 0);
-
-		session_fclose(session, fp);
-		fp = NULL;
-
-		if (scanned < 0) {
-			rc = (unsigned) scanned;
-			goto quit;
-		}
-
-		truncated = ((unsigned) scanned > maxitems);
-	}
-
 	/* Walk the directory and emit as we go.  This used to call __listpd(),
 	   which builds the complete member array in storage first: on a data set
 	   like SYS1.SMPCDS (~23000 members) that exhausts the region, abends S878,
@@ -2141,8 +2105,13 @@ int memberListHandler(Session *session)
 	   SCRATCH enqueue forever, costing a worker permanently (#217). */
 	session_register_file(session, fp);
 
+	/* A listing cut short by X-IBM-Max-Items stays 200 and carries the fact in
+	   moreRows -- measured against z/OSMF 29, which answers 200 for every
+	   truncation and emits no 206 on the files service at all (#274).  That is
+	   also what lets this handler settle the question in the walk below rather
+	   than reading the directory a second time before the header goes out. */
 	session->headers_sent = 1;
-	if ((rc = http_resp(session->httpc, truncated ? 206 : 200)) < 0) goto quit;
+	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
@@ -2153,19 +2122,20 @@ int memberListHandler(Session *session)
 	if ((rc = http_printf(session->httpc, "  \"items\": [\n")) < 0) goto quit;
 
 	scanned = member_scan(session, fp, skipping ? start_key : NULL,
-			start_after, pattern_key, have_pattern, maxitems, 1);
+			start_after, pattern_key, have_pattern, maxitems);
 	if (scanned < 0) {
 		rc = (unsigned) scanned;
 		goto quit;
 	}
-	emitted = (unsigned) scanned;
+
+	/* the walk looks one match past the page, so what it saw and what it wrote
+	   part company exactly when there is more to come */
+	truncated = (maxitems > 0 && (unsigned) scanned > maxitems);
+	emitted   = truncated ? maxitems : (unsigned) scanned;
 
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", emitted)) < 0) goto quit;
 	// TODO: add totalRows if X-IBM-Attributes has ',total'
-	/* the counting pass, not this one: the two walks are seconds apart on a
-	   large directory and a member added in between must not leave the body
-	   contradicting the status line */
 	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
 		truncated ? "true" : "false")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1008,8 +1008,9 @@ dslist_cmp(const void *a, const void *b)
 ** sorts below the character the value continues with).  Drop it too (#240).
 **
 ** Both passes below ask this one question: the counting pass turns the answer
-** into the status code, the emit pass into the body.  A second copy of the rule
-** would let 206 and moreRows disagree on exactly the names #240 is about. */
+** into eligible, the emit pass into the items.  A second copy of the rule would
+** let moreRows and the list itself disagree on exactly the names #240 is
+** about. */
 __asm__("\n&FUNC    SETC 'dslist_in_page'");
 static int
 dslist_in_page(const DSLIST *ds, const char *start_key, int have_start,

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -480,9 +480,6 @@ int ussListHandler(Session *session)
 	unsigned maxitems = USS_LIST_DEFAULT_MAX_ITEMS;
 	unsigned emitted = 0;
 	unsigned total = 0;
-	unsigned counted = 0;
-	int have_maxitems = 0;
-	int truncated = 0;
 	int more = 0;
 	char *path = NULL;
 	char *maxitems_str = NULL;
@@ -501,7 +498,6 @@ int ussListHandler(Session *session)
 	maxitems_str = getHeaderParam(session, "X-IBM-Max-Items");
 	if (maxitems_str) {
 		maxitems = (unsigned) atoi(maxitems_str);
-		have_maxitems = 1;
 	}
 
 	// Open UFS session
@@ -516,45 +512,17 @@ int ussListHandler(Session *session)
 		return uss_stat_file(session, ufs, path);
 	}
 
-	/* Counting pass.  A listing cut short by X-IBM-Max-Items answers 206
-	   Partial content, and the status line goes out before the first entry is
-	   written -- so the page has to be measured up front (#249).  The walk
-	   stops one entry past the page and there is no ufs_dirrewind(), so it
-	   costs a close and a second open.
+	/* Directory listing -- send response headers (streaming JSON).
 
-	   Only when the client set the header.  USS_LIST_DEFAULT_MAX_ITEMS
-	   truncates too, but that limit is ours, not the client's, and z/OSMF ties
-	   206 to "the request contained the X-IBM-Max-Items header".  Leaving the
-	   default alone also keeps every plain listing at one walk.
-
-	   A negative or absurd value arrives here as UINT_MAX, which no directory
-	   can exceed: the counting pass could only walk the whole thing to prove
-	   nothing was truncated, so skip it. */
-	if (have_maxitems && maxitems > 0 && maxitems < UINT_MAX) {
-		while ((entry = ufs_dirread(dd)) != NULL) {
-			if (strcmp(entry->name, ".") == 0 ||
-				strcmp(entry->name, "..") == 0) {
-				continue;
-			}
-
-			counted++;
-			if (counted > maxitems) break;
-		}
-
-		truncated = (counted > maxitems);
-
-		ufs_dirclose(&dd);
-
-		// same fallback as the first open: the path may have become a file
-		dd = ufs_diropen(ufs, path, NULL);
-		if (!dd) {
-			return uss_stat_file(session, ufs, path);
-		}
-	}
-
-	// Directory listing — send response headers (streaming JSON)
+	   A listing cut short by X-IBM-Max-Items stays 200 and carries the fact in
+	   moreRows below -- measured against z/OSMF 29, which answers 200 for every
+	   truncation and emits no 206 on the files service at all (#274).  Nothing
+	   here therefore depends on knowing the size of the directory before the
+	   status line goes out, and the single walk below is the whole listing:
+	   there is no ufs_dirrewind(), so measuring up front would cost a close and
+	   a second open of every directory the client puts a limit on. */
 	session->headers_sent = 1;
-	if ((rc = http_resp(session->httpc, truncated ? 206 : 200)) < 0) goto quit;
+	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
@@ -621,12 +589,10 @@ int ussListHandler(Session *session)
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %u,\n", emitted)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"totalRows\": %u,\n", total)) < 0) goto quit;
-	/* With the header in play the status line has already committed to an
-	   answer, so the body repeats it rather than recomputing it: the two walks
-	   are apart in time, and an entry created in between would otherwise leave
-	   a 206 standing next to moreRows false.  Without the header nothing was
-	   committed and this walk's own count is the better value. */
-	more = have_maxitems ? truncated : (maxitems > 0 && emitted < total);
+	/* The emit loop keeps counting after the page is full, so total is the
+	   whole directory and this is exact -- for the client's limit and for
+	   USS_LIST_DEFAULT_MAX_ITEMS alike, which truncates the same way. */
+	more = (maxitems > 0 && emitted < total);
 	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
 		more ? "true" : "false")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -361,10 +361,9 @@ BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
-# a listing cut short by X-IBM-Max-Items is partial content, not a complete
-# answer: a client keying off the status could not otherwise tell the two
-# apart (#249)
-assert_http_status "206" "$HTTP_CODE" "list datasets (max-items=1)"
+# a listing cut short by X-IBM-Max-Items stays 200 and says so in moreRows --
+# that is what real z/OSMF does, measured (#274)
+assert_http_status "200" "$HTTP_CODE" "list datasets (max-items=1)"
 
 RETURNED=$(echo "$CONTENT" | jq '.returnedRows' 2>/dev/null) || RETURNED=0
 if [ "$RETURNED" -eq 1 ] 2>/dev/null; then
@@ -380,9 +379,8 @@ else
 	fail "moreRows=true when truncated" "expected true, got $MORE_ROWS"
 fi
 
-# The other half of #249, and the half a "send 206 when max-items is set"
-# implementation would get wrong: the header alone does not make a response
-# partial. A limit nothing reaches is a complete listing and stays 200.
+# The other half: the header alone does not make a listing partial. A limit
+# nothing reaches is a complete answer and moreRows stays false.
 BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
 	-H "X-IBM-Max-Items: 1000" \
 	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL")
@@ -659,7 +657,7 @@ HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
 LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null)
 
-if [ "$HTTP_CODE" = "206" ] &&
+if [ "$HTTP_CODE" = "200" ] &&
    [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "2" ] &&
    [ "$(echo "$LIST" | head -1)" = "MBRC" ] &&
    [ "$(echo "$LIST" | sed -n 2p)" = "MBRF1" ] &&
@@ -736,13 +734,36 @@ CONTENT=$(echo "$BODY" | sed '$d')
 LIST=$(echo "$CONTENT" | jq -r '.items[].member' 2>/dev/null |
 	tr '\n' ' ' | sed 's/ *$//')
 
-if [ "$HTTP_CODE" = "206" ] && [ "$LIST" = "MBRA MBRB" ] &&
+if [ "$HTTP_CODE" = "200" ] && [ "$LIST" = "MBRA MBRB" ] &&
    [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "2" ] &&
    [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "true" ]; then
 	pass "pattern= with max-items=2 fills the page with matches only"
 else
 	fail "pattern= with max-items=2 fills the page with matches only" \
 		"got HTTP $HTTP_CODE items='$LIST' moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+fi
+
+# A page that is exactly full is not truncated. The walk looks one match past
+# the page to tell those two apart, and a walk bounded at the page instead
+# cannot: it returns the limit either way, and every directory whose member
+# count equals the limit would report moreRows true (#274). The limit is read
+# off an unlimited listing rather than hardcoded, so adding members above does
+# not quietly turn this into the truncated case again.
+TOTAL=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member" |
+	jq -r '.returnedRows' 2>/dev/null)
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" -H "X-IBM-Max-Items: ${TOTAL}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member")
+HTTP_CODE=$(echo "$BODY" | tail -1)
+CONTENT=$(echo "$BODY" | sed '$d')
+
+if [ "$HTTP_CODE" = "200" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "$TOTAL" ] &&
+   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
+	pass "max-items equal to the member count: moreRows=false"
+else
+	fail "max-items equal to the member count: moreRows=false" \
+		"got HTTP $HTTP_CODE rows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) of $TOTAL moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
 fi
 
 # an over-long pattern is rejected, not quietly cut down to size: a truncated
@@ -862,7 +883,7 @@ else
 	HTTP_CODE=$(echo "$BODY" | tail -1)
 	CONTENT=$(echo "$BODY" | sed '$d')
 
-	if [ "$HTTP_CODE" = "206" ] &&
+	if [ "$HTTP_CODE" = "200" ] &&
 	   [ "$(echo "$CONTENT" | jq -r '.returnedRows')" = "10" ] &&
 	   [ "$(echo "$CONTENT" | jq -r '.items | length')" = "10" ] &&
 	   [ "$(echo "$CONTENT" | jq -r '.moreRows')" = "true" ]; then
@@ -872,10 +893,10 @@ else
 			"got HTTP $HTTP_CODE returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows') moreRows=$(echo "$CONTENT" | jq -r '.moreRows')"
 	fi
 
-	# The counting pass walks the directory a second time, so this is where a
-	# large directory would show it: the page must still be the first 10
-	# members and the walk must still stop one match past them, not read
-	# 23000 entries twice. A timeout here is the regression.
+	# This is where a large directory shows whether the walk still stops one
+	# match past the page: with start= applied first it must return the first
+	# 10 members behind the key and give up there, not read 23000 entries.
+	# A timeout here is the regression.
 	START=$(date +%s)
 	BODY=$(curl -s -w '\n%{http_code}' -m 180 -u "$AUTH" -H 'X-IBM-Max-Items: 10' \
 		"${BASE_URL}/zosmf/restfiles/ds/${BIG_PDS}/member?start=A")
@@ -883,7 +904,7 @@ else
 	HTTP_CODE=$(echo "$BODY" | tail -1)
 	CONTENT=$(echo "$BODY" | sed '$d')
 
-	if [ "$HTTP_CODE" = "206" ] &&
+	if [ "$HTTP_CODE" = "200" ] &&
 	   [ "$(echo "$CONTENT" | jq -r '.returnedRows')" = "10" ]; then
 		pass "max-items=10 with start= on ${BIG_PDS} (${ELAPSED}s)"
 	else

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -182,9 +182,6 @@ RESP=$(curl -s -w '\n%{http_code}' \
 HTTP_CODE=$(echo "$RESP" | tail -1)
 BODY=$(echo "$RESP" | sed '$d')
 
-# No X-IBM-Max-Items, so this is a complete listing and stays 200 even though
-# the handler applies a default cap of its own -- 206 answers the client's
-# limit, not ours (#249). See the max-items block below for the truncated case.
 assert_http_status "200" "$HTTP_CODE" "list directory ${TEST_DIR}"
 assert_json_field_exists "$BODY" ".items" "list: items array present"
 assert_json_field_exists "$BODY" ".returnedRows" "list: returnedRows present"
@@ -224,19 +221,18 @@ else
 	fail "list max-items: returnedRows" "expected <= 2, got '$RETURNED'"
 fi
 
-# Whether this directory has more than two entries decides both the status and
-# moreRows, and the point of asserting them together is that they must agree:
-# a 206 next to moreRows false (or the reverse) is the failure #249 is about.
+# The status stays 200 either way -- a truncated listing carries the fact in
+# moreRows and nowhere else (#274). What totalRows decides here is only which
+# value moreRows must have.
+assert_http_status "200" "$HTTP_CODE" "list with max-items=2"
 if [ -n "$TOTAL_ROWS" ] && [ "$TOTAL_ROWS" -gt 2 ] 2>/dev/null; then
-	assert_http_status "206" "$HTTP_CODE" "list with max-items=2 (truncated)"
 	assert_json_field "$BODY" ".moreRows" "true" "list max-items: moreRows is true when truncated"
 else
-	assert_http_status "200" "$HTTP_CODE" "list with max-items=2 (not truncated)"
 	assert_json_field "$BODY" ".moreRows" "false" "list max-items: moreRows is false when complete"
 fi
 
-# a limit nothing reaches is a complete listing: the header being present is
-# not what makes a response partial
+# a limit nothing reaches is a complete listing: the header being present does
+# not make moreRows true
 RESP=$(curl -s -w '\n%{http_code}' \
 	-u "$AUTH" \
 	-H "X-IBM-Max-Items: 10000" \

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -374,11 +374,11 @@ if [ "$MEMBER_WRITE_OK" -eq 1 ]; then
 		fail "member names are returned unpadded" "got: $NAMES"
 	fi
 
-	# A truncated member list answers 206 rather than 200 (#249), and the
-	# assertion that matters is that Zowe still treats it as success: the
-	# status is what its RestClient decides on, so a client that rejected 206
-	# would fail here with the body perfectly well-formed. The dataset list
-	# above covers the same ground for the other handler.
+	# A truncated member list is a 200 carrying moreRows true (#274), and what
+	# is asserted here is that the fact survives Zowe's own parsing -- the
+	# status says nothing about it, so moreRows is the only thing a client has
+	# to go on. The dataset list above covers the same ground for the other
+	# handler.
 	#
 	# A second member has to exist first. With only TESTMBR in the directory
 	# max-items=1 is not a truncation at all, the response is a plain 200, and
@@ -395,7 +395,7 @@ if [ "$MEMBER_WRITE_OK" -eq 1 ]; then
 
 	RC=0
 	OUTPUT=$(run_zowe_json files list am "$TEST_PDS" --max 1) || RC=$?
-	assert_rc 0 "$RC" "list PDS members (max-items=1, HTTP 206)"
+	assert_rc 0 "$RC" "list PDS members (max-items=1, truncated)"
 
 	ROWS=$(echo "$OUTPUT" | jq -r '.data.apiResponse.returnedRows' 2>/dev/null) || ROWS=0
 	MORE=$(echo "$OUTPUT" | jq -r '.data.apiResponse.moreRows' 2>/dev/null) || MORE=""

--- a/tests/zowe-uss.sh
+++ b/tests/zowe-uss.sh
@@ -207,12 +207,12 @@ else
 	fail "list: testfile.txt present" "not found in listing"
 fi
 
-# A truncated listing answers 206 rather than 200 (#249). What is asserted here
-# is that Zowe still treats it as success -- the status is what its RestClient
-# decides on, so a client rejecting 206 fails here with a well-formed body.
+# A truncated listing is a 200 carrying moreRows true (#274). What is asserted
+# here is that the fact survives Zowe's own parsing -- the status says nothing
+# about it, so moreRows is the only thing a client has to go on.
 RC=0
 OUTPUT_MAX=$(run_zowe_json files list uss-files "${TEST_DIR}" --max 1) || RC=$?
-assert_rc 0 "$RC" "list USS directory (max-items=1, HTTP 206)"
+assert_rc 0 "$RC" "list USS directory (max-items=1, truncated)"
 
 MORE=$(echo "$OUTPUT_MAX" | jq -r '.data.apiResponse.moreRows' 2>/dev/null) || MORE=""
 if [ "$MORE" = "true" ]; then


### PR DESCRIPTION
Fixes #274.

#249/PR #265 read z/OSMF's status list as requiring **206 Partial content** for
a listing cut short by `X-IBM-Max-Items`. Measured against z/OSMF version 29 /
z/OS 05.29.00, the reference does no such thing: every truncation is a **200
carrying `moreRows: true`**, on the dataset list, the member list and the file
list alike, and no 206 comes out of the files service at all — not even for a
record-range read, the other case it would plausibly cover.

That is the same evidence class that closed #266 the other way, where mvsMF
answers an empty listing 200 rather than the documented 204. The rule is to
follow the reference where it and the documentation disagree, and this applies
it to the one row that was going the other way. **mvsMF now emits no 206
anywhere.**

## It removes work rather than only adjusting it

The status was the only reason two handlers measured the page before the header
went out, so both second walks go with it.

| Handler | Before | Now |
|---|---|---|
| `datasetListHandler` | counting pass over the sorted array | unchanged — no I/O, and `eligible` is what makes `moreRows` correct with `start=` |
| `memberListHandler` | second `fopen()` + directory walk | one walk |
| `ussListHandler` | `ufs_dirclose()` + second `ufs_diropen()` | one walk |

**The member walk is the part that is not a deletion.** `member_scan()` now
takes the page size, writes that many matches and looks *one further* before it
stops. That extra match is the whole mechanism: a walk bounded at the page
returns the page whether or not anything follows, so a directory holding
exactly as many members as the limit would report `moreRows: true`. The failure
is silent, so it gets its own test.

On USS the emit walk already counts every entry for `totalRows`, so `moreRows`
falls out of it exactly — for the client's limit and for the 1000-entry default
alike, which removes the `have_maxitems` special case as well.

`member_scan()` and `dslist_in_page()` stay as PR #265 left them; both removed
duplication rather than adding it.

## Verified live

Deployed and activated on the branch head — `/zosmf/test?fn=version` →
`4936870`, checked before the runs rather than assumed.

The exactly-full boundary on a real directory — the case the new test is about:

```
SYS1.MACLIB/member max=741   200 rows=741 more=true   first=ABEND last=XDAP
SYS1.MACLIB/member max=742   200 rows=742 more=false  first=ABEND last=XLATE
SYS1.MACLIB/member max=743   200 rows=742 more=false  first=ABEND last=XLATE
```

And the three listings against the values #274 measured on the reference:

```
ds?dslevel=SYS1.**  max=2    200 rows=2   more=true
SYS1.MACLIB/member  max=2    200 rows=2   more=true
SYS1.MACLIB/member  unlim.   200 rows=742 more=false
fs?path=/           max=1    200 rows=1   more=true
fs?path=/           unlim.   200 rows=4   more=false
```

`SYS1.SMPCDS` (~23000 members) with `start=` and max-items 10 still answers in
**1s** — the single walk still stops one match past the page rather than
reading the directory.

Suites, all 0 failed (the pre-existing #243 and ETag-flag skips remain):

- on `4936870`: curl datasets **184/184**, curl USS **118/118**
- on `a165c90`: Zowe datasets **50/50**, Zowe USS **25/25** — that is the
  commit before the head, and the two differ by one comment.

## Also in the diff

- `CLAUDE.md` — the "206 is the unresolved twin … do not cite #249 as settled
  precedent" paragraph recorded an open question that this closes. It now
  records the resolution, and why the one-past-the-page walk is load-bearing.
- `docs/endpoints/datasets/list.md`, `members-list.md`, `docs/endpoints/uss/list.md`
- the 206 assertions in the four suites, plus the new equal-to-the-member-count
  case in `curl-datasets.sh`. The two negatives PR #265 added stay and get more
  valuable: a limit nothing reaches, and a USS listing truncated by the
  server's own default.

## Deliberately not here

`moreRows` being emitted even when false, and the missing `totalRows` — both
noted in #274 as separate, both filed as **#279**.
