### PR TITLE
Delete the unused cleanup_resources() and allocate_buffer()

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -54,31 +54,6 @@ static int dataset_etag(Session *session, const char *dataset,
 static int check_if_match(Session *session, const char *dataset,
                           long max_records);
 
-// Helper functions for memory management
-static void cleanup_resources(char* buffer, FILE* fp) {
-    if (buffer) {
-        free(buffer);
-        buffer = NULL;
-    }
-    if (fp) {
-        fclose(fp);
-        fp = NULL;
-    }
-}
-
-static char* allocate_buffer(FILE* fp, int* rc) {
-    if (!fp || fp->lrecl <= 0) {
-        *rc = ERR_INVALID_PARAM;
-        return NULL;
-    }
-
-    char* buffer = calloc(1, fp->lrecl + 2);
-    if (!buffer) {
-        *rc = ERR_MEMORY;
-    }
-    return buffer;
-}
-
 // Helper function for HTTP headers
 //
 // etag is NULL unless the client asked for one with X-IBM-Return-Etag. The

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -605,8 +605,6 @@ quit:
 	if (dd) {
 		ufs_dirclose(&dd);
 	}
-	if (ufs) {
-	}
 
 	return rc;
 }
@@ -751,8 +749,6 @@ int ussGetHandler(Session *session)
 quit:
 	if (fp) {
 		ufs_fclose(&fp);
-	}
-	if (ufs) {
 	}
 
 	return rc;
@@ -1022,8 +1018,6 @@ quit:
 		ufs_fclose(&fp);
 	}
 	free(body);
-	if (ufs) {
-	}
 
 	return rc;
 }
@@ -1258,9 +1252,6 @@ int ussCreateHandler(Session *session)
 	rc = sendDefaultHeaders(session, 201, HTTP_CONTENT_TYPE_NONE, 0);
 
 quit:
-	if (ufs) {
-	}
-
 	return rc;
 }
 


### PR DESCRIPTION
Fixes #301

Neither helper has a caller anywhere in the tree, and `cleanup_resources()` encodes the one thing the session tracker exists to prevent:

```c
static void cleanup_resources(char* buffer, FILE* fp) {   /* dsapi.c:58 */
    if (buffer) { free(buffer); buffer = NULL; }
    if (fp)     { fclose(fp);   fp = NULL;     }
}
```

A raw `fclose()` on a handle that every live open in `dsapi.c` registers with `session_register_file()`. Used as written it would leave a dangling pointer in `session->open_files[]`, and `session_cleanup()` would close it a second time — under ESTAE, on the recovery path, where a second abend is unrecoverable. The trailing `fp = NULL` assigns to the local parameter and does nothing for the caller either.

Not a live defect; a helper that looks correct and reusable, sitting at the top of the file where the next open-and-cleanup would find it. That is the `dsapi.c:64` listed in #293.

Also drops the empty `if (ufs) { }` blocks in `ussapi.c` — leftovers from the switch to the HTTPD-managed UFS session lifecycle, where `http_get_ufs()` owns the handle and a handler has nothing to release.

No behaviour change; nothing calls any of it. `make` clean (`-Wall -Werror`).

Found in the #293 audit.

https://claude.ai/code/session_019TT2zwWGXK6rL6zMmV22j4