### PR TITLE
Set __stklen to 64K: 65584 contiguous bytes per LINK instead of 262328

### DIFF
--- a/docs/storage-probe.md
+++ b/docs/storage-probe.md
@@ -79,17 +79,31 @@ or a watch that keys on `S80A` is looking for the wrong event.** The upside is
 that a `U0801` is now positive proof it was the startup stack, where an `S80A`
 could have come from anywhere in the address space.
 
-**There is a knob, and mvsMF does not use it.** `@@crt0` reads a `WXTRN`
-`@@STKLEN` and takes that value instead of the default (minimum 4096); from C
-it is simply a global `unsigned __stklen`. **httpd sets it** — `httpd.c:22`,
-`64*1024` — and runs a whole server on it. mvsMF, ftpd, ufsd, lua370, rexx370,
-httplua and httprexx do not, so each of them asks for the full 262328 per
-LINK. For the one module httpd re-LINKs on *every request*, that is a
-four-fold difference in the contiguous demand this page exists to measure.
-Whether mvsMF's handlers fit in 64 K is an open question — httpd's main task
-is not the same call chain — but it is measurable, and it is a much more
-surgical lever than hunting the abend. The knob is declared in no libc370
-header; you only learn about it by reading `@@crt0.asm`.
+**mvsMF sets `__stklen` to 64 K (#290), so its figure is 65584.** `@@crt0`
+reads a `WXTRN` `@@STKLEN` and takes that instead of the default (minimum
+4096); from C it is a plain global `unsigned __stklen` (`mvsmf.c`). httpd has
+done the same since long before mvsMF existed (`httpd.c:22`); ftpd, ufsd,
+lua370, rexx370, httplua and httprexx still take the 262328 default.
+
+This matters most for mvsMF because httpd re-LINKs it on *every request*. The
+point is not the 4× smaller demand but that it changes the failure mode:
+concurrency fences off free holes of roughly one stack each
+(mvslovers/httpd#195), and a 65584-byte request fits in holes that a
+262328-byte one cannot use at all. Measured both ways with `&hold=` against
+the same fragmented space — **8 of 8 requests failed before the change, 8 of
+8 succeeded after it.**
+
+`link_stack` is read from `PPASTKLN`, the length `@@crt0`/`@@crt1` actually
+GETMAINed (`ST R8,PPASTKLN`), so it follows `__stklen` and cannot drift from
+it.
+
+**Stack headroom, since a too-small stack overruns rather than failing
+cleanly:** the deepest recursion in the code is `uss_recursive_delete()`, at
+`UFS_PATH_MAX` (256) bytes of path buffer per level. `UFS_PATH_MAX` also caps
+how deep a tree can be built (~119 levels of `/d`), and a tree at that
+ceiling walks without trouble — the recursion stops on path length with a
+clean 400, not on stack. 50 levels plus a file at the bottom deletes in one
+204. The path limit is the binding constraint, not the stack.
 
 Sampled over a run, the two numbers separate the two hypotheses:
 

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -20,6 +20,29 @@
 #include "testapi.h"
 #include "router.h"
 
+/* C stack size for this module, read by libc370's @@crt0/@@crt1 through the
+ * WXTRN @@STKLEN (issue #290).  Without it the startup takes the default:
+ * STACKLEN X'040088' + L'CLIBPPA+7, rounded down to a doubleword = 262328
+ * bytes of CONTIGUOUS subpool 0 -- and httpd re-LINKs this module on every
+ * single request, so that quarter megabyte is demanded per request.
+ *
+ * That demand is what the degradation in #287 runs into.  The address space
+ * does not run out of storage; it runs out of a 262328-byte contiguous piece,
+ * because concurrency episodes fence off holes of about one stack each
+ * (mvslovers/httpd#195).  At 64 K the request fits in every hole that
+ * mechanism produces -- a fenced-off ~256 K hole holds four of these instead
+ * of none -- so the failure stops being terminal rather than merely rarer.
+ *
+ * 65536 + 55 rounds down to 65584 bytes actually GETMAINed.  httpd itself has
+ * run on this value since long before mvsMF existed (httpd.c:22), but that is
+ * its main task, not this call chain: the sizing is justified by the test
+ * suites, not by httpd's precedent.  /zosmf/test?fn=storage reports the live
+ * figure out of PPASTKLN, so the probe follows any change made here.
+ *
+ * Written by nobody: @@crt0 only loads it, so it stays legal in a RENT
+ * module. */
+unsigned __stklen = 64 * 1024;
+
 /* httpd has already resolved the client credential (Basic/token) before
  * dispatching to this CGI; ACEE(0) means no credential resolved. Reject
  * here rather than trusting httpd's MOD= login flag, which today is a

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -6,6 +6,7 @@
 #include <clibjes2.h>
 #include <cliblist.h>
 #include <clibmtt.h>
+#include <clibppa.h>
 #include <clibwto.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -152,7 +153,7 @@ static int testJesAbend(Session *session) {
  *
  *   largest  the biggest contiguous block GETMAIN would hand out right now.
  *            httpd LINKs MVSMF fresh per request and libc370's C startup
- *            takes an *unconditional* GETMAIN of STG_LINK_STACK bytes for
+ *            takes a GETMAIN of the C stack (link_stack, from PPASTKLN) for
  *            the main stack, so once `largest` drops below that the next
  *            request cannot start -- S80A, before mvsMF's ESTAE exists.
  *   total    everything still free, counted in blocks of >= STG_GRAN
@@ -162,8 +163,8 @@ static int testJesAbend(Session *session) {
  * falling together is an ordinary leak.  Either number alone cannot tell the
  * two apart, which is the whole reason the comb exists.
  *
- * Both are measured from *inside* a CGI request, so this task's own
- * STG_LINK_STACK is already carved out of what is being reported, and each
+ * Both are measured from *inside* a CGI request, so this task's own C stack
+ * is already carved out of what is being reported, and each
  * sample is itself one more LINK.  Read the numbers accordingly.
  *
  * Probing uses the register form of GETMAIN/FREEMAIN, issued inline: MVSMF
@@ -186,7 +187,16 @@ static int testJesAbend(Session *session) {
  * which is why it lands on X'0400B8' and not one word higher.  262144 is the
  * round number this was first written against and it is too low: a largest
  * block between the two reads "fits" and does not. */
-#define STG_LINK_STACK 262328u        /* X'0400B8' */
+/* Measured, not recomputed: @@crt0/@@crt1 store the length they GETMAINed in
+ * PPASTKLN (`ST R8,PPASTKLN`), so this reports what this very task's stack
+ * actually cost and follows any `__stklen` change (mvsmf.c, #290) with no
+ * second source of truth to drift.  0 when the PPA is unreachable. */
+__asm__("\n&FUNC	SETC 'stg_link_stack'");
+static unsigned stg_link_stack(void) {
+  CLIBPPA *ppa = __ppaget();
+
+  return ppa ? ppa->ppastkln : 0;
+}
 #define STG_COMB_MAX   256            /* blocks the &total=1 comb may hold  */
 #define STG_SIZES_MAX  32             /* block sizes reported in the JSON   */
 
@@ -817,7 +827,7 @@ int testHandler(Session *session) {
                        "{ \"fn\": \"storage\", \"sp\": %u, \"largest\": %u,"
                        " \"largest_at\": \"%s\", \"link_stack\": %u,"
                        " \"granularity\": %u, \"stack_at\": \"%s\"",
-                       sp, largest, largest_at, STG_LINK_STACK, STG_GRAN,
+                       sp, largest, largest_at, stg_link_stack(), STG_GRAN,
                        stack_at);
       if (rc < 0)
         goto quit;


### PR DESCRIPTION
Fixes #290.

`unsigned __stklen = 64 * 1024;` in `mvsmf.c`. libc370's `@@crt0` reads that
through a `WXTRN @@STKLEN` and uses it instead of its default, so every LINK
of MVSMF now asks for **65584 contiguous bytes of subpool 0 instead of
262328**.

## Why this is more than a 4x reduction

The degradation measured in #287 is not a shortage of storage — it is a
shortage of *contiguity*. Concurrency episodes (a deploy upload holding its
stack while other requests run) fence off free holes of about one stack each
(mvslovers/httpd#195). Before this change those holes were ~262144 and
~258048 bytes: **too small to hold the next 262328-byte stack, so dead**.
At 65584 the same holes hold three or four stacks each.

Measured both ways on `mvsdev`, same server, same provocation
(`fn=storage&hold=8`, holding the big block so requests must start in the
holes):

| | before | after |
|---|---|---|
| concurrent requests that started | **0 of 8** (`U0801`, `@@CRT1 - No storage for C stack`, client 503) | **8 of 8** (200) |

## Verification

- `fn=storage` reports `link_stack: 65584` live, read from `PPASTKLN` — the
  length `@@crt0`/`@@crt1` actually GETMAINed (`ST R8,PPASTKLN`), so the
  probe follows `__stklen` with no second source of truth. The hardcoded
  262328 constant is gone.
- Generated assembler confirms the symbol: `ENTRY @@STKLEN` / `DC F'65536'`.
- **Full curl suites: 544 passed, 0 failed** (info 40, datasets 188, jobs
  100, uss 128, console 64, binary 10, auth 14).
- **Stack depth**, since a too-small stack overruns rather than failing
  cleanly: the deepest recursion is `uss_recursive_delete()` at
  `UFS_PATH_MAX` (256) bytes per level. `UFS_PATH_MAX` also caps tree depth
  at ~119 levels, and a tree built to that ceiling walks without trouble —
  the recursion stops on path length with a clean 400, never on stack. A
  50-level tree with a file at the bottom deletes in one 204. The path limit
  binds before the stack does.
- Fragmentation reproducer re-run after the change: one round cost nothing at
  all, a second round still fenced off holes — but of 233472 and 192512
  bytes, i.e. **usable**, which is the whole point.

## Not claimed

This does not stop the fragmentation; it makes the resulting holes
reusable. The root fix is naming the small long-lived allocation and
pre-allocating it at startup — mvslovers/httpd#195.
