### PR TITLE
Emit moreRows only when true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,8 +406,15 @@ from the OS credential store without ever printing them.
 Two things met on the way: a member `pattern=` longer than 8 characters is
 rejected `400 {"category":1,"rc":4,"reason":13,"message":"pattern"}` — that is
 the member-name limit, not an empty result. And z/OSMF emits `moreRows` **only
-when true**, plus a `totalRows` mvsMF does not have yet (`dsapi.c:1221`,
-`dsapi.c:2090`).
+when true** — mvsMF followed suit in #279, on all three listings and the USS
+stat reply, so a complete listing now carries no `moreRows` key at all.
+
+`totalRows` is the piece still missing, and it is narrower than it looks: the
+reference emits it on the **file** list (`totalRows: 39` for `/`), and on a
+complete data set or member list it emits neither `totalRows` nor `moreRows` —
+measured, keys `["JSONversion","items","returnedRows"]`. mvsMF matches that
+today by accident rather than by decision; the open TODOs sit at `dsapi.c:1284`
+and `dsapi.c:2145` and are about `X-IBM-Attributes` `,total`.
 
 ### Operator Messages (WTO) — the catalog is closed
 

--- a/docs/endpoints/datasets/list.md
+++ b/docs/endpoints/datasets/list.md
@@ -27,6 +27,10 @@ HTTP status code 200 (OK), whether the listing is complete or was cut short by
 That is what real z/OSMF does; it emits no 206 on the files service at all
 (issue #274).
 
+**`moreRows` appears only when it is `true`.** A complete listing carries no
+such key, again matching the reference (issue #279) — so read the field as a
+flag, not as a value to compare against `false`.
+
 The body is a JSON object:
 
 ```json
@@ -46,7 +50,6 @@ The body is a JSON object:
         }
     ],
     "returnedRows": 0,
-    "moreRows": false,
     "JSONversion": 1
 }
 ```
@@ -109,7 +112,6 @@ zowe files list data-set "MIKE.**"
         }
     ],
     "returnedRows": 1,
-    "moreRows": false,
     "JSONversion": 1
 }
 ```

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -53,12 +53,14 @@ The body is a JSON object:
         }
     ],
     "returnedRows": 0,
-    "moreRows": false,
     "JSONversion": 1
 }
 ```
 
-`moreRows` is `true` only when the list was cut short by `X-IBM-Max-Items`.
+**`moreRows` appears only when the list was cut short by `X-IBM-Max-Items`**,
+and is `true` when it does. A complete listing carries no such key, matching the
+reference (issue #279) — so read the field as a flag, not as a value to compare
+against `false`.
 
 ## Large directories
 
@@ -172,7 +174,6 @@ curl -H 'X-IBM-Max-Items: 100' \
         { "member": "LINKJOB" }
     ],
     "returnedRows": 3,
-    "moreRows": false,
     "JSONversion": 1
 }
 ```

--- a/docs/endpoints/uss/list.md
+++ b/docs/endpoints/uss/list.md
@@ -40,7 +40,6 @@ GET /zosmf/restfiles/fs?path=<filepath>
   ],
   "returnedRows": 1,
   "totalRows": 1,
-  "moreRows": false,
   "JSONversion": 1
 }
 ```
@@ -63,11 +62,15 @@ GET /zosmf/restfiles/fs?path=<filepath>
 When `X-IBM-Max-Items` is set and the directory contains more entries:
 - `returnedRows` = number of items in the response
 - `totalRows` = total entries in the directory (excluding `.` and `..`)
-- `moreRows` = `true` when results were truncated
+- `moreRows` = `true` when results were truncated, **and absent otherwise**
 
 **The status is 200 either way** — a truncated listing is carried in `moreRows`
 and nowhere else. That is what real z/OSMF does; it emits no 206 on the files
 service at all (issue #274).
+
+**`moreRows` appears only when it is `true`**, on a directory listing and on the
+single-item stat reply alike, again matching the reference (issue #279) — so
+read the field as a flag, not as a value to compare against `false`.
 
 The 1000-entry default cap works the same way: a directory larger than that,
 listed without the header, answers 200 with `moreRows: true`.
@@ -124,7 +127,6 @@ Returns a single-item list with the full path in the `name` field:
   ],
   "returnedRows": 1,
   "totalRows": 1,
-  "moreRows": false,
   "JSONversion": 1
 }
 ```

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1282,8 +1282,14 @@ end:
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", emitted)) < 0) goto quit;
 	// TODO: add totalRows if X-IBM-Attributes has ',total'
-	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
-		(emitted < eligible) ? "true" : "false")) < 0) goto quit;
+	/* Only when true.  z/OSMF omits the key on a complete listing rather than
+	** answering false, measured on version 29 for all three listings (#279),
+	** and an absent key is what a client testing the field already reads as
+	** "no more rows".  JSONversion follows unconditionally, so the comma above
+	** stands either way. */
+	if (emitted < eligible) {
+		if ((rc = http_printf(session->httpc, "  \"moreRows\": true,\n")) < 0) goto quit;
+	}
 
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;
@@ -2137,8 +2143,10 @@ int memberListHandler(Session *session)
 	if ((rc = http_printf(session->httpc, "  ],\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "  \"returnedRows\": %d,\n", emitted)) < 0) goto quit;
 	// TODO: add totalRows if X-IBM-Attributes has ',total'
-	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
-		truncated ? "true" : "false")) < 0) goto quit;
+	/* only when true -- see the note in datasetListHandler() (#279) */
+	if (truncated) {
+		if ((rc = http_printf(session->httpc, "  \"moreRows\": true,\n")) < 0) goto quit;
+	}
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "} \n")) < 0) goto quit;
 

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -451,7 +451,8 @@ uss_stat_file(Session *session, UFS *ufs, const char *path)
 		"  ],\n"
 		"  \"returnedRows\": 1,\n"
 		"  \"totalRows\": 1,\n"
-		"  \"moreRows\": false,\n"
+		/* no moreRows: a stat reply is one row and complete by
+		   construction, and the key is emitted only when true (#279) */
 		"  \"JSONversion\": 1\n"
 		"}\n",
 		path, entry->attr, entry->filesize,
@@ -593,8 +594,10 @@ int ussListHandler(Session *session)
 	   whole directory and this is exact -- for the client's limit and for
 	   USS_LIST_DEFAULT_MAX_ITEMS alike, which truncates the same way. */
 	more = (maxitems > 0 && emitted < total);
-	if ((rc = http_printf(session->httpc, "  \"moreRows\": %s,\n",
-		more ? "true" : "false")) < 0) goto quit;
+	/* only when true -- see the note in datasetListHandler() (#279) */
+	if (more) {
+		if ((rc = http_printf(session->httpc, "  \"moreRows\": true,\n")) < 0) goto quit;
+	}
 	if ((rc = http_printf(session->httpc, "  \"JSONversion\": 1\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "}\n")) < 0) goto quit;
 

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -118,6 +118,22 @@ assert_json_field_exists() {
 	fi
 }
 
+assert_json_field_absent() {
+	local json="$1"
+	local expr="$2"
+	local label="$3"
+	local present
+	# the expression is a has() test, not a value read: jq -r on an absent key
+	# and on a literal null both print "null", so reading the value cannot tell
+	# "omitted" from "present and null" -- and only the first is what z/OSMF does
+	present=$(echo "$json" | jq -r "$expr" 2>/dev/null) || present="?"
+	if [ "$present" = "false" ]; then
+		pass "$label (key absent)"
+	else
+		fail "$label" "expected the key to be absent, got present=$present"
+	fi
+}
+
 # =========================================================================
 # Cleanup helper — delete datasets ignoring errors
 # =========================================================================
@@ -380,19 +396,16 @@ else
 fi
 
 # The other half: the header alone does not make a listing partial. A limit
-# nothing reaches is a complete answer and moreRows stays false.
+# nothing reaches is a complete answer, and a complete answer carries no
+# moreRows key at all (#279).
 BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
 	-H "X-IBM-Max-Items: 1000" \
 	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
-if [ "$HTTP_CODE" = "200" ] &&
-   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
-	pass "max-items above the row count stays 200"
-else
-	fail "max-items above the row count stays 200" \
-		"got HTTP $HTTP_CODE moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
-fi
+assert_http_status "200" "$HTTP_CODE" "max-items above the row count stays 200"
+assert_json_field_absent "$CONTENT" 'has("moreRows")' \
+	"max-items above the row count: no moreRows"
 
 # --- List datasets (start=) ---
 #
@@ -454,17 +467,18 @@ else
 			"${BASE_URL}/zosmf/restfiles/ds/${D}"
 	done
 
-	# past the last name is an empty page, not a full one -- and moreRows
-	# must not claim there is more to fetch
+	# past the last name is an empty page, not a full one -- and nothing may
+	# claim there is more to fetch, which since #279 means no moreRows key
 	CONTENT=$(curl -s -u "$AUTH" \
 		"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL&start=ZZZZZZZZ")
-	if [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "0" ] &&
-	   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
+	if [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "0" ]; then
 		pass "start= beyond the last dataset returns an empty page"
 	else
 		fail "start= beyond the last dataset returns an empty page" \
-			"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+			"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)"
 	fi
+	assert_json_field_absent "$CONTENT" 'has("moreRows")' \
+		"start= beyond the last dataset: no moreRows"
 
 	# --- over-long start= (issue #240) ---
 	#
@@ -590,7 +604,8 @@ HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
 assert_http_status "200" "$HTTP_CODE" "list PDS members"
 assert_json_field_exists "$CONTENT" '.items[0].member' "member list has member field"
-assert_json_field "$CONTENT" '.moreRows' "false" "member list: moreRows false when complete"
+assert_json_field_absent "$CONTENT" 'has("moreRows")' \
+	"member list: no moreRows when complete"
 
 # Names come back as z/OSMF reports them, without the directory's blank padding
 # (#154). A padded name makes a client build "dsn(member )" for the follow-up
@@ -684,13 +699,14 @@ fi
 
 CONTENT=$(curl -s -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member?start=ZZZZZZZZ")
-if [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "0" ] &&
-   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
+if [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "0" ]; then
 	pass "start= beyond the last member returns an empty page"
 else
 	fail "start= beyond the last member returns an empty page" \
-		"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+		"returnedRows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)"
 fi
+assert_json_field_absent "$CONTENT" 'has("moreRows")' \
+	"start= beyond the last member: no moreRows"
 
 # --- List PDS members (pattern=) ---
 #
@@ -758,13 +774,14 @@ HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
 
 if [ "$HTTP_CODE" = "200" ] &&
-   [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "$TOTAL" ] &&
-   [ "$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)" = "false" ]; then
-	pass "max-items equal to the member count: moreRows=false"
+   [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "$TOTAL" ]; then
+	pass "max-items equal to the member count returns every member"
 else
-	fail "max-items equal to the member count: moreRows=false" \
-		"got HTTP $HTTP_CODE rows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) of $TOTAL moreRows=$(echo "$CONTENT" | jq -r '.moreRows' 2>/dev/null)"
+	fail "max-items equal to the member count returns every member" \
+		"got HTTP $HTTP_CODE rows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) of $TOTAL"
 fi
+assert_json_field_absent "$CONTENT" 'has("moreRows")' \
+	"max-items equal to the member count: no moreRows"
 
 # an over-long pattern is rejected, not quietly cut down to size: a truncated
 # pattern selects a different set of members, and answering 200 with that list

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -131,6 +131,22 @@ assert_json_field_exists() {
 	fi
 }
 
+assert_json_field_absent() {
+	local json="$1"
+	local expr="$2"
+	local label="$3"
+	local present
+	# the expression is a has() test, not a value read: jq -r on an absent key
+	# and on a literal null both print "null", so reading the value cannot tell
+	# "omitted" from "present and null" -- and only the first is what z/OSMF does
+	present=$(echo "$json" | jq -r "$expr" 2>/dev/null) || present="?"
+	if [ "$present" = "false" ]; then
+		pass "$label (key absent)"
+	else
+		fail "$label" "expected the key to be absent, got present=$present"
+	fi
+}
+
 assert_json_field_gte() {
 	local json="$1"
 	local field="$2"
@@ -222,17 +238,18 @@ else
 fi
 
 # The status stays 200 either way -- a truncated listing carries the fact in
-# moreRows and nowhere else (#274). What totalRows decides here is only which
-# value moreRows must have.
+# moreRows and nowhere else (#274), and a complete one carries no moreRows key
+# at all (#279). What totalRows decides here is only which of the two applies.
 assert_http_status "200" "$HTTP_CODE" "list with max-items=2"
 if [ -n "$TOTAL_ROWS" ] && [ "$TOTAL_ROWS" -gt 2 ] 2>/dev/null; then
 	assert_json_field "$BODY" ".moreRows" "true" "list max-items: moreRows is true when truncated"
 else
-	assert_json_field "$BODY" ".moreRows" "false" "list max-items: moreRows is false when complete"
+	assert_json_field_absent "$BODY" 'has("moreRows")' \
+		"list max-items: no moreRows when complete"
 fi
 
 # a limit nothing reaches is a complete listing: the header being present does
-# not make moreRows true
+# not make moreRows appear
 RESP=$(curl -s -w '\n%{http_code}' \
 	-u "$AUTH" \
 	-H "X-IBM-Max-Items: 10000" \
@@ -241,7 +258,8 @@ HTTP_CODE=$(echo "$RESP" | tail -1)
 BODY=$(echo "$RESP" | sed '$d')
 
 assert_http_status "200" "$HTTP_CODE" "list with max-items above the entry count"
-assert_json_field "$BODY" ".moreRows" "false" "list max-items=10000: moreRows is false"
+assert_json_field_absent "$BODY" 'has("moreRows")' \
+	"list max-items=10000: no moreRows"
 
 echo ""
 echo "--- List with X-IBM-Max-Items: 0 ---"
@@ -254,7 +272,8 @@ HTTP_CODE=$(echo "$RESP" | tail -1)
 BODY=$(echo "$RESP" | sed '$d')
 
 assert_http_status "200" "$HTTP_CODE" "list with max-items=0 (unlimited)"
-assert_json_field "$BODY" ".moreRows" "false" "list unlimited: moreRows is false"
+assert_json_field_absent "$BODY" 'has("moreRows")' \
+	"list unlimited: no moreRows"
 
 echo ""
 echo "--- List error cases ---"
@@ -296,6 +315,19 @@ if [ -n "$TEST_FILE_EXISTS" ]; then
 		pass "stat query: name contains full path"
 	else
 		fail "stat query: name does not contain full path ${TEST_FILE}"
+	fi
+
+	# a stat reply is one row and complete by construction, so it carries no
+	# moreRows key either -- it used to hardcode false (#279)
+	assert_json_field_absent "$BODY" 'has("moreRows")' \
+		"stat query: no moreRows"
+
+	# the JSON has to stay parseable after a key was dropped from the middle
+	# of the object: a stale comma is exactly what this would produce
+	if echo "$BODY" | jq -e . >/dev/null 2>&1; then
+		pass "stat query: response is valid JSON"
+	else
+		fail "stat query: response is valid JSON" "jq rejected the body"
 	fi
 fi
 

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -153,6 +153,22 @@ assert_json_field_exists() {
 	fi
 }
 
+assert_json_field_absent() {
+	local json="$1"
+	local expr="$2"
+	local label="$3"
+	local present
+	# the expression is a has() test, not a value read: jq -r on an absent key
+	# and on a literal null both print "null", so reading the value cannot tell
+	# "omitted" from "present and null" -- and only the first is what z/OSMF does
+	present=$(echo "$json" | jq -r "$expr" 2>/dev/null) || present="?"
+	if [ "$present" = "false" ]; then
+		pass "$label (key absent)"
+	else
+		fail "$label" "expected the key to be absent, got present=$present"
+	fi
+}
+
 # =========================================================================
 # Cleanup helper
 # =========================================================================
@@ -406,16 +422,15 @@ if [ "$MEMBER_WRITE_OK" -eq 1 ]; then
 			"returnedRows=$ROWS moreRows=$MORE"
 	fi
 
-	# and the negative: a limit the directory does not reach is complete (200)
+	# and the negative: a limit the directory does not reach is a complete
+	# listing, which carries no moreRows key at all (#279). Zowe has to cope
+	# with the field being absent -- it is written against a reference that
+	# omits it, and this is where that would show.
 	RC=0
 	OUTPUT=$(run_zowe_json files list am "$TEST_PDS" --max 100) || RC=$?
 	assert_rc 0 "$RC" "list PDS members (max-items=100, complete)"
-	MORE=$(echo "$OUTPUT" | jq -r '.data.apiResponse.moreRows' 2>/dev/null) || MORE=""
-	if [ "$MORE" = "false" ]; then
-		pass "member list max-items=100: moreRows=false"
-	else
-		fail "member list max-items=100: moreRows=false" "got '$MORE'"
-	fi
+	assert_json_field_absent "$OUTPUT" '.data.apiResponse | has("moreRows")' \
+		"member list max-items=100: no moreRows"
 
 	run_zowe files delete ds "${TEST_PDS}(PAGEMBR)" -f >/dev/null 2>&1
 fi


### PR DESCRIPTION
Fixes #279.

Real z/OSMF omits `moreRows` on a complete listing rather than answering
`false`. mvsMF emitted it unconditionally. Same class of divergence as #266 and
#274, resolved by the same rule: match the reference.

## Measured first, on all three surfaces

The claim in #279 was one line of prose, so it was checked before being encoded
in four code paths — read-only `list` against z/OSMF version 29:

| Request | `apiResponse` keys |
|---|---|
| `files list ds SYS1.MACLIB` | `["JSONversion","items","returnedRows"]` |
| `files list am SYS1.MACLIB --pattern ABEND` | `["JSONversion","items","returnedRows"]` |
| `files list uss-files /` | `["JSONversion","items","returnedRows","totalRows"]` |
| `files list am SYS1.MACLIB --max 2` | …plus `"moreRows": true` |

No `moreRows` anywhere on a complete listing; `true` when truncated.

## The change

The three list handlers and the single-item USS stat reply, which hardcoded
`false`. `JSONversion` follows unconditionally in all four, so no comma
bookkeeping is involved — the stat reply is asserted valid JSON in the suite
precisely because a key was dropped from the middle of an object.

Nothing on the client side has to change: an absent key is what a client
testing the field already reads as "no more rows", and Zowe is written against
a server that omits it.

## The tests grew a helper rather than reusing `assert_json_field`

`jq -r` prints `null` both for an absent key and for a literal `null`, so
reading the value cannot tell "omitted" from "present and null" — and only the
first is what the reference does. `assert_json_field_absent()` asserts on
`has()` instead, so a regression that emits `"moreRows": null` still fails.

## Verified live

Deployed and activated on the branch head — `/zosmf/test?fn=version` →
`1f9d552`, checked before the runs.

```
ds     SYS1.MACLIB  complete    has=false  rows=1
ds     SYS1.**      max=2       has=true   more=true   rows=2
member SYS1.MACLIB  complete    has=false  rows=742
member SYS1.MACLIB  max=2       has=true   more=true   rows=2
member SYS1.MACLIB  max=742     has=false  rows=742     <- exactly full, #274's case
fs     /            complete    has=false  rows=4
fs     /            max=1       has=true   more=true   rows=1
fs     /wwwroot/probe.txt  stat  has=false  valid JSON
```

Suites, 0 failed: curl datasets **188/188**, curl USS **118/118**, Zowe datasets
**50/50**, Zowe USS **25/25** (the pre-existing #243 and ETag-flag skips remain).

## Also in the diff

`CLAUDE.md` carried the note this makes stale — *"z/OSMF emits `moreRows` only
when true (mvsMF always emits it, including `false`)"*. It now records the
resolution, and corrects the `totalRows` half of the same sentence: the
reference emits `totalRows` on the **file** list, not on a complete data set or
member list, so mvsMF is not missing it there. The two `TODO` line references in
that paragraph had also drifted with the #274 diff and are updated.

Docs: the six `"moreRows": false` example bodies lose the key, and each of the
three endpoint pages says to read the field as a flag rather than compare it
against `false`.

## Note on the stand, not on this change

`USS_TEST_FILE` in `.env` points at `/tmp/README.md`, which is not on the
target, so `curl-uss.sh` skips its stat-query block — the one covering the reply
this PR edits. I verified that path by hand instead. Pointing the variable at an
existing file (e.g. `/wwwroot/probe.txt`) makes the suite cover it; that is a
local config change, so it is not in this diff.