### PR TITLE
Route every raw send through send_all() so a stalled client cannot spin a worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,13 +520,17 @@ project: on a non-blocking socket **the application waits — 100 attempts of
 On a *blocking* socket libc370 waits instead and the application must not — see
 libc370#120 / ftpd#104. One layer per socket, never two.
 
-Two things this depends on that fail silently if broken. The ECB handed to
+Three things this depends on that fail silently if broken. The ECB handed to
 `cthread_timed_wait()` is zeroed on the waiting frame **every** time; an
 already-posted ECB that outlives one wait makes every later wait return
-instantly, which is the busy spin again. And the reason `send_all()` marks the
+instantly, which is the busy spin again. The reason `send_all()` marks the
 client `CSTATE_DONE` on failure is not tidiness — without it the handler's
 error path comes straight back through `sendErrorResponse()` and pays the whole
-10 s budget again for a peer that is already gone (httpd#203).
+10 s budget again for a peer that is already gone (httpd#203). And it must
+clear `keepalive` in the same breath: `CSTATE_DONE` is *normal completion*, so
+httpd walks `DONE → REPORT → RESET` and `httprese()` reuses the socket if the
+flag is still set — appending the next response to a body that is short of the
+Content-Length it announced. A hang traded for a corrupt stream is not a fix.
 
 The loop lives in its own TU only so `TSTSEND` (`test/host/tstsend.c`) drives
 the real one on the host; its four MVS/httpd services are injected through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,13 +66,14 @@ http_xlate((unsigned char *)body, body_len, httpx->xlate_cp037->atoe);
   applies `http_etoa()` with the *server-default* table. Response headers and
   JSON bodies built with `http_printf` need no explicit call — and must not be
   pre-translated, or they get converted twice.
-- **`http_send()` does not translate.** It sends the buffer raw and expects the
-  caller to have produced ASCII already.
+- **`send_all()` does not translate.** It sends the buffer raw and expects the
+  caller to have produced ASCII already. (Neither does the `http_send()` under
+  it — which nothing outside `common.c` may call, see **Sending** below.)
 - **Raw bytes are always yours.** Every explicit `http_xlate()` in this repo sits
-  on payload crossing a boundary — outbound before `http_send()` (`dsapi.c:203`,
-  `ussapi.c:488`), inbound after reading a body or a chunk header
-  (`dsapi.c:1067`, `ussapi.c:594`), or before writing a record to a data set
-  (`dsapi.c:549`). None of them wrap a `http_printf()`.
+  on payload crossing a boundary — outbound before `send_all()` (`dsapi.c:236`,
+  `ussapi.c:741`), inbound after reading a body or a chunk header
+  (`dsapi.c:1528`, `ussapi.c:847`), or before writing a record to a data set
+  (`dsapi.c:754`). None of them wrap a `http_printf()`.
 
 So the rule is: **payload bytes are yours to translate, formatted output is
 httpd's.**
@@ -498,6 +499,41 @@ The MVS 3.8j TCP/IP stack has a ring buffer bug that corrupts data when a multi-
 
 The `receive_raw_data()` function in `jobsapi.c` works around this by reading one byte at a time from the socket (same approach as the HTTPD's `http_getc`). **Do not change `receive_raw_data()` to use larger recv sizes** — any multi-byte recv will reintroduce data corruption for large request bodies (see PR #22 and Issue #42).
 
+### Sending — `send_all()` is the only way out
+
+**Never call `http_send()` directly.** Every raw send goes through
+`send_all()` (`common.c`), which wraps the loop in `src/sendall.c`.
+
+`http_send()` returns **0** for "socket send buffer full, no progress, retry"
+— on a non-chunked response httpd's `send_raw()` reports the bytes it managed
+this call, and `EWOULDBLOCK` means none. A loop written `for (pos = 0; pos <
+len; pos += rc)` that only tests `rc < 0` therefore never terminates: `pos +=
+0`, a `send()` SVC per turn, one worker pinned at 100% CPU until the STC is
+restarted. That was #298, and it is byte-for-byte httpd#199 one level up. A
+single *unchecked* call is the other half: it silently drops whatever it did
+not send.
+
+The policy is agreed across the ecosystem and must not be re-invented per
+project: on a non-blocking socket **the application waits — 100 attempts of
+100 ms = 10 s without progress, then abandon** (httpd's `SEND_STALL_MAX` /
+`SEND_STALL_PAUSE`, mvsMF's in `include/sendall.h`, note the different unit).
+On a *blocking* socket libc370 waits instead and the application must not — see
+libc370#120 / ftpd#104. One layer per socket, never two.
+
+Two things this depends on that fail silently if broken. The ECB handed to
+`cthread_timed_wait()` is zeroed on the waiting frame **every** time; an
+already-posted ECB that outlives one wait makes every later wait return
+instantly, which is the busy spin again. And the reason `send_all()` marks the
+client `CSTATE_DONE` on failure is not tidiness — without it the handler's
+error path comes straight back through `sendErrorResponse()` and pays the whole
+10 s budget again for a peer that is already gone (httpd#203).
+
+The loop lives in its own TU only so `TSTSEND` (`test/host/tstsend.c`) drives
+the real one on the host; its four MVS/httpd services are injected through
+`SEND_OPS`. Until the Hercules X'75' fix (`mvslovers/hyperion` `1a599b0d`) a
+full send buffer froze the emulated CPU rather than returning `EWOULDBLOCK`,
+which is the only reason this never fired before 2026-08-18.
+
 ### Conventions
 
 - Headers use `asm("SYMBOL")` annotations for MVS external symbol naming.
@@ -600,7 +636,8 @@ mount, so nothing produces this rc today.
 
 ### I/O Pattern for File Read
 
-`http_send()` does not translate — convert the payload before handing it over.
+`send_all()` does not translate — convert the payload before handing it over,
+and never reach past it to `http_send()` (see **Sending**).
 `USS_DATA_TYPE_TEXT` / `_BINARY` are file-local `#define`s in `src/ussapi.c`;
 `get_data_type()` derives the mode from the `X-IBM-Data-Type` header.
 
@@ -614,7 +651,7 @@ while ((n = ufs_fread(buf, 1, sizeof(buf), fp)) > 0) {
         /* EBCDIC -> ASCII, IBM-1047 (USS), not CP037 */
         http_xlate((unsigned char *)buf, n, httpx->xlate_1047->etoa);
     }
-    if (http_send(session->httpc, (const UCHAR *)buf, n) < 0) {
+    if (send_all(session, (const UCHAR *)buf, (int)n) < 0) {
         break;  /* real handlers goto their cleanup label */
     }
 }

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -51,6 +51,7 @@ Ranges:
 | `MVSMF005E` | `pgm MUST BE CALLED BY THE HTTPD SERVER` | MVSMF was started from TSO or batch instead of as a CGI under httpd. It returns 12. |
 | `MVSMF006E` | `STORAGE ALLOCATION FAILED FOR what` | GETMAIN/`malloc` failed. The region is too small or the address space is leaking — see the httpd notes on CGI storage. `what` names the allocation (request body, JCL text, JCL line table). |
 | `MVSMF007W` | `RECEIVE TIMED OUT AFTER n RETRIES` | A client stopped sending in the middle of a request body and the read gave up. The worker was tied up for the whole wait. Isolated occurrences are a client or network problem; a steady stream means workers are being consumed. |
+| `MVSMF008W` | `SEND TIMED OUT AFTER n RETRIES` | The mirror image on the way out: the client stopped reading, so the socket send buffer stayed full for the whole 10 second budget (100 retries of 100 ms) and the response was abandoned. The connection is dropped and the worker released — before the fix for #298 that same condition spun the worker at 100% CPU forever, so this message replaces a hang. A stopping server (`P HTTPD`) is **not** reported here; it fails the send at once and silently. |
 
 ## MVSMF1xx — data sets
 

--- a/include/common.h
+++ b/include/common.h
@@ -198,6 +198,33 @@ int sendErrorResponse(Session *session, int status, int category, int rc,
 int send_not_modified(Session *session, const char *etag) asm("CMN0013");
 
 /**
+ * @brief Sends a whole buffer to the client, or fails
+ *
+ * The one raw send in mvsMF -- every streaming handler and every JSON
+ * response goes through it. Short writes are resumed and a no-progress
+ * return (0, a full socket send buffer) is paused and retried within a
+ * bounded budget, so the loop can neither spin at 100% CPU nor silently
+ * drop the tail of a record (issue #298).
+ *
+ * Do not call http_send() directly. A bare loop over it is the httpd#199
+ * defect, and a single unchecked call truncates whatever it did not send --
+ * today invisible only because those routes happen to be chunked.
+ *
+ * The buffer must already carry the bytes the client is to receive; no
+ * translation happens here.
+ *
+ * A failure leaves the client at CSTATE_DONE, which stops the handler's
+ * remaining output rather than letting each later call wait out its own
+ * budget for a peer that is gone.
+ *
+ * @param session Current session context
+ * @param buf Bytes to send
+ * @param len Number of bytes; <= 0 succeeds without sending
+ * @return 0 when everything was sent, -1 otherwise
+ */
+int send_all(Session *session, const UCHAR *buf, int len) asm("CMN0014");
+
+/**
  * @brief Reads the full request body into a malloc'd buffer
  *
  * Supports both Content-Length and Transfer-Encoding: chunked.

--- a/include/common.h
+++ b/include/common.h
@@ -215,7 +215,10 @@ int send_not_modified(Session *session, const char *etag) asm("CMN0013");
  *
  * A failure leaves the client at CSTATE_DONE, which stops the handler's
  * remaining output rather than letting each later call wait out its own
- * budget for a peer that is gone.
+ * budget for a peer that is gone, and clears keepalive so the connection is
+ * closed instead of reused -- the body is short of the Content-Length it
+ * announced, so the next response on that socket would be appended to a
+ * truncated one.
  *
  * @param session Current session context
  * @param buf Bytes to send

--- a/include/mvsmfmsg.h
+++ b/include/mvsmfmsg.h
@@ -66,6 +66,9 @@
 /** MVSMF007W the client stopped sending mid-body and the read gave up */
 #define MSG_RECV_TIMEOUT	"MVSMF007W RECEIVE TIMED OUT AFTER %d RETRIES"
 
+/** MVSMF008W the client stopped reading mid-response and the send gave up */
+#define MSG_SEND_TIMEOUT	"MVSMF008W SEND TIMED OUT AFTER %d RETRIES"
+
 /*
  * MVSMF1xx -- data sets (restfiles/ds)
  */

--- a/include/sendall.h
+++ b/include/sendall.h
@@ -1,0 +1,98 @@
+#ifndef SENDALL_H
+#define SENDALL_H
+
+/**
+ * @file sendall.h
+ * @brief The send loop, and its no-progress policy (issue #298).
+ *
+ * A send loop written as
+ *
+ *     for (pos = 0; pos < len; pos += rc)
+ *         rc = http_send(httpc, &buf[pos], len - pos);
+ *
+ * spins forever the moment http_send() returns 0: pos += 0 never reaches len,
+ * and the worker issues a send() SVC per turn at 100% CPU. Zero is a legitimate
+ * return -- for a non-chunked response httpd's send_raw() reports the bytes it
+ * managed this call, which is 0 when the socket send buffer is full
+ * (EWOULDBLOCK). It means "no progress, retry", not "error". This is the defect
+ * httpd fixed one level down as httpd#199/#201.
+ *
+ * The policy is the one agreed for the whole ecosystem: on a non-blocking
+ * socket the application waits, 100 attempts of 100 ms = 10 s without progress,
+ * then abandon. httpd applies it in httpprtv.c and httpsend.c, and the receive
+ * side of this file's caller does the same with a different granularity
+ * (RAW_RECV_MAX_RETRIES, 200 x 50 ms).
+ *
+ * ====================================================================
+ * The loop lives here, apart from common.c, so the host test can drive
+ * the real one. Its four MVS/httpd dependencies -- the send, the pause,
+ * the "client is gone or the server is stopping" test and the give-up
+ * action -- are injected through SEND_OPS, so this TU is portable C with
+ * no httpd session headers. common.c supplies the real ops; the test
+ * supplies scripted ones (see test/host/tstsend.c).
+ * ====================================================================
+ */
+
+/** @brief Consecutive no-progress sends tolerated before giving up. */
+#define SEND_STALL_MAX      100
+
+/**
+ * @brief Pause between no-progress retries, in .01s units for
+ *        cthread_timed_wait() -- 10 = 100 ms.
+ *
+ * NOTE the unit. httpd spells the same policy SEND_STALL_PAUSE 100000,
+ * microseconds for usleep(). Both are 100 ms, and 100 x 100 ms = 10 s is the
+ * budget shared by httpd, mvsMF and ftpd.
+ */
+#define SEND_STALL_PAUSE    10
+
+/**
+ * @brief The external services the send loop needs.
+ *
+ * Every member is required; send_bytes() does not test them for NULL.
+ * The instance is read-only -- keep it `static const` in the caller, since
+ * MVSMF is link-edited RENT and a writable static would S0C4.
+ */
+typedef struct send_ops {
+	/**
+	 * Send up to @p len bytes. Returns the number sent (may be short),
+	 * 0 for "no progress, retry later", or negative on a dead socket.
+	 */
+	int  (*send)(void *ctx, const unsigned char *buf, int len);
+
+	/** Pause one retry interval (SEND_STALL_PAUSE). */
+	void (*pause)(void *ctx);
+
+	/**
+	 * Non-zero when no further progress is possible at all: the client is
+	 * already finished or dead, or the server is quiescing/shutting down.
+	 * Polled on every no-progress turn, never cached -- a stopping server
+	 * must not sit out the stall budget in each of its workers.
+	 */
+	int  (*aborted)(void *ctx);
+
+	/**
+	 * Called once when the stall budget runs out, with the number of
+	 * consecutive no-progress sends. Reports it; the failure itself is the
+	 * caller's to act on. Not called for a dead socket or for @c aborted --
+	 * those are expected events with nothing for an operator to do.
+	 */
+	void (*giveup)(void *ctx, int stall);
+} SEND_OPS;
+
+/**
+ * @brief Send the whole buffer, or fail.
+ *
+ * Short writes are resumed, no-progress returns are paused and retried within
+ * the budget, and the position is never advanced by zero.
+ *
+ * @param ctx  Opaque context handed to every op.
+ * @param ops  Service table; must be fully populated.
+ * @param buf  Bytes to send, already in the encoding the client expects.
+ * @param len  Number of bytes; <= 0 is success with nothing sent.
+ * @return 0 when everything was sent, -1 otherwise.
+ */
+int send_bytes(void *ctx, const SEND_OPS *ops,
+	const unsigned char *buf, int len) asm("SND0001");
+
+#endif /* SENDALL_H */

--- a/project.toml
+++ b/project.toml
@@ -98,5 +98,15 @@ name = "TSTETAG"
 sources = ["test/host/tstetag.c"]
 norent = true
 
+# TSTSEND: #298 — the send loop must never advance by the return value without
+# checking it. A 0 from http_send() means "socket send buffer full, retry", and
+# `pos += rc` on it spins a worker at 100% CPU forever. Portable C (test-host);
+# the TU #includes src/sendall.c so it drives the real loop every response goes
+# through — do not list sendall.c here.
+[[test]]
+name = "TSTSEND"
+sources = ["test/host/tstsend.c"]
+norent = true
+
 [release]
 version_files = ["VERSION"]

--- a/src/common.c
+++ b/src/common.c
@@ -11,6 +11,7 @@
 #include "httpcgi.h"
 #include "json.h"
 #include "mvsmfmsg.h"
+#include "sendall.h"
 
 #define INITIAL_BUFFER_SIZE 4096
 
@@ -220,6 +221,107 @@ send_not_modified(Session *session, const char *etag)
 	if ((rc = http_printf(session->httpc,
 			"Access-Control-Expose-Headers: ETag\r\n")) < 0) return rc;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) return rc;
+
+	return rc;
+}
+
+//
+// Send a whole buffer to the client (issue #298).
+//
+// Every raw send in mvsMF goes through here. The loop itself is in
+// src/sendall.c so the host test can drive the real one; what stays here are
+// the four services it needs, bound to this session. See include/sendall.h.
+//
+// Returns 0 when everything was sent, -1 otherwise.
+//
+
+__asm__("\n&FUNC    SETC 'send_op_send'");
+static int
+send_op_send(void *ctx, const unsigned char *buf, int len)
+{
+	Session *session = (Session *)ctx;
+
+	return http_send(session->httpc, (const UCHAR *)buf, len);
+}
+
+__asm__("\n&FUNC    SETC 'send_op_pause'");
+static void
+send_op_pause(void *ctx)
+{
+	unsigned ecb = 0;
+
+	(void)ctx;
+
+	// The ECB is zeroed here, on this frame, every single time. A posted
+	// ECB that outlives one wait makes every later wait return at once --
+	// the 100% CPU spin this whole file exists to remove, back again and
+	// invisible. receive_raw_data() re-zeros for the same reason.
+	(void)cthread_timed_wait((void *)&ecb, SEND_STALL_PAUSE, 0);
+}
+
+__asm__("\n&FUNC    SETC 'send_op_abort'");
+static int
+send_op_aborted(void *ctx)
+{
+	Session *session = (Session *)ctx;
+	unsigned char flag;
+
+	// The client is finished or a failed send already marked it dead:
+	// nothing more can go out, so do not wait for it.
+	if (session->httpc->state >= CSTATE_DONE) {
+		return 1;
+	}
+
+	// A stopping server must not sit out the stall budget -- shutdown waits
+	// for the workers, so every worker wait has to honor quiesce
+	// (httpd#122, #205). The macro is a volatile read and this function runs
+	// once per poll, so the byte the operator-command thread sets is picked
+	// up on the next turn -- never hoisted out of the send loop.
+	flag = http_get_flag(session->httpd);
+	if (flag & (HTTPD_FLAG_QUIESCE | HTTPD_FLAG_SHUTDOWN)) {
+		return 1;
+	}
+
+	return 0;
+}
+
+__asm__("\n&FUNC    SETC 'send_op_gvup'");
+static void
+send_op_giveup(void *ctx, int stall)
+{
+	(void)ctx;
+
+	wtof(MSG_SEND_TIMEOUT, stall);
+}
+
+// RENT: read-only, so it may be static. A writable static would S0C4.
+static const SEND_OPS send_ops = {
+	send_op_send,
+	send_op_pause,
+	send_op_aborted,
+	send_op_giveup
+};
+
+__asm__("\n&FUNC    SETC 'send_all'");
+int
+send_all(Session *session, const UCHAR *buf, int len)
+{
+	int rc;
+
+	if (!session || !session->httpc) {
+		return -1;
+	}
+
+	rc = send_bytes(session, &send_ops, (const unsigned char *)buf, len);
+
+	if (rc < 0 && session->httpc->state < CSTATE_DONE) {
+		// Mark the client done, exactly as httpd's send_raw_all() does on
+		// the same failure. It is what stops the handler's remaining
+		// output -- http_printf() and the entry guard above both refuse a
+		// client at CSTATE_DONE -- instead of every later call paying its
+		// own 10 second budget for a peer that is gone.
+		session->httpc->state = CSTATE_DONE;
+	}
 
 	return rc;
 }
@@ -474,21 +576,13 @@ __asm__("\n&FUNC	SETC 'send_data'");
 static int 
 send_data(Session *session, char *buf) 
 {
-	int rc = 0;
 	size_t len = strlen(buf);
-	size_t pos = 0;
 
 	http_etoa((unsigned char *)buf, len);
 
-	for (pos = 0; pos < len; pos += rc) {
-		rc = http_send(session->httpc, &buf[pos], len - pos);
-		if (rc < 0) {
-			goto quit; /* socket error */
-		}
-	}
-
-	rc = 0; /* success */
-
-quit:
-	return rc;
+	/* sendJSONResponse() sets Content-Length before this, so the response is
+	   NOT chunked -- which is precisely the mode where http_send() reports 0
+	   for a full send buffer. Every JSON response mvsMF produces lands here,
+	   so this is the normal path, not an edge case (issue #298). */
+	return send_all(session, (const UCHAR *)buf, (int)len);
 }

--- a/src/common.c
+++ b/src/common.c
@@ -314,13 +314,27 @@ send_all(Session *session, const UCHAR *buf, int len)
 
 	rc = send_bytes(session, &send_ops, (const unsigned char *)buf, len);
 
-	if (rc < 0 && session->httpc->state < CSTATE_DONE) {
-		// Mark the client done, exactly as httpd's send_raw_all() does on
-		// the same failure. It is what stops the handler's remaining
-		// output -- http_printf() and the entry guard above both refuse a
+	if (rc < 0) {
+		// Drop the connection, both halves of it.
+		//
+		// CSTATE_DONE stops the handler's remaining output --
+		// http_printf() and the entry guard in send_bytes() both refuse a
 		// client at CSTATE_DONE -- instead of every later call paying its
-		// own 10 second budget for a peer that is gone.
-		session->httpc->state = CSTATE_DONE;
+		// own 10 second budget for a peer that is gone (httpd#203).
+		//
+		// It does NOT close the socket, though: DONE is the normal
+		// completion state, and httpd walks DONE -> REPORT -> RESET, where
+		// httprese() keeps the connection open if keepalive is still set.
+		// That is fine for a response that finished and wrong for this one
+		// -- the body is short of the Content-Length it announced, so the
+		// next response on the socket would be appended to a truncated one
+		// and the client would read the two as a single corrupt reply.
+		// Clearing keepalive sends httprese() down its CSTATE_CLOSE branch.
+		// httpd's chunked path clears the same flag for the same reason.
+		if (session->httpc->state < CSTATE_DONE) {
+			session->httpc->state = CSTATE_DONE;
+		}
+		session->httpc->keepalive = 0;
 	}
 
 	return rc;

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -205,6 +205,13 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 		return rc;
 	}
 
+	/* No Content-Length above, so httpd frames the body chunked, and its
+	   chunked path is all-or-error -- which is the only reason a bare
+	   http_send() per record used to be safe here. That dependency was
+	   invisible at the call site and one Content-Length away from silently
+	   truncating every download, so the records go through send_all() like
+	   everything else (issue #298). */
+
 	if (data_type == DATA_TYPE_TEXT) {
 		/* Text mode: fgets + EBCDIC->ASCII + strlen for length.
 		   F/FB records are padded with EBCDIC blanks to LRECL; strip them
@@ -227,8 +234,7 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 				len = end + 1;
 			}
 			http_xlate((unsigned char *)buffer, len, httpx->xlate_cp037->etoa);
-			if ((rc = http_send(session->httpc,
-					(const UCHAR *)buffer, len)) < 0) {
+			if ((rc = send_all(session, (const UCHAR *)buffer, (int)len)) < 0) {
 				break;
 			}
 		}
@@ -237,8 +243,7 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 		size_t n;
 		while ((n = fread(buffer, 1, lrecl, fp)) > 0) {
 			if (max_records >= 0 && count >= max_records) break;
-			if ((rc = http_send(session->httpc,
-					(const UCHAR *)buffer, n)) < 0) {
+			if ((rc = send_all(session, (const UCHAR *)buffer, (int)n)) < 0) {
 				break;
 			}
 			count++;
@@ -254,12 +259,10 @@ read_and_send_dataset(Session *session, FILE *fp, int data_type,
 			len_prefix[1] = (n >> 16) & 0xFF;
 			len_prefix[2] = (n >> 8) & 0xFF;
 			len_prefix[3] = n & 0xFF;
-			if ((rc = http_send(session->httpc,
-					(const UCHAR *)len_prefix, 4)) < 0) {
+			if ((rc = send_all(session, (const UCHAR *)len_prefix, 4)) < 0) {
 				break;
 			}
-			if ((rc = http_send(session->httpc,
-					(const UCHAR *)buffer, n)) < 0) {
+			if ((rc = send_all(session, (const UCHAR *)buffer, (int)n)) < 0) {
 				break;
 			}
 			count++;

--- a/src/sendall.c
+++ b/src/sendall.c
@@ -1,0 +1,67 @@
+/*
+ * sendall.c - the send loop and its no-progress policy (issue #298).
+ *
+ * See include/sendall.h for why this is its own TU and why the loop never
+ * advances by the return value without checking it first.
+ *
+ * Portable C on purpose: no httpd headers, no MVS services, no statics. The
+ * host test #includes it (test/host/tstsend.c) so the loop it drives is the
+ * one that runs on MVS, not a copy of it.
+ */
+
+#include "sendall.h"
+
+#ifdef __MVS__
+__asm__("\n&FUNC    SETC 'send_bytes'");
+#endif
+int
+send_bytes(void *ctx, const SEND_OPS *ops, const unsigned char *buf, int len)
+{
+	int pos = 0;
+	int stall = 0;
+
+	if (len <= 0) {
+		return 0;
+	}
+
+	/* Entry guard, not just a loop guard: once a send has failed, the
+	   handler's error path comes straight back here through
+	   sendErrorResponse(). Without this it would pay the full stall budget
+	   a second time for a client that is already gone (httpd#203). */
+	if (ops->aborted(ctx)) {
+		return -1;
+	}
+
+	while (pos < len) {
+		int rc = ops->send(ctx, &buf[pos], len - pos);
+
+		if (rc < 0) {
+			return -1;      /* dead socket */
+		}
+
+		if (rc > 0) {
+			/* Progress resets the budget: a slow but advancing client
+			   must not be cut off at attempt 101 just because it took
+			   that many turns to drain. */
+			pos += rc;
+			stall = 0;
+			continue;
+		}
+
+		/* rc == 0: the receive window is closed. Wait it out -- but only
+		   while waiting can still pay off, and only within the budget.
+		   Never advance pos here; that is the whole defect. */
+		if (ops->aborted(ctx)) {
+			return -1;
+		}
+
+		if (++stall > SEND_STALL_MAX) {
+			ops->giveup(ctx, stall);
+			return -1;
+		}
+
+		ops->pause(ctx);
+	}
+
+	return 0;
+}

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -740,7 +740,7 @@ int ussGetHandler(Session *session)
 		if (data_type == USS_DATA_TYPE_TEXT) {
 			http_xlate((unsigned char *)buf, n, httpx->xlate_1047->etoa);
 		}
-		rc = http_send(session->httpc, (const UCHAR *)buf, n);
+		rc = send_all(session, (const UCHAR *)buf, (int)n);
 		if (rc < 0) {
 			goto quit;
 		}

--- a/test/host/tstsend.c
+++ b/test/host/tstsend.c
@@ -1,0 +1,313 @@
+/*
+ * tstsend.c - #298 regression: the send loop must never advance by zero.
+ *
+ * mvsMF sent every response with
+ *
+ *     for (pos = 0; pos < len; pos += rc)
+ *         rc = http_send(session->httpc, &buf[pos], len - pos);
+ *
+ * checking only rc < 0. A zero return -- httpd's documented "socket send
+ * buffer full, no progress, retry later" -- leaves pos where it was, so the
+ * loop never terminates and the worker issues a send() SVC per turn at 100%
+ * CPU until the server is restarted. Until the Hercules X'75' fix
+ * (mvslovers/hyperion 1a599b0d) a full buffer froze the emulated CPU instead
+ * of returning EWOULDBLOCK, which is the only reason this never fired.
+ *
+ * Every JSON response goes through that loop -- sendJSONResponse() sets
+ * Content-Length, so the response is non-chunked, the one mode where
+ * http_send() can return 0.
+ *
+ * ====================================================================
+ * This test drives the REAL loop: src/sendall.c is #included below.
+ * common.c itself cannot compile on the host (it pulls in the httpd
+ * session headers), which is why the loop lives in its own TU with its
+ * four MVS/httpd services injected through SEND_OPS.
+ * ====================================================================
+ *
+ * Runs on host via `make test-host`.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include <mbtcheck.h>
+
+#include "../../src/sendall.c"
+
+static char msg[160];
+
+#define PAYLOAD 64
+#define ATTEMPT_CAP 10000   /* far above any legal attempt count */
+
+/*
+ * A scripted client. `script` gives the value the n-th send returns, except
+ * that a positive entry is capped at the bytes actually left, so a script can
+ * say "as much as you like" with a large number. The script's last entry
+ * repeats once it runs out, which is how "stalled forever" is expressed.
+ */
+struct client {
+	const int *script;
+	int        script_len;
+	int        attempts;      /* sends issued */
+	int        pauses;        /* pauses taken */
+	int        sent;          /* bytes accepted */
+	int        aborted;       /* what aborted() reports */
+	int        abort_after;   /* start reporting aborted at this attempt */
+	int        giveups;       /* giveup() calls */
+	int        giveup_stall;  /* stall count it was given */
+	unsigned char got[PAYLOAD];
+};
+
+static int
+op_send(void *ctx, const unsigned char *buf, int len)
+{
+	struct client *c = (struct client *)ctx;
+	int want;
+
+	/* A runaway loop must fail the test, not hang the suite. */
+	if (c->attempts >= ATTEMPT_CAP) {
+		return -1;
+	}
+
+	want = c->script[c->attempts < c->script_len
+		? c->attempts : c->script_len - 1];
+	c->attempts++;
+
+	if (c->attempts >= c->abort_after) {
+		c->aborted = 1;
+	}
+
+	if (want <= 0) {
+		return want;
+	}
+
+	if (want > len) {
+		want = len;
+	}
+	if (c->sent + want > (int)sizeof(c->got)) {
+		want = (int)sizeof(c->got) - c->sent;
+	}
+	memcpy(&c->got[c->sent], buf, want);
+	c->sent += want;
+
+	return want;
+}
+
+static void
+op_pause(void *ctx)
+{
+	((struct client *)ctx)->pauses++;
+}
+
+static int
+op_aborted(void *ctx)
+{
+	return ((struct client *)ctx)->aborted;
+}
+
+static void
+op_giveup(void *ctx, int stall)
+{
+	struct client *c = (struct client *)ctx;
+
+	c->giveups++;
+	c->giveup_stall = stall;
+}
+
+static const SEND_OPS ops = { op_send, op_pause, op_aborted, op_giveup };
+
+/* Run one scripted client over `len` bytes of a known payload. */
+static int
+run(struct client *c, const int *script, int script_len, int len)
+{
+	static unsigned char payload[PAYLOAD];
+	int i;
+
+	for (i = 0; i < PAYLOAD; i++) {
+		payload[i] = (unsigned char)i;
+	}
+
+	memset(c, 0, sizeof(*c));
+	c->script = script;
+	c->script_len = script_len;
+	c->abort_after = ATTEMPT_CAP;   /* never, unless the case says so */
+
+	return send_bytes(c, &ops, payload, len);
+}
+
+/* The payload the client accepted is the payload it should have accepted. */
+static void
+check_payload(struct client *c, int len)
+{
+	int i;
+
+	sprintf(msg, "%d of %d bytes accepted", c->sent, len);
+	CHECK_EQ(c->sent, len, msg);
+
+	for (i = 0; i < c->sent; i++) {
+		if (c->got[i] != (unsigned char)i) {
+			sprintf(msg, "byte %d is 0x%02X, expected 0x%02X",
+				i, c->got[i], (unsigned char)i);
+			CHECK(0, msg);
+			return;
+		}
+	}
+	CHECK(1, "the bytes arrived in order, none dropped or repeated");
+}
+
+int
+main(void)
+{
+	struct client c;
+	int rc;
+
+	printf("\n--- #298: a zero return must not advance, and must terminate ---\n");
+	{
+		/* The defect itself: a client that never accepts anything. The old
+		   loop spun here forever. */
+		const int stalled[] = { 0 };
+
+		rc = run(&c, stalled, 1, PAYLOAD);
+
+		CHECK_EQ(rc, -1, "a client that never drains fails the send");
+		CHECK(c.attempts <= SEND_STALL_MAX + 1,
+			"the loop gives up inside the budget instead of spinning");
+		CHECK_EQ(c.attempts, SEND_STALL_MAX + 1,
+			"it spends the whole budget before giving up");
+		CHECK_EQ(c.sent, 0, "nothing was sent");
+		CHECK_EQ(c.pauses, SEND_STALL_MAX,
+			"every no-progress turn paused -- no busy spin");
+	}
+
+	printf("\n--- #298: the give-up is reported once, with its count ---\n");
+	{
+		const int stalled[] = { 0 };
+
+		rc = run(&c, stalled, 1, PAYLOAD);
+
+		CHECK_EQ(rc, -1, "the send failed");
+		CHECK_EQ(c.giveups, 1, "MVSMF008W is written exactly once");
+		CHECK_EQ(c.giveup_stall, SEND_STALL_MAX + 1,
+			"the reported retry count is the one that broke the budget");
+	}
+
+	printf("\n--- #298: a short write is resumed, not dropped ---\n");
+	{
+		/* This is the secondary finding: dsapi.c and ussapi.c used to send
+		   a record with a single unchecked call, so a short write lost the
+		   remainder. Safe only because those routes happen to be chunked --
+		   one Content-Length away from silent truncation. */
+		const int dribble[] = { 1, 7, 20, 3, 64 };
+
+		rc = run(&c, dribble, 5, PAYLOAD);
+
+		CHECK_EQ(rc, 0, "a dribbling client still receives everything");
+		check_payload(&c, PAYLOAD);
+	}
+
+	printf("\n--- #298: progress resets the budget ---\n");
+	{
+		/* Slow but advancing: SEND_STALL_MAX stalls, one byte, and so on.
+		   A budget that did not reset would kill this client at attempt
+		   101 even though it is draining. */
+		static int slow[2 * SEND_STALL_MAX * 4];
+		int i, n = 0;
+
+		for (i = 0; i < 4; i++) {
+			int j;
+			for (j = 0; j < SEND_STALL_MAX; j++) {
+				slow[n++] = 0;
+			}
+			slow[n++] = 1;
+		}
+		slow[n - 1] = 1;
+
+		/* four bytes is all this script can deliver, so ask for four */
+		rc = run(&c, slow, n, 4);
+
+		CHECK_EQ(rc, 0, "a slow but advancing client is not cut off");
+		check_payload(&c, 4);
+		CHECK_EQ(c.pauses, 4 * SEND_STALL_MAX,
+			"it waited out four full stalls without ever giving up");
+	}
+
+	printf("\n--- #298: a dead socket fails at once ---\n");
+	{
+		const int dead[] = { -1 };
+
+		rc = run(&c, dead, 1, PAYLOAD);
+
+		CHECK_EQ(rc, -1, "a negative return fails the send");
+		CHECK_EQ(c.attempts, 1, "no retry -- a dead socket is not retryable");
+		CHECK_EQ(c.pauses, 0, "and nothing was waited out");
+		CHECK_EQ(c.giveups, 0, "a dead socket is not a stall timeout");
+	}
+
+	printf("\n--- #298: a partial send then a dead socket keeps the failure ---\n");
+	{
+		const int half_then_dead[] = { 32, -1 };
+
+		rc = run(&c, half_then_dead, 2, PAYLOAD);
+
+		CHECK_EQ(rc, -1, "a failure after partial progress still fails");
+		CHECK_EQ(c.sent, 32, "the accepted half is not re-sent or rolled back");
+	}
+
+	printf("\n--- #298: an already-finished client is not waited for ---\n");
+	{
+		/* The entry guard. After one send fails the handler's error path
+		   comes straight back here through sendErrorResponse(); without
+		   this it would pay the whole budget a second time for a peer that
+		   is already gone (httpd#203). The same guard covers a quiescing
+		   server: P HTTPD waits for its workers, so no worker may sit out
+		   10 seconds per response in flight. */
+		const int stalled[] = { 0 };
+
+		rc = run(&c, stalled, 1, PAYLOAD);   /* seed the struct */
+		CHECK_EQ(rc, -1, "the first send failed as set up");
+
+		memset(&c, 0, sizeof(c));
+		c.script = stalled;
+		c.script_len = 1;
+		c.abort_after = ATTEMPT_CAP;
+		c.aborted = 1;
+
+		rc = send_bytes(&c, &ops, (const unsigned char *)"HELLO", 5);
+
+		CHECK_EQ(rc, -1, "a client already at CSTATE_DONE fails the send");
+		CHECK_EQ(c.attempts, 0, "and is not even written to");
+		CHECK_EQ(c.pauses, 0, "no budget is spent on it");
+		CHECK_EQ(c.giveups, 0, "and it is not reported as a stall timeout");
+	}
+
+	printf("\n--- #298: a client that goes away mid-stall stops the wait ---\n");
+	{
+		/* Quiesce arriving while a response is stalled: the loop must
+		   notice on the next turn, not finish the 10 seconds first. */
+		const int stalled[] = { 0 };
+
+		memset(&c, 0, sizeof(c));
+		c.script = stalled;
+		c.script_len = 1;
+		c.abort_after = 3;     /* aborted() turns true after 3 sends */
+
+		rc = send_bytes(&c, &ops, (const unsigned char *)"HELLO", 5);
+
+		CHECK_EQ(rc, -1, "the send fails");
+		CHECK_EQ(c.attempts, 3, "it stops on the turn the client went away");
+		CHECK(c.pauses < SEND_STALL_MAX,
+			"without sitting out the rest of the budget");
+		CHECK_EQ(c.giveups, 0, "an expected shutdown is not reported as a timeout");
+	}
+
+	printf("\n--- #298: nothing to send is not a failure ---\n");
+	{
+		const int any[] = { 64 };
+
+		rc = run(&c, any, 1, 0);
+
+		CHECK_EQ(rc, 0, "a zero-length send succeeds");
+		CHECK_EQ(c.attempts, 0, "without touching the socket");
+	}
+
+	return mbt_test_summary("TSTSEND");
+}


### PR DESCRIPTION
Fixes #298

## The defect

`send_data()` advanced its loop by the return value of `http_send()` and treated
only a negative return as failure. Zero is not a failure: on a non-chunked
response httpd's `send_raw()` reports the bytes it managed *this call*, and a
full socket send buffer (`EWOULDBLOCK`) means none. `pos += 0` never reaches
`len`, so the loop issues a `send()` SVC per turn at 100% CPU and the worker is
never returned to the pool. This is httpd#199 one level up, on the **normal
path** — `sendJSONResponse()` sets `Content-Length`, so every JSON response
mvsMF produces is non-chunked, which is precisely the mode where zero comes
back.

Until the Hercules X'75' fix (`mvslovers/hyperion` `1a599b0d`) a full send
buffer froze the emulated CPU instead of returning `EWOULDBLOCK`, which is the
only reason this never fired.

## The fix

The loop moves to `src/sendall.c` and follows the policy agreed for the whole
ecosystem in the coordination comment on #298: on a non-blocking socket **the
application waits — 100 attempts of 100 ms = 10 s without progress, then
abandon**. Independent of libc370#120, which covers the blocking-socket half.

- never advances by zero, and resumes short writes
- fails at once when the client is already gone or the server is quiescing —
  `P HTTPD` waits for its workers, so no worker may sit out 10 s per response
  in flight
- reports only the timeout, as `MVSMF008W`; an expected shutdown stays silent
- on failure marks the client `CSTATE_DONE` **and** clears `keepalive`

That last pair matters more than it looks. `CSTATE_DONE` alone is not "drop
this client" — it is normal completion, and httpd walks `DONE → REPORT → RESET`
where `httprese()` reuses the socket if `keepalive` is still set. An abandoned
response is short of the `Content-Length` it announced, so reuse would append
the next response to a truncated one: a hang traded for a corrupt stream.
`CSTATE_DONE` is still needed on its own account — it is what stops the
handler's error path from coming straight back through `sendErrorResponse()`
and paying the whole budget a second time (httpd#203).

`send_all()` is now the only way out. `include/common.h` and `CLAUDE.md` say so:
**do not call `http_send()` directly.**

## Secondary finding: the streaming sites

`dsapi.c` (4 sites) and `ussapi.c` (1) sent a record with a single unchecked
call, so a short write silently dropped the remainder. They were safe only
because those routes stream without `Content-Length`, so httpd frames them
chunked and its chunked path is all-or-error (httpd#201/#202) — a dependency
invisible at the call site and one `Content-Length` away from silently
truncating every download. They go through `send_all()` too; at runtime that
costs nothing today.

## Testing

New host test `TSTSEND` (`test/host/tstsend.c`, 32 assertions). It `#include`s
`src/sendall.c` and drives the **real** loop, not a copy — the four MVS/httpd
services are injected through `SEND_OPS`, which is the only reason the TU is
split out at all.

Red/green is real. Restoring the pre-fix loop in `send_bytes()`:

```
TSTSEND    FAIL rc=1    24 pass / 8 fail
  FAIL: the loop gives up inside the budget instead of spinning
  FAIL: it spends the whole budget before giving up (got 10000, want 101)
  FAIL: every no-progress turn paused -- no busy spin (got 0, want 100)
  ...
```

10000 is the test's own attempt cap; without it the old loop does not
terminate. With the fix: `TSTSEND ok rc=0 32 pass / 0 fail`, and the full host
suite is 202/202.

Covered: a zero return never advances and always terminates; the give-up is
reported once with its count; a dribbling client still receives every byte in
order; progress resets the budget so a slow-but-advancing client is not cut off
at attempt 101; a dead socket fails without a retry; partial progress before a
failure is not rolled back; an already-finished client is not even written to;
a client that goes away mid-stall stops the wait immediately; a zero-length
send is not a failure.

Also verified: clean `cc370 -Wall -Werror` build, no clangd diagnostics, and
the generated assembler puts the `static const SEND_OPS` in the code CSECT as
`DC A(@@F9…F12)` — the same construct as the per-function page tables every
prologue already loads, so it is RENT-safe and never written.

## Not verified on MVS

**This is host-verified only.** The runtime behaviour — a stalled client
abandoned at ~10 s with `MVSMF008W` instead of pinning a worker — has not been
measured on a live system. To check it: `make deploy` lands in the deploy
LINKLIB and changes nothing until `tests/jcl/mvsmfact.jcl` copies the member
into the httpd STEPLIB; then `GET /zosmf/test?fn=version` must equal the HEAD
built here before any conclusion is drawn.

One caution if anyone probes it live: a slow-reading HTTP client is the natural
way to provoke this, and a slow reader used to segfault Hercules on `mvsdev`
within 30–45 s — killing the whole emulator, 4 times out of 4. That is the very
X'75' stall `hyperion 1a599b0d` fixes, so confirm the stand runs the patched
hyperion first, and prefer one that can be restarted.