### PR TITLE
Drive the auth suite through the Zowe SDK, not a command that does not exist

### DIFF
--- a/tests/zowe-auth-flow.js
+++ b/tests/zowe-auth-flow.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/*
+ * Drives mvsMF's authentication service through the Zowe SDK and prints one
+ * key=value line per step for tests/zowe-auth.sh to assert on.
+ *
+ * Why the SDK and not the CLI: Zowe CLI v8 has no `auth login zosmf` command
+ * at all -- `zowe auth login` offers only `apiml`, and the SDK exposes only
+ * apimlLogin/apimlLogout. So every flag the old suite passed came back
+ * "Unknown argument", including the `zosmf` subcommand itself, and the suite
+ * failed three of six assertions with nothing wrong on the server (#206).
+ * ZosmfRestClient + Session are what the CLI itself runs on, so this still
+ * exercises a real Zowe client stack against /zosmf/services/authenticate.
+ *
+ * Sessions are built explicitly rather than mutated after construction:
+ * Session computes base64EncodedAuth in its constructor, so deleting
+ * user/password from an existing session leaves Basic auth in place and every
+ * request keeps authenticating with credentials. A probe written that way
+ * reports login-with-a-wrong-password as 200 and a logged-out token as still
+ * valid -- it is measuring Basic auth in every case and asserting nothing.
+ *
+ * Connection details come from the environment (the caller exports them from
+ * .env), not from a Zowe profile, to match the explicit-connection model the
+ * other suites use since #204.
+ */
+
+"use strict";
+
+const { execSync } = require("child_process");
+const path = require("path");
+
+const RESOURCE = "/zosmf/services/authenticate";
+
+function cliDir() {
+	if (process.env.ZOWE_CLI_DIR) {
+		return process.env.ZOWE_CLI_DIR;
+	}
+	const root = execSync("npm root -g", { encoding: "utf8" }).trim();
+	return path.join(root, "@zowe", "cli");
+}
+
+function main() {
+	const dir = cliDir();
+	const load = (m) => require(require.resolve(m, { paths: [dir] }));
+	const { Session } = load("@zowe/imperative");
+	const { ZosmfRestClient } = load("@zowe/core-for-zowe-sdk");
+
+	const base = {
+		hostname: process.env.MVSMF_HOST,
+		port: Number(process.env.MVSMF_PORT),
+		protocol: process.env.MVSMF_PROTOCOL || "http",
+		rejectUnauthorized: false,
+	};
+
+	const basic = (user, password) =>
+		new Session({ ...base, type: "basic", user, password });
+	const token = (tokenValue) =>
+		new Session({ ...base, type: "token", tokenType: "LtpaToken2", tokenValue });
+
+	/* The client throws on a 4xx, and the status is then only on the error --
+	   client.response is not populated for a rejected request. */
+	const statusOf = (client, err) =>
+		(client.response && client.response.statusCode) ||
+		(err && err.mDetails && err.mDetails.errorCode) ||
+		0;
+
+	const call = async (session, resource, request) => {
+		const client = new ZosmfRestClient(session);
+		try {
+			await client.request({ resource, request });
+			return { status: statusOf(client), headers: client.response.headers };
+		} catch (err) {
+			/* A 4xx is a result and carries a status. Anything with no status at
+			   all -- refused connection, DNS, TLS -- is the driver failing to
+			   reach the server, which the caller reports once instead of as one
+			   confusing assertion failure per step. */
+			const status = statusOf(client, err);
+			if (!status) {
+				throw new Error("cannot reach " + base.hostname + ":" + base.port +
+					" -- " + (err && err.message ? err.message.split("\n")[0] : String(err)));
+			}
+			return { status, headers: {} };
+		}
+	};
+
+	const listing =
+		"/zosmf/restfiles/ds?dslevel=" + encodeURIComponent(process.env.MVSMF_USER) + ".*";
+
+	return (async () => {
+		const out = [];
+
+		const login = await call(basic(process.env.MVSMF_USER, process.env.MVSMF_PASS),
+			RESOURCE, "POST");
+		out.push(["login_status", login.status]);
+
+		const cookies = login.headers["set-cookie"] || [];
+		const ltpa = cookies
+			.map((c) => c.split(";")[0])
+			.find((c) => c.startsWith("LtpaToken2="));
+		const value = ltpa ? ltpa.slice("LtpaToken2=".length) : "";
+		out.push(["login_token_type", ltpa ? "LtpaToken2" : ""]);
+		out.push(["login_token_len", value.length]);
+		out.push(["login_cookie_path", /Path=\//.test(cookies[0] || "") ? "/" : ""]);
+
+		const bad = await call(basic(process.env.MVSMF_USER, "WRONGPW"), RESOURCE, "POST");
+		out.push(["bad_login_status", bad.status]);
+
+		const replay = await call(token(value), listing, "GET");
+		out.push(["replay_status", replay.status]);
+
+		const logout = await call(token(value), RESOURCE, "DELETE");
+		out.push(["logout_status", logout.status]);
+
+		const after = await call(token(value), listing, "GET");
+		out.push(["replay_after_logout_status", after.status]);
+
+		const bogus = await call(token("not-a-real-token"), RESOURCE, "DELETE");
+		out.push(["logout_bogus_status", bogus.status]);
+
+		out.forEach(([k, v]) => console.log(k + "=" + v));
+	})();
+}
+
+Promise.resolve()
+	.then(main)
+	.catch((err) => {
+		console.log("error=" + (err && err.message ? err.message : String(err)));
+		process.exit(1);
+	});

--- a/tests/zowe-auth.sh
+++ b/tests/zowe-auth.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 # =========================================================================
-# mvsMF Authentication service REST API - Zowe CLI test suite
+# mvsMF Authentication service REST API - Zowe SDK test suite
 #
-# Tests the z/OSMF Authentication service through Zowe CLI:
-#   zowe auth login  zosmf --show-token   (POST   /zosmf/services/authenticate)
-#   zowe auth logout zosmf                (DELETE /zosmf/services/authenticate)
+# Mirrors tests/curl-auth.sh case for case, but through a real Zowe client
+# stack: POST /zosmf/services/authenticate to obtain an LtpaToken2, replay it
+# on a files request, log out, and confirm the token dies with the session.
 #
-# Covers: login (obtain an LtpaToken2), token replay on a files command,
-# invalid credentials, and logout.
-#
-# `--show-token` prints the token WITHOUT storing it in the Zowe config, so
-# this suite does not disturb the user's profiles.
+# It does NOT use `zowe auth login zosmf`, because that command does not exist.
+# Zowe CLI v8 offers only `auth login apiml`, and the SDK only apimlLogin /
+# apimlLogout -- so every argument the old suite passed came back "Unknown
+# argument", the `zosmf` subcommand included, and three of six assertions
+# failed with nothing wrong on the server (#206). The driver in
+# tests/zowe-auth-flow.js uses ZosmfRestClient and Session directly, which is
+# what the CLI itself runs on.
 #
 # Prerequisites:
-#   - Zowe CLI installed (npm i -g @zowe/cli) and jq.
+#   - Zowe CLI installed (npm i -g @zowe/cli) for its SDK packages, node, jq.
 #   - Copy .env.example to .env at the repo root and fill in (host/port/user/pass).
 #
 # Usage:
@@ -25,11 +27,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENV_FILE="${ROOT_DIR}/.env"
-
-if ! command -v zowe >/dev/null 2>&1; then
-	echo "ERROR: zowe CLI not found (npm i -g @zowe/cli)"
-	exit 1
-fi
+FLOW="${SCRIPT_DIR}/zowe-auth-flow.js"
 
 if [ ! -f "$ENV_FILE" ]; then
 	echo "ERROR: ${ENV_FILE} not found."
@@ -39,8 +37,6 @@ fi
 
 # shellcheck source=../.env
 . "$ENV_FILE"
-
-COMMON=(--host "$MVSMF_HOST" --port "$MVSMF_PORT" --reject-unauthorized false)
 
 # --- state ---
 PASSED=0
@@ -53,91 +49,105 @@ fail() {
 	FAILED=$((FAILED + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"
 	[ -n "${2:-}" ] && echo "        $2"
 }
+skip() { SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1)); echo "  SKIP: $1"; }
 
-# Run a zowe command with JSON output; sets OUTPUT and RC.
-run_zowe_json() {
-	RC=0
-	OUTPUT=$(zowe "$@" --rfj 2>&1 </dev/null) || RC=$?
+# A missing node or an unresolvable SDK is a client capability the suite cannot
+# supply, so it is a skip. Anything the driver reports back is an assertion.
+require_driver() {
+	if ! command -v node >/dev/null 2>&1; then
+		echo "  (node not found — the SDK driver cannot run)"
+		return 1
+	fi
+	if ! command -v zowe >/dev/null 2>&1 && [ -z "${ZOWE_CLI_DIR:-}" ]; then
+		echo "  (zowe CLI not installed — its SDK packages are what the driver loads)"
+		return 1
+	fi
+	return 0
 }
 
-assert_rc() {
-	if [ "$2" = "$1" ]; then pass "$3 (rc=$2)"
-	else fail "$3" "expected rc $1, got $2: $(echo "${OUTPUT:-}" | head -3)"; fi
-}
-
-assert_rc_nonzero() {
-	if [ "$1" != "0" ]; then pass "$2 (rc=$1)"
-	else fail "$2" "expected non-zero rc"; fi
-}
-
-assert_json_field() {
-	local actual
-	actual=$(echo "$1" | jq -r "$2" 2>/dev/null) || actual=""
-	if [ "$actual" = "$3" ]; then pass "$4 ($2=$actual)"
-	else fail "$4" "$2: expected '$3', got '$actual'"; fi
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+	if [ "$actual" = "$expected" ]; then pass "$label ($actual)"
+	else fail "$label" "expected '$expected', got '$actual'"; fi
 }
 
 echo ""
 echo "========================================"
-echo " mvsMF Authentication API - Zowe CLI test suite"
+echo " mvsMF Authentication API - Zowe SDK test suite"
 echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
 echo " User: ${MVSMF_USER}"
 echo "========================================"
 
-# =========================================================================
-# 1. Login with valid credentials -> obtain an LtpaToken2
-# =========================================================================
-echo ""
-echo "--- auth login zosmf (valid credentials) ---"
-run_zowe_json auth login zosmf "${COMMON[@]}" \
-	--user "$MVSMF_USER" --password "$MVSMF_PASS" --show-token
-assert_rc "0" "$RC" "login succeeds"
-assert_json_field "$OUTPUT" '.data.tokenType' "LtpaToken2" "login: tokenType LtpaToken2"
+if ! require_driver; then
+	echo ""
+	for c in "login (valid credentials)" "login: LtpaToken2 cookie" \
+	         "login: token value present" "login: cookie is scoped Path=/" \
+	         "login (invalid credentials)" "token replay on a files request" \
+	         "logout" "token invalid after logout" "logout without a valid token"; do
+		skip "$c (no node or Zowe SDK available)"
+	done
+	echo ""
+	echo "========================================"
+	echo " Total: ${TOTAL}  Passed: ${PASSED}  Failed: ${FAILED}  Skipped: ${SKIPPED}"
+	echo "========================================"
+	exit 0
+fi
 
-TOKEN=$(echo "$OUTPUT" | jq -r '.data.tokenValue' 2>/dev/null)
-if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ]; then
-	pass "login: tokenValue present (${#TOKEN} chars)"
-else
-	TOKEN=""
-	fail "login: tokenValue present" "no tokenValue in output"
+OUT=$(MVSMF_HOST="$MVSMF_HOST" MVSMF_PORT="$MVSMF_PORT" \
+      MVSMF_PROTOCOL="${MVSMF_PROTOCOL:-http}" \
+      MVSMF_USER="$MVSMF_USER" MVSMF_PASS="$MVSMF_PASS" \
+      node "$FLOW" 2>&1) || true
+
+get() { echo "$OUT" | sed -n "s/^$1=//p" | head -1; }
+
+if [ -n "$(get error)" ] || [ -z "$(get login_status)" ]; then
+	echo ""
+	fail "authentication flow driver" "$(echo "$OUT" | head -3)"
+	echo ""
+	echo "========================================"
+	echo " Total: ${TOTAL}  Passed: ${PASSED}  Failed: ${FAILED}  Skipped: ${SKIPPED}"
+	echo "========================================"
+	exit 1
 fi
 
 # =========================================================================
-# 2. Replay the token on a files command -> succeeds (token accepted)
+# 1. Login with valid credentials -> 200 and an LtpaToken2 cookie
 # =========================================================================
 echo ""
-echo "--- token replay (zos-files list) ---"
-if [ -n "$TOKEN" ]; then
-	run_zowe_json zos-files list data-set "SYS1.*" "${COMMON[@]}" \
-		--token-type LtpaToken2 --token-value "$TOKEN"
-	assert_rc "0" "$RC" "files list accepts the LtpaToken2"
+echo "--- login (valid credentials) ---"
+assert_eq "200" "$(get login_status)" "login succeeds"
+assert_eq "LtpaToken2" "$(get login_token_type)" "login: tokenType LtpaToken2"
+if [ "$(get login_token_len)" -gt 0 ] 2>/dev/null; then
+	pass "login: tokenValue present ($(get login_token_len) chars)"
 else
-	SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1))
-	echo "  SKIP: token replay (no token captured)"
+	fail "login: tokenValue present" "empty token"
 fi
+# Path=/ scopes the cookie to the whole /zosmf API -- a narrower path would
+# silently break every request outside /zosmf/services.
+assert_eq "/" "$(get login_cookie_path)" "login: cookie is scoped Path=/"
 
 # =========================================================================
-# 3. Login with invalid credentials -> fails
+# 2. Login with invalid credentials -> 401
 # =========================================================================
 echo ""
-echo "--- auth login zosmf (invalid credentials) ---"
-run_zowe_json auth login zosmf "${COMMON[@]}" \
-	--user NOSUCHUSER --password WRONGPW --show-token
-assert_rc_nonzero "$RC" "bad login fails"
+echo "--- login (invalid credentials) ---"
+assert_eq "401" "$(get bad_login_status)" "bad password is rejected"
 
 # =========================================================================
-# 4. Logout the token
+# 3. Replay the token on a files request -> accepted, no credentials sent
 # =========================================================================
 echo ""
-echo "--- auth logout zosmf ---"
-if [ -n "$TOKEN" ]; then
-	run_zowe_json auth logout zosmf "${COMMON[@]}" \
-		--token-type LtpaToken2 --token-value "$TOKEN"
-	assert_rc "0" "$RC" "logout succeeds"
-else
-	SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1))
-	echo "  SKIP: logout (no token captured)"
-fi
+echo "--- token replay (files list) ---"
+assert_eq "200" "$(get replay_status)" "files list accepts the LtpaToken2"
+
+# =========================================================================
+# 4. Logout, and the token dies with it
+# =========================================================================
+echo ""
+echo "--- logout ---"
+assert_eq "204" "$(get logout_status)" "logout succeeds"
+assert_eq "401" "$(get replay_after_logout_status)" "logged-out token is rejected"
+assert_eq "401" "$(get logout_bogus_status)" "logout without a valid token is rejected"
 
 # =========================================================================
 # Summary


### PR DESCRIPTION
Fixes #206.

## The cause is simpler than the issue's guesses

`zowe-auth.sh` failed three of six assertions with nothing wrong on the server. **Zowe CLI v8 has no `auth login zosmf` command at all:**

```
$ zowe auth login --help
 COMMANDS
   apiml   Log in to API ML authentication service
```

The SDK matches it — `@zowe/core-for-zowe-sdk` exports `Login.apimlLogin` and `Logout.apimlLogout`, nothing else. So the parser never recognised the command and reported *every* argument as unknown, the `zosmf` subcommand included. That is why the issue saw the whole command line rejected rather than one bad flag. The two follow-on skips were consequences of no token being captured.

## What replaces it

mvsMF's `/zosmf/services/authenticate` is unreachable through any CLI login path, but not through a Zowe *client*: `ZosmfRestClient` and `Session` are what the CLI itself runs on. `tests/zowe-auth-flow.js` drives the flow with them and prints one `key=value` line per step; `zowe-auth.sh` keeps its shape and does the asserting, with the same `pass`/`fail`/`skip` reporting as the other suites.

## The trap that nearly shipped

**Sessions must be constructed for the identity they carry, never mutated afterwards.** `Session` computes `base64EncodedAuth` in its constructor, so deleting `user`/`password` from an existing session leaves Basic auth in place and every request keeps authenticating with credentials.

A first version did exactly that. It reported:

```
bad login (deliberately wrong password): 200
replay after logout:                     SUCCEEDED
logout with no token:                    204
```

Every one of those was Basic auth answering, and every assertion built on them would have been vacuous. Building a fresh `Session` per identity gives the answers `curl-auth.sh` has always measured:

| case | status |
|---|---|
| login, valid credentials | 200 + `LtpaToken2` (44 chars, `Path=/`) |
| login, wrong password | 401 |
| token replay on `/restfiles/ds` | 200 |
| logout | 204 |
| replay after logout | 401 |
| logout carrying a token never issued | 401 |

## Nine assertions instead of six

The SDK reaches two cases the CLI never could — a replay *after* logout, and a logout carrying a token that was never issued — so the suite now mirrors `curl-auth.sh` case for case. It also checks the cookie is scoped `Path=/`: a narrower path would silently break every request outside `/zosmf/services`.

## Failure modes

- **No node, or no Zowe CLI installed** → skip, with the reason. That is a client capability the suite cannot supply, which is the category the rule block added in #309 blesses.
- **SDK present but unresolvable** → one clean failure naming the module.
- **Server unreachable** → reported once as `error=cannot reach host:port — …` rather than as nine confusing "expected 200, got 0" assertion failures.

## Full regression on mvsdev — thirteen suites

**704 passed, 0 failed, 6 skipped.**

```
curl:  info 40   auth 14   datasets 188/0/2   jobs 115/0/0   uss 128/0/0   console 64   binary 10
zowe:  auth 9/0/0   datasets 50/0/2   jobs 42/0/0   uss 25/0/2   console 9   binary 10
```

`zowe-auth` was **1 passed / 3 failed / 2 skipped** before this. There are now no failures anywhere in the regression.

The six remaining skips are all explained and none of them hides anything:

- **four** Zowe CLI etag capability limits (`X-IBM-Return-Etag` / `If-Match` / `If-None-Match`), each pointing at the `curl-*` suite that covers the protocol in full
- **two** for #243, the mid-body-failure data-loss defect; they become assertions the moment it lands

Refs #309.
