### PR TITLE
Close the JES spool handle when a handler abends

### DIFF
--- a/docs/messages.md
+++ b/docs/messages.md
@@ -89,6 +89,9 @@ member not found, record too long) produce **no** console message.
 | `MVSMF905W` | `RECOVERY FCLOSE ABENDED FOR SLOT n` | The recovery close abended in turn. The DD stays allocated and its storage stays held for the life of the address space. |
 | `MVSMF906W` | `FORCING S0C1 TO EXERCISE THE ESTAE RECOVERY` | `/zosmf/test?fn=abend` is about to abend the worker **on purpose**. Only reachable with `MVSMF_ABEND_TEST=1` in the server environment. Not a fault. |
 | `MVSMF907I` | `ENV[n] "name"="value"` | CGI environment dump, one line per variable. Only written when `logging_middleware` is registered — it is not by default. A developer aid, not an operator message. |
+| `MVSMF908I` | `RECOVERY CLOSING THE JES SPOOL HANDLE` | Recovery is closing the JES2 spool handle an abending handler left open. Informational; it accompanies a `MVSMF901E`. Its absence after a jobs-API abend is the leak of issue #286. |
+| `MVSMF909W` | `RECOVERY JESCLOSE ABENDED, SPOOL DATA SETS STAY OPEN` | The recovery `jesclose()` abended in turn. The JES2 spool data sets stay allocated and their storage stays held for the life of the address space. |
+| `MVSMF910W` | `SESSION ALREADY HOLDS A JES HANDLE, THIS ONE NOT TRACKED` | A request opened a second JES handle while the first was still held. No path does this today; the second handle is not closed if the handler abends. Report it — it means a code change broke the one-at-a-time assumption in `Session`. |
 
 ## Adding a message
 

--- a/include/mvsmfmsg.h
+++ b/include/mvsmfmsg.h
@@ -135,6 +135,15 @@
 /** MVSMF907I CGI environment dump; only written when logmw is registered */
 #define MSG_ENV_DUMP		"MVSMF907I ENV[%u] \"%s\"=\"%s\""
 
+/** MVSMF908I recovery is closing the JES spool handle a handler left open */
+#define MSG_RECOVERY_JES	"MVSMF908I RECOVERY CLOSING THE JES SPOOL HANDLE"
+
+/** MVSMF909W the recovery jesclose() abended in turn; the spool stays open */
+#define MSG_RECOVERY_JES_ABEND	"MVSMF909W RECOVERY JESCLOSE ABENDED, SPOOL DATA SETS STAY OPEN"
+
+/** MVSMF910W a second JES handle was opened while one was still held */
+#define MSG_JES_TRACKED		"MVSMF910W SESSION ALREADY HOLDS A JES HANDLE, THIS ONE NOT TRACKED"
+
 /*
  * Arguments for MSG_STORAGE_FAILED -- uppercase, since they are substituted
  * into an uppercase literal.

--- a/include/router.h
+++ b/include/router.h
@@ -95,6 +95,12 @@ struct session {
     // Resource tracking for ESTAE abend recovery
     FILE *open_files[MAX_SESSION_FILES];  /**< Tracked FILE handles */
     int open_file_count;                  /**< Number of tracked files */
+    /* One slot, not a table: no request path opens two JES handles at a time.
+       jobRecordsHandler comes closest and its two are sequential, the first
+       closed before the second is opened. Registering a second while one is
+       held is therefore a bug, and session_register_jes() says so rather than
+       overwriting the slot and leaking what was in it (issue #286). */
+    struct jes *open_jes;                 /**< Tracked JES spool handle */
 } __attribute__((aligned(FULL_WORD_ALIGNMENT)));
 
 /**
@@ -170,10 +176,24 @@ void session_unregister_file(Session *session, FILE *fp) asm("RTR0007");
 void session_fclose(Session *session, FILE *fp) asm("RTR0008");
 
 /**
+ * @brief Register the JES spool handle for ESTAE recovery cleanup
+ * @return 0 on success, -1 if a handle is already registered
+ */
+int session_register_jes(Session *session, struct jes *jes) asm("RTR0010");
+
+/**
+ * @brief Unregister and close the tracked JES handle
+ *
+ * Takes JES ** because jesclose() nulls the caller's pointer, and the quit
+ * paths test it afterwards.
+ */
+void session_jesclose(Session *session, struct jes **jes) asm("RTR0011");
+
+/**
  * @brief Close all tracked resources (ESTAE recovery)
  *
- * Closes all registered FILE handles, UFS file handles and UFS sessions.
- * Called by the router after catching a handler abend.
+ * Closes all registered FILE handles, the JES spool handle, UFS file handles
+ * and UFS sessions. Called by the router after catching a handler abend.
  */
 void session_cleanup(Session *session) asm("RTR0009");
 

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -139,6 +139,7 @@ jobListHandler(Session *session)
 	process_job_list_filters(session, &filter, &jesfilt, status, sizeof(status));
 
 	jes = jesopen();
+	session_register_jes(session, jes);
 	if (!jes) {
 		wtof(MSG_JES_UNAVAILABLE);
 		sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR, CATEGORY_VSAM,
@@ -183,9 +184,7 @@ quit:
 		freeJsonBuilder(builder);
 	}
 
-	if (jes) {
-		jesclose(&jes);
-	}
+	session_jesclose(session, &jes);
 
 	return 0;
 }
@@ -706,6 +705,7 @@ do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 	JESPRST st;
 
 	JES *jes = jesopen();
+	session_register_jes(session, jes);
 	if (!jes) {
 		wtof(MSG_JES_UNAVAILABLE);
 		sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -824,9 +824,7 @@ do_print_sysout(Session *session, JESJOB *job, unsigned dsid)
 	rc = sendDefaultHeaders(session, HTTP_STATUS_OK, "text/plain", 0);
 
 quit:
-	if (jes) {
-		jesclose(&jes);
-	}
+	session_jesclose(session, &jes);
 
 	return rc;
 }
@@ -1139,6 +1137,9 @@ JESJOB* find_job_by_name_and_id(Session *session, const char *jobname, const cha
 	JESJOB **joblist = NULL;
 	JESFILT jesfilt = FILTER_JOBID;
 	const char *filter = jobid;
+	/* declared here, not at the jesopen() below: the early exit for a missing
+	   path variable jumps over that line, and quit: reads this pointer */
+	JES *jes = NULL;
 
 	if (out_joblist) {
 		*out_joblist = NULL;
@@ -1148,12 +1149,15 @@ JESJOB* find_job_by_name_and_id(Session *session, const char *jobname, const cha
 		goto quit;
 	}
 
-	JES *jes = jesopen();
+	jes = jesopen();
+	session_register_jes(session, jes);
 	if (!jes) {
 		wtof(MSG_JES_UNAVAILABLE);
 		goto quit;
 	}
 
+	/* the abend of #282 lands in here, which is why the handle is registered
+	   above rather than merely closed at quit: -- that label is not reached */
 	joblist = jesjob(jes, filter, jesfilt, 1);
 	if (!joblist) {
 		goto quit;
@@ -1181,9 +1185,7 @@ JESJOB* find_job_by_name_and_id(Session *session, const char *jobname, const cha
 	}
 
 quit:
-	if (jes) {
-		jesclose(&jes);
-	}
+	session_jesclose(session, &jes);
 
 	if (out_joblist) {
 		*out_joblist = joblist;

--- a/src/router.c
+++ b/src/router.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <clibwto.h>
 #include <clibtry.h>
+#include <clibjes2.h>
 
 #include "router.h"
 #include "common.h"
@@ -218,6 +219,41 @@ void session_fclose(Session *session, FILE *fp)
     fclose(fp);
 }
 
+__asm__("\n&FUNC    SETC 'ses_reg_jes'");
+int session_register_jes(Session *session, JES *jes)
+{
+    if (!session || !jes) return -1;
+    if (session->open_jes) {
+        // one slot, and no path opens two at a time -- see router.h. Say so
+        // rather than overwrite, which would leak the handle in the slot.
+        wtof(MSG_JES_TRACKED);
+        return -1;
+    }
+    session->open_jes = jes;
+    return 0;
+}
+
+__asm__("\n&FUNC    SETC 'ses_jesclose'");
+void session_jesclose(Session *session, JES **jes)
+{
+    if (!jes || !*jes) return;
+    if (session && session->open_jes == *jes) {
+        session->open_jes = NULL;
+    }
+    jesclose(jes);
+}
+
+// Thunk for ESTAE-protected jesclose() during recovery.
+// Returns 0 on success; a secondary abend is caught by try().
+__asm__("\n&FUNC    SETC 'safe_jesclose'");
+static int safe_jesclose_thunk(JES *jes)
+{
+    JES *local = jes;
+
+    jesclose(&local);
+    return 0;
+}
+
 // Thunk for ESTAE-protected fclose during recovery.
 // Returns 0 on success; a secondary abend is caught by try().
 __asm__("\n&FUNC    SETC 'safe_fclose'");
@@ -250,6 +286,19 @@ void session_cleanup(Session *session)
         }
     }
     session->open_file_count = 0;
+
+    // The JES handle holds the JES2 spool data sets. Left open it costs the
+    // address space their DCBs for good, and an abend inside jesjob() is
+    // exactly the case that skips the handler's own jesclose() (issue #286).
+    if (session->open_jes) {
+        JES *jes = session->open_jes;
+
+        session->open_jes = NULL;
+        wtof(MSG_RECOVERY_JES);
+        if (try(safe_jesclose_thunk, jes) != 0) {
+            wtof(MSG_RECOVERY_JES_ABEND);
+        }
+    }
 
     // UFS session lifecycle is managed by HTTPD (http_get_ufs).
     // HTTPD's worker ESTAE handles cleanup on abend.

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -106,6 +106,41 @@ static int testAbend(Session *session) {
   return 0; /* not reached */
 }
 
+/* fn=jesabend -- abend with a JES handle open, the shape of issue #282.
+ *
+ * fn=abend proves the ESTAE catches; this proves the catch also releases the
+ * JES2 spool data sets. Recovery must answer with MVSMF908I; without the
+ * registration in session_register_jes() the handle is simply lost and the DCBs
+ * stay open for the life of the address space (issue #286).
+ */
+__asm__("\n&FUNC	SETC 'testJesAbend'");
+static int testJesAbend(Session *session) {
+  JES *jes = NULL;
+
+  if (!abend_test_enabled()) {
+    return sendErrorResponse(
+        session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE, RC_ERROR,
+        REASON_SERVER_ERROR,
+        "fn=jesabend is disabled. Set MVSMF_ABEND_TEST=1 in the server "
+        "environment to enable the ESTAE recovery test hook.",
+        NULL, 0);
+  }
+
+  jes = jesopen();
+  if (!jes) {
+    return sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                             CATEGORY_SERVICE, RC_SEVERE, REASON_SERVER_ERROR,
+                             "jesopen() failed, nothing to leak", NULL, 0);
+  }
+  session_register_jes(session, jes);
+
+  wtof(MSG_ABEND_TEST);
+
+  __asm__ volatile("  DC	H'0'");
+
+  return 0; /* not reached */
+}
+
 int testHandler(Session *session) {
   int rc = 0;
   char *fn = NULL;
@@ -119,6 +154,9 @@ int testHandler(Session *session) {
    * its 500 recovery response after failed() retries. */
   if (strcmp(fn, "abend") == 0)
     return testAbend(session);
+
+  if (strcmp(fn, "jesabend") == 0)
+    return testJesAbend(session);
 
   session->headers_sent = 1;
   if ((rc = http_resp(session->httpc, 200)) < 0)
@@ -205,6 +243,7 @@ int testHandler(Session *session) {
 
     if (step >= 1) {
       jes = jesopen();
+      session_register_jes(session, jes);
       http_printf(session->httpc, "step1 jesopen -> %s\r\n",
                   jes ? "OK" : "NULL");
     }
@@ -274,8 +313,7 @@ int testHandler(Session *session) {
 
     if (jobs)
       jesjobfr(&jobs);
-    if (jes)
-      jesclose(&jes);
+    session_jesclose(session, &jes);
 
     rc = http_printf(session->httpc, "DONE step=%d\r\n", step);
 

--- a/tests/curl-diag.sh
+++ b/tests/curl-diag.sh
@@ -102,6 +102,32 @@ this suite must run against a production-like server with it UNSET."
 fi
 
 # =========================================================================
+# 3. fn=jesabend is guarded the same way
+#
+# It abends with a JES handle open, so on the ENABLED path recovery has to
+# close it (MVSMF908I) instead of leaking the JES2 spool DCBs -- issue #286.
+# Here, as above, only the guard is asserted: the enabled path is exercised
+# by hand against a server that sets MVSMF_ABEND_TEST.
+# =========================================================================
+echo ""
+echo "--- fn=jesabend guard (expect DISABLED in production) ---"
+RESP=$(get_fn jesabend)
+CODE=$(echo "$RESP" | tail -1)
+
+if [ "$CODE" = "400" ]; then
+	pass "fn=jesabend disabled -> HTTP 400"
+
+	echo ""
+	echo "--- server still serving after guarded fn=jesabend ---"
+	CODE2=$(get_fn version | tail -1)
+	assert_http_status "200" "$CODE2" "server alive after fn=jesabend (fn=version)"
+else
+	fail "fn=jesabend disabled -> HTTP 400" \
+		"got HTTP '${CODE}'. If 500, MVSMF_ABEND_TEST is set on the server: \
+this suite must run against a production-like server with it UNSET."
+fi
+
+# =========================================================================
 # summary
 # =========================================================================
 echo ""


### PR DESCRIPTION
Fixes #286.

`session_cleanup()` closed tracked `FILE` handles and nothing else, so a
jobs-API request that abended between `jesopen()` and `jesclose()` left the JES2
spool data sets open **for the life of the address space**. The abend of #282
lands inside exactly that window — `jesjob()` at `jobsapi.c:1157`, opened six
lines above, closed at a `quit:` label the ESTAE never reaches.

Every leaked handle costs the address space its DCBs — DEB, IOB, buffers — held
for the life of the address space. The console says so at shutdown: one
`IEC999I IFG0TC0A` per DCB MVS had to close on the program's behalf, and there
were very many.

Whether that is what drives the shortage is **not** claimed here. The review in
mvslovers/libc370#108 puts the S80A at the unconditional ~262 K contiguous stack
GETMAIN every LINK of the module makes, so the quantity under pressure is a
large *contiguous* block; small long-lived control blocks like these are the
kind of thing that fragments a subpool rather than exhausts it. Which of the two
matters is #287's question. This PR closes the leak on its own merits.

## Verified on the real defect, not just the hook

The degradation returned mid-session and the #282 abend fired on its own. The
console, same second:

```
7.13.43 STC 951  MVSMF901E HANDLER ABEND S0C4 U0000 FOR GET /zosmf/restjobs/jobs/MBTTEST/JOB01193/files
7.13.43 STC 951  MVSMF908I RECOVERY CLOSING THE JES SPOOL HANDLE
```

One abend, one release — and no `MVSMF909W` (the close did not abend in turn),
no `MVSMF910W`. Before this change the first line appeared alone and the handle
was simply lost.

**The abend itself is untouched and still happens.** That is mvslovers/libc370#108
(a failed GETMAIN dereferenced instead of returned), and what drives the address
space there is #287. This PR only stops the abend from costing the server a set
of spool DCBs each time.

## Shape

`Session` carries the handle the way it carries files, with **one slot, not a
table**: no request path holds two at a time, and `jobRecordsHandler` — the
closest thing to an exception — closes the first before opening the second.
Registering a second while one is held is therefore a bug, and `MVSMF910W` says
so rather than overwriting the slot and losing what was in it.

Recovery closes it under its own `try()`, like the file loop, and clears the slot
**before** the call so a secondary abend cannot leave a dangling pointer for a
later pass. `jesclose()` itself is safe on a half-built handle — it guards with
`if (jes->js)` and only walks the elements `arraycount()` reports — so closing
the handle that just caused an abend cannot compound it; the `try()` is belt and
braces.

Four call sites converted: `jobsapi.c:141` (list), `:708` (spool print),
`:1151` (job lookup), and `testapi.c` `fn=syslog`.

## Test hook

`fn=jesabend` opens a handle, registers it and faults, so the recovery path has
something to release. `fn=abend` proves the ESTAE catches; this proves the catch
also lets go of the spool. Guarded by `MVSMF_ABEND_TEST` like its sibling, and
`curl-diag.sh` asserts the guard — the enabled path needs a server that sets the
variable, which `mvsdev` does not, so it was the live abend above that exercised
the code.

## Also here

`find_job_by_name_and_id()` declared `JES *jes = jesopen()` **after** an early
`goto quit`, so the missing-parameter path read the pointer uninitialised and
called `jesclose()` on whatever the stack held. Only reachable if the router
hands the handler a NULL path variable — not the bug above, but a wild pointer
in recovery-adjacent code, and the declaration now sits with the other locals.

## Suites

Against `dd8f6e3` on the stand: curl jobs **100/100**, Zowe jobs **38/38**,
curl diagnostics **4/4** (0 failed; the pre-existing skips remain).
