### PR TITLE
Stop reporting a broken test run as green

### DIFF
--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -22,6 +22,22 @@
 #   ./tests/curl-datasets.sh
 # =========================================================================
 
+# When a skip is right, and when it is a failure wearing a disguise
+# ---------------------------------------------------------------------------
+# A skip is right when the precondition is something this suite did not create
+# and cannot: other jobs on the system, a data set that only exists on one
+# stand, an ACTIVE started task, a client capability (python3, a Zowe CLI flag),
+# or a defect with a ticket behind it.
+#
+# A skip is wrong -- and reports a broken run as green -- when the precondition
+# is something this suite created through the very API under test, or was
+# explicitly asked to create with --setup. Its absence then means that API
+# misbehaved, and that has to be red. This is #304: the dataset-submit path went
+# unexercised for months behind exactly such a skip.
+#
+# Downstream skips ("no submitted job") are fine as they are: they only fire
+# after an assertion has already failed, so the run is red regardless.
+
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -420,8 +436,13 @@ ALL=$(curl -s -u "$AUTH" \
 COUNT=$(echo "$ALL" | grep -c .)
 
 if [ "$COUNT" -lt 2 ]; then
-	skip "start= returns the tail of the list (need two datasets under ${MVSMF_USER}.CURL)"
-	skip "start= beyond the last dataset (need two datasets under ${MVSMF_USER}.CURL)"
+	# This suite creates its own data sets under <user>.CURL earlier in the run,
+	# so fewer than two here means the listing under test lost them, not that
+	# the system is bare. Reporting that as a skip hides it (#304).
+	fail "start= returns the tail of the list" \
+		"the listing reported ${COUNT} data set(s) under ${MVSMF_USER}.CURL; this suite created more"
+	fail "start= beyond the last dataset" \
+		"the listing reported ${COUNT} data set(s) under ${MVSMF_USER}.CURL; this suite created more"
 else
 	SECOND=$(echo "$ALL" | sed -n 2p)
 
@@ -541,7 +562,7 @@ if [ -n "$VOLUME" ] && [ "$VOLUME" != "null" ]; then
 	HTTP_CODE=$(echo "$BODY" | tail -1)
 	assert_http_status "200" "$HTTP_CODE" "read dataset with volume prefix -(${VOLUME})"
 else
-	skip "read dataset with volume prefix (could not determine volume)"
+	fail "read dataset with volume prefix" "the listing reported no volume for ${TEST_SEQ} -- the value comes from the API under test"
 fi
 
 # --- Delete sequential dataset ---
@@ -580,7 +601,7 @@ if [ "$HTTP_CODE" = "201" ] && [ -n "$VOLUME" ] && [ "$VOLUME" != "null" ]; then
 		"${BASE_URL}/zosmf/restfiles/ds/-(${VOLUME})/${TEST_SEQ}")
 	assert_http_status "204" "$HTTP_CODE" "delete dataset with volume prefix -(${VOLUME})"
 else
-	skip "delete dataset with volume prefix (could not create or no volume)"
+	fail "delete dataset with volume prefix" "could not create the fixture, or the listing reported no volume for it"
 fi
 
 # --- Write PDS member ---
@@ -765,20 +786,23 @@ fi
 # count equals the limit would report moreRows true (#274). The limit is read
 # off an unlimited listing rather than hardcoded, so adding members above does
 # not quietly turn this into the truncated case again.
-TOTAL=$(curl -s -u "$AUTH" \
+# MEMBER_COUNT, not TOTAL: TOTAL is the suite's own test counter, and assigning
+# to it here reset the run tally mid-suite -- which is why the summary line read
+# "188 passed, 0 failed, 2 skipped (141 total)".
+MEMBER_COUNT=$(curl -s -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member" |
 	jq -r '.returnedRows' 2>/dev/null)
-BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" -H "X-IBM-Max-Items: ${TOTAL}" \
+BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" -H "X-IBM-Max-Items: ${MEMBER_COUNT}" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
 
 if [ "$HTTP_CODE" = "200" ] &&
-   [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "$TOTAL" ]; then
+   [ "$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null)" = "$MEMBER_COUNT" ]; then
 	pass "max-items equal to the member count returns every member"
 else
 	fail "max-items equal to the member count returns every member" \
-		"got HTTP $HTTP_CODE rows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) of $TOTAL"
+		"got HTTP $HTTP_CODE rows=$(echo "$CONTENT" | jq -r '.returnedRows' 2>/dev/null) of $MEMBER_COUNT"
 fi
 assert_json_field_absent "$CONTENT" 'has("moreRows")' \
 	"max-items equal to the member count: no moreRows"
@@ -970,7 +994,7 @@ if [ "$HTTP_CODE" = "201" ]; then
 	fi
 	curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIST_SEQ}" >/dev/null 2>&1 || true
 else
-	skip "list members of a sequential dataset (could not create ${LIST_SEQ})"
+	fail "list members of a sequential dataset" "could not create ${LIST_SEQ} (HTTP ${HTTP_CODE})"
 fi
 
 BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
@@ -996,7 +1020,7 @@ if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
 	HTTP_CODE=$(echo "$BODY" | tail -1)
 	assert_http_status "200" "$HTTP_CODE" "list members with volume prefix -(${PDS_VOLUME})"
 else
-	skip "list members with volume prefix (could not determine volume)"
+	fail "list members with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
 fi
 
 # --- Read PDS member ---
@@ -1025,7 +1049,7 @@ if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
 	HTTP_CODE=$(echo "$BODY" | tail -1)
 	assert_http_status "200" "$HTTP_CODE" "read member with volume prefix -(${PDS_VOLUME})"
 else
-	skip "read member with volume prefix (could not determine volume)"
+	fail "read member with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
 fi
 
 # --- Write PDS member with volume prefix ---
@@ -1040,7 +1064,7 @@ if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
 		"${BASE_URL}/zosmf/restfiles/ds/-(${PDS_VOLUME})/${TEST_PDS}(VOLMBR)")
 	assert_http_status "204" "$HTTP_CODE" "write member with volume prefix -(${PDS_VOLUME})"
 else
-	skip "write member with volume prefix (could not determine volume)"
+	fail "write member with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
 fi
 
 # --- Rename PDS member ---
@@ -1107,7 +1131,7 @@ if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
 		"${BASE_URL}/zosmf/restfiles/ds/-(${PDS_VOLUME})/${TEST_PDS}(VOLMBR)")
 	assert_http_status "204" "$HTTP_CODE" "delete member with volume prefix -(${PDS_VOLUME})"
 else
-	skip "delete member with volume prefix (could not determine volume)"
+	fail "delete member with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
 fi
 
 # --- Delete PDS member: not found ---
@@ -1175,7 +1199,7 @@ if [ "$HTTP_CODE" = "201" ]; then
 	fi
 	curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${PROBE_SEQ}" >/dev/null 2>&1 || true
 else
-	skip "member of a sequential dataset (could not create ${PROBE_SEQ})"
+	fail "member of a sequential dataset" "could not create ${PROBE_SEQ} (HTTP ${HTTP_CODE})"
 fi
 
 # writing into a dataset that does not exist. fopen("w") auto-allocates an
@@ -1296,7 +1320,7 @@ if [ "$HTTP_CODE" = "201" ]; then
 		"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}.NOPE2")
 	assert_http_status "404" "$HTTP_CODE" "rename non-existent dataset returns 404"
 else
-	skip "rename sequential dataset (could not create source)"
+	fail "rename sequential dataset" "could not create the rename source"
 fi
 
 # =========================================================================
@@ -2114,7 +2138,7 @@ if [ "$HTTP_CODE" = "201" ] && [ "$HTTP_CODE2" = "201" ]; then
 			"expected 0 bytes, got $CONTENT"
 	fi
 else
-	skip "failed-PUT atomicity (could not create ${ATOM_SEQ}/${ATOM_PDS})"
+	fail "failed-PUT atomicity" "could not create ${ATOM_SEQ}/${ATOM_PDS}"
 fi
 
 curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${ATOM_SEQ}" >/dev/null 2>&1 || true

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -59,6 +59,21 @@ for arg in "$@"; do
 	esac
 done
 
+# When a skip is right, and when it is a failure wearing a disguise
+# ---------------------------------------------------------------------------
+# A skip is right when the precondition is something this suite did not create
+# and cannot: other jobs on the system, a data set that only exists on one
+# stand, an ACTIVE started task, a client capability (python3, a Zowe CLI flag),
+# or a defect with a ticket behind it.
+#
+# A skip is wrong -- and reports a broken run as green -- when the precondition
+# is something this suite created through the very API under test, or was
+# explicitly asked to create with --setup. Its absence then means that API
+# misbehaved, and that has to be red. This is #304: the dataset-submit path went
+# unexercised for months behind exactly such a skip.
+#
+# Downstream skips ("no submitted job") are fine as they are: they only fire
+# after an assertion has already failed, so the run is red regardless.
 # =========================================================================
 # Helpers
 # =========================================================================
@@ -82,6 +97,18 @@ skip() {
 	SKIPPED=$((SKIPPED + 1))
 	TOTAL=$((TOTAL + 1))
 	echo "  SKIP: $1"
+}
+
+# A precondition that --setup was supposed to establish is a failure when
+# --setup was requested, and only a skip when it was not. Reporting it as a skip
+# either way is what let a broken setup look green (#304).
+missing_precondition() {
+	local label="$1" reason="$2"
+	if [ "$DO_SETUP" -eq 1 ]; then
+		fail "$label" "$reason (--setup was requested)"
+	else
+		skip "$label ($reason)"
+	fi
 }
 
 assert_http_status() {
@@ -584,7 +611,7 @@ test_submit_from_dataset() {
 	echo "--- Submit Job: from dataset ---"
 
 	if ! have_test_pds; then
-		skip "submit from dataset (no ${TEST_PDS} - run with --setup)"
+		missing_precondition "submit from dataset" "no ${TEST_PDS}"
 		return
 	fi
 
@@ -644,7 +671,7 @@ test_submit_from_dataset_without_notify() {
 	# submit_file() is a separate caller of process_jobcard() from the inline
 	# path, so the injection has to be shown on this one too.
 	if ! have_test_pds; then
-		skip "dataset submit without NOTIFY (no ${TEST_PDS} - run with --setup)"
+		missing_precondition "dataset submit without NOTIFY" "no ${TEST_PDS}"
 		return
 	fi
 
@@ -1394,7 +1421,13 @@ echo "========================================"
 
 # Optional setup
 if [ "$DO_SETUP" -eq 1 ]; then
-	setup_test_pds || true
+	# A setup that was explicitly asked for and then failed is a failure. It used
+	# to be swallowed here, after which every test depending on it took its skip
+	# branch and the run still reported green -- which is how the dataset-submit
+	# path went unexercised for months (#304).
+	if ! setup_test_pds; then
+		fail "setup: create the test PDS" "--setup was requested and setup failed"
+	fi
 fi
 
 # Submit tests

--- a/tests/curl-uss.sh
+++ b/tests/curl-uss.sh
@@ -247,7 +247,10 @@ if [ "$FIRST_ITEM" != "null" ] && [ -n "$FIRST_ITEM" ]; then
 	assert_json_field_exists "$BODY" '.items[0].inode' "list: item has inode"
 	assert_json_field_exists "$BODY" '.items[0].links' "list: item has links"
 else
-	skip "list: no items returned, skipping field checks"
+	# ${TEST_DIR} is created by this suite and a directory always carries at
+	# least . and .. -- an empty items array means the list under test lost
+	# them, which a skip would hide (#304).
+	fail "list: item field checks" "the listing of ${TEST_DIR} returned no items"
 fi
 
 echo ""

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -359,7 +359,10 @@ if [ "$RC" -eq 0 ]; then
 	pass "write PDS member (rc=$RC)"
 	MEMBER_WRITE_OK=1
 else
-	skip "write PDS member (known issue: member URI routing)"
+	# This was labelled a known issue with no ticket behind it, and the upload
+	# has since started working -- so the branch was dead while still able to
+	# swallow a regression silently. It is a failure now (#304).
+	fail "write PDS member" "upload to ${TEST_PDS}(TESTMBR) failed (rc=$RC)"
 	MEMBER_WRITE_OK=0
 fi
 

--- a/tests/zowe-jobs.sh
+++ b/tests/zowe-jobs.sh
@@ -22,6 +22,22 @@
 #     --cleanup  Delete test PDS after tests
 # =========================================================================
 
+# When a skip is right, and when it is a failure wearing a disguise
+# ---------------------------------------------------------------------------
+# A skip is right when the precondition is something this suite did not create
+# and cannot: other jobs on the system, a data set that only exists on one
+# stand, an ACTIVE started task, a client capability (python3, a Zowe CLI flag),
+# or a defect with a ticket behind it.
+#
+# A skip is wrong -- and reports a broken run as green -- when the precondition
+# is something this suite created through the very API under test, or was
+# explicitly asked to create with --setup. Its absence then means that API
+# misbehaved, and that has to be red. This is #304: the dataset-submit path went
+# unexercised for months behind exactly such a skip.
+#
+# Downstream skips ("no submitted job") are fine as they are: they only fire
+# after an assertion has already failed, so the run is red regardless.
+
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -137,6 +153,18 @@ run_zowe_json() {
 	output=$(zowe "$@" --rfj "${ZOWE_CONN[@]}" 2>&1 </dev/null) || rc=$?
 	echo "$output"
 	return $rc
+}
+
+# A precondition that --setup was supposed to establish is a failure when
+# --setup was requested, and only a skip when it was not. Reporting it as a skip
+# either way is what let a broken setup look green (#304).
+missing_precondition() {
+	local label="$1" reason="$2"
+	if [ "$DO_SETUP" -eq 1 ]; then
+		fail "$label" "$reason (--setup was requested)"
+	else
+		skip "$label ($reason)"
+	fi
 }
 
 assert_rc() {
@@ -397,7 +425,7 @@ test_submit_from_dataset() {
 	echo "--- Submit Job: from dataset ---"
 
 	if ! have_test_pds; then
-		skip "submit from dataset (no ${TEST_PDS} - run with --setup)"
+		missing_precondition "submit from dataset" "no ${TEST_PDS}"
 		return
 	fi
 
@@ -424,7 +452,7 @@ test_submit_from_dataset_without_notify() {
 	# submit_file() is a separate caller of process_jobcard() from the inline
 	# path, so the NOTIFY injection has to be shown on this one too.
 	if ! have_test_pds; then
-		skip "dataset submit without NOTIFY (no ${TEST_PDS} - run with --setup)"
+		missing_precondition "dataset submit without NOTIFY" "no ${TEST_PDS}"
 		return
 	fi
 
@@ -648,7 +676,13 @@ echo "========================================"
 
 # Optional setup
 if [ "$DO_SETUP" -eq 1 ]; then
-	setup_test_pds || true
+	# A setup that was explicitly asked for and then failed is a failure. It used
+	# to be swallowed here, after which every test depending on it took its skip
+	# branch and the run still reported green -- which is how the dataset-submit
+	# path went unexercised for months (#304).
+	if ! setup_test_pds; then
+		fail "setup: create the test PDS" "--setup was requested and setup failed"
+	fi
 fi
 
 # Submit tests


### PR DESCRIPTION
Fixes #304.

#308 fixed the two faults that kept the dataset-submit branch unexercised. This is the third item on #304's list — the *shape* that let them hide — plus the audit the issue asks for.

## A requested setup that fails is a failure

`setup_test_pds || true` swallowed it. Every test depending on the PDS then took its skip branch and the run still reported `0 failed`. Both jobs suites now register a failure, and the dependent tests distinguish the two cases through `missing_precondition()`: missing is a **failure** when `--setup` asked for it, a **skip** when it did not.

Measured, with setup forced to `return 1` and no PDS on the system:

```
curl-jobs --setup   ->  111 passed, 3 failed, 0 skipped
curl-jobs           ->  111 passed, 0 failed, 2 skipped
zowe-jobs --setup   ->   39 passed, 3 failed, 0 skipped
```

## The audit: thirteen more of the same shape

None of these fire on the reference stand, which is why they had never been noticed.

| where | was | why it is a failure |
|---|---|---|
| `curl-datasets.sh` ×5 | `could not create <fixture>` | the fixture is created through the very API under test |
| `curl-datasets.sh` ×5 | `could not determine volume` | the volume is read back out of the listing under test |
| `curl-datasets.sh` ×2 | `need two datasets under <user>.CURL` | this suite created them earlier in the same run |
| `curl-uss.sh` ×1 | `no items returned, skipping field checks` | the directory is created by this suite and always holds at least `.` and `..` |

And one that was already dead: `zowe-datasets.sh` reported a failed member upload as `known issue: member URI routing`, with **no ticket behind it**. The upload passes today, so the branch was unreachable while still able to swallow a regression silently.

## What stays a skip

The rule is now written into the suites so it does not erode again:

- preconditions the suite did not create and cannot — other jobs on the system, a data set that only exists on one stand, an ACTIVE started task
- client capabilities — `python3`, a Zowe CLI flag that does not exist
- defects with a ticket behind them — #243
- downstream skips (`no submitted job`): they only fire after an assertion has already failed, so the run is red regardless

## Also: a counter collision

`curl-datasets.sh` assigned a member count to `TOTAL`, which is the suite's own test counter, resetting the tally mid-suite — the summary read `188 passed, 0 failed, 2 skipped (141 total)`. Renamed to `MEMBER_COUNT`; it adds up again (190).

## Full regression, before and after — unchanged

On mvsdev against build `efc6ea7`:

| suite | result |
|---|---|
| curl: info / auth / console / binary | 40, 14, 64, 10 — all green |
| curl-datasets | 188 passed, 0 failed, 2 skipped |
| curl-jobs | 115 passed, 0 failed, 0 skipped |
| curl-uss | 128 passed, 0 failed, 0 skipped |
| zowe: datasets / jobs / uss / console / binary | 50/0/2, 42/0/0, 25/0/2, 9, 10 |

The two remaining `curl-datasets` skips are the #243 known-defect pair; the zowe ones are Zowe CLI capability limits. `zowe-auth` stays 1 passed / 3 failed — that is #206 and is untouched here.

Refs #308.
