### PR TITLE
Truncate an over-long record instead of abandoning the body

### DIFF
--- a/docs/endpoints/datasets/members-put.md
+++ b/docs/endpoints/datasets/members-put.md
@@ -69,7 +69,7 @@ and compares before opening anything for output:
 Details that matter in practice:
 
 - **The check runs before the member is opened for output.** That is why a 412
-  leaves the previous content intact, unlike the "Record too long" case under
+  leaves the previous content intact, unlike the truncation case under
   *Limitations*.
 - **Send `X-IBM-Return-Etag: true` on the PUT as well** if the client intends to
   save more than once. The write normalizes what it stores (records split at
@@ -86,13 +86,15 @@ Details that matter in practice:
 
 ## Text mode framing
 - A record ends at LF, CR or CRLF. The terminator is not part of the record.
-- A line of exactly LRECL characters is accepted. Only a longer line is
-  rejected, with "Record too long"; it is never silently split across two
+- A line of exactly LRECL characters is accepted. A longer line is **truncated
+  to LRECL** — the overflow is discarded, the record is written, the rest of the
+  body is written after it, and the request then answers 500 "Record truncated
+  to the record length of the data set". It is never silently split across two
   records. Until issue #233 the usable length was LRECL-2, so 80-column source
   could not be uploaded into an FB80 library at all.
 - For RECFM=V the usable line length is LRECL-4: the record descriptor word is
   not content. A longer line used to be split into a second record without
-  notice and is now rejected.
+  notice, and is now truncated like any other.
 - A blank line is written as a record of blanks — it used to disappear (#233).
 - A body whose last line carries no terminator still produces that record, and
   a body ending in a newline does not gain a trailing blank one.
@@ -101,17 +103,19 @@ Details that matter in practice:
 
 ## Limitations
 - Binary mode: the final incomplete record is padded with binary zeros to LRECL
-- A request that fails **before its first record is framed** leaves the member
-  exactly as it was — a dropped connection, a body that never arrives, a body
-  whose very first line is over-long. The member is not opened for output until
-  there is a record to put in it, and it is CLOSE that stows the new directory
-  entry over the old one, so an unopened member is an untouched member
-  (issue #246).
-- A request that fails **after** that point still does not roll back. On
-  "Record too long" halfway through a body, the records written up to that line
-  are stored and the previous content is gone. Making a mid-body failure atomic
-  needs the member staged under a temporary name and renamed on success, which
-  is open as issue #243.
+- A request that produces **no record at all** leaves the member exactly as it
+  was — a dropped connection, a body that never arrives. The member is not
+  opened for output until there is a record to put in it, and it is CLOSE that
+  stows the new directory entry over the old one, so an unopened member is an
+  untouched member (issue #246). An over-long first line is no longer such a
+  case: it is truncated to LRECL and written like any other record.
+- **A failed write does not roll back, and real z/OSMF does not roll back
+  either.** Measured on version 29 (#243): a body whose second of three lines is
+  200 characters lands in an FB/80 member as three records of 5, 80 and 6, the
+  previous content replaced, and answers 500. A rejected PUT to a member that
+  did not exist yet also leaves the member behind, on both. mvsMF matches that.
+  Staging under a temporary name would spend a directory entry per write and
+  would not buy conformance, because there is nothing to conform to.
 - An empty body is a truncate, not a no-op: `Content-Length: 0` empties the
   member.
 

--- a/docs/endpoints/datasets/put.md
+++ b/docs/endpoints/datasets/put.md
@@ -55,13 +55,15 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 
 ## Text mode framing
 - A record ends at LF, CR or CRLF. The terminator is not part of the record.
-- A line of exactly LRECL characters is accepted. Only a longer line is
-  rejected, with "Record too long"; it is never silently split across two
+- A line of exactly LRECL characters is accepted. A longer line is **truncated
+  to LRECL** — the overflow is discarded, the record is written, the rest of the
+  body is written after it, and the request then answers 500 "Record truncated
+  to the record length of the data set". It is never silently split across two
   records. Until issue #233 the usable length was LRECL-2, so 80-column source
   could not be uploaded into an FB80 dataset at all.
 - For RECFM=V the usable line length is LRECL-4: the record descriptor word is
   not content. A longer line used to be split into a second record without
-  notice and is now rejected.
+  notice, and is now truncated like any other.
 - A blank line is written as a record of blanks — it used to disappear (#233).
 - A body whose last line carries no terminator still produces that record, and
   a body ending in a newline does not gain a trailing blank one.
@@ -71,15 +73,18 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 ## Limitations
 - Only sequential (PS) datasets are supported; PDS datasets return HTTP 400
 - Binary mode: the final incomplete record is padded with binary zeros to LRECL
-- A request that fails **before its first record is framed** leaves the dataset
-  exactly as it was — a dropped connection, a body that never arrives, a body
-  whose very first line is over-long. The dataset is not opened for output until
-  there is a record to put in it (issue #246).
-- A request that fails **after** that point still does not roll back. On
-  "Record too long" halfway through a body, the records written up to that line
-  are in the dataset and what was there before is gone. Making a mid-body
-  failure atomic needs the write staged elsewhere and swapped in on success,
-  which is open as issue #243.
+- A request that produces **no record at all** leaves the dataset exactly as it
+  was — a dropped connection, a body that never arrives. The dataset is not
+  opened for output until there is a record to put in it (issue #246). An
+  over-long first line is no longer such a case: it is truncated to LRECL and
+  written like any other record.
+- **A failed write does not roll back, and real z/OSMF does not roll back
+  either.** Measured on version 29 (#243): a body whose second of three lines is
+  200 characters lands in an FB/80 data set as three records of 5, 80 and 6, the
+  previous content replaced, and answers 500. mvsMF matches that. Staging the
+  write elsewhere and swapping it in would turn a PUT into
+  allocate/write/delete/rename and would not buy conformance, because there is
+  nothing to conform to.
 - An empty body is a truncate, not a no-op: `Content-Length: 0` empties the
   dataset.
 

--- a/include/reclines.h
+++ b/include/reclines.h
@@ -35,16 +35,16 @@
  * compiler's (EBCDIC) character literals.
  */
 
-/* Result of recline_put(). */
+/* Result of recline_put(). There is no "too long" result: see `truncated`. */
 #define RECLINE_MORE		0	/* byte consumed, record not complete yet */
 #define RECLINE_RECORD		1	/* record complete, returned in rec/rec_len */
-#define RECLINE_TOOLONG		2	/* content would exceed content_max         */
 
 typedef struct {
 	char	*buf;			/* caller's buffer, at least content_max bytes  */
 	size_t	 len;			/* content bytes currently held in buf          */
 	size_t	 content_max;	/* usable content bytes per record, must be > 0 */
 	int	 pending_lf;		/* last byte was CR: a following LF belongs to it */
+	int	 truncated;		/* sticky: at least one record lost its overflow  */
 } RECLINE;
 
 /**
@@ -63,9 +63,16 @@ void recline_init(RECLINE *rl, char *buf, size_t content_max)	asm("MFRECINI");
  * must write that record out before feeding the next byte -- the buffer is
  * reused, and write_record() translates it in place.
  *
- * Returns RECLINE_TOOLONG when the byte would be content number
- * content_max + 1. Nothing is stored and the stream cannot be continued; the
- * caller is expected to fail the request.
+ * A byte past content_max is DISCARDED and `truncated` is set, and framing
+ * carries on to the terminator -- the record is then emitted at exactly
+ * content_max. This is what real z/OSMF does, measured on version 29: a body
+ * whose second of three lines is 200 characters lands in an FB/80 data set as
+ * three records of 5, 80 and 6, and the request answers 500 afterwards. It is
+ * deliberately not a per-byte error: aborting there loses every record after
+ * the offending one, which is the more destructive half of #243.
+ *
+ * The caller writes the records as they come and, once the whole body has
+ * been consumed, checks `truncated` to decide the response.
  *
  * Returns RECLINE_MORE otherwise; *rec and *rec_len are not touched.
  */

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -715,11 +715,11 @@ static int write_record(Session *session, FILE *fp, char *record_buffer, size_t 
         default:
             // Text mode - convert from ASCII to EBCDIC
 
-            /* Backstop only: recline_put() already rejects a line longer than
-               content_max with "Record too long", so this cannot normally
-               fire. It stays as the last line of defence against a caller
-               and this function disagreeing about the limit -- which is
-               precisely how issue #198 happened. */
+            /* Backstop only: recline_put() already caps a line at content_max
+               (truncating the overflow, #243), so this cannot normally fire.
+               It stays as the last line of defence against a caller and this
+               function disagreeing about the limit -- which is precisely how
+               issue #198 happened. */
             if (content_max && record_length > content_max) {
                 record_length = content_max;
             }

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1592,11 +1592,6 @@ int datasetPutHandler(Session *session)
                     bytes_read++;
 
                     switch (recline_put(&rl, c, &rec, &rec_len)) {
-                    case RECLINE_TOOLONG:
-                        free(record_buffer);
-                        session_fclose(session, fp);
-                        return handle_error(session, ERR_IO, "Record too long");
-
                     case RECLINE_RECORD:
                         if (write_record_open(session, &fp, dsname, mode_str, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                             free(record_buffer);
@@ -1678,11 +1673,6 @@ int datasetPutHandler(Session *session)
                 bytes_remaining--;
 
                 switch (recline_put(&rl, c, &rec, &rec_len)) {
-                case RECLINE_TOOLONG:
-                    free(record_buffer);
-                    session_fclose(session, fp);
-                    return handle_error(session, ERR_IO, "Record too long");
-
                 case RECLINE_RECORD:
                     if (write_record_open(session, &fp, dsname, mode_str, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                         free(record_buffer);
@@ -1721,6 +1711,18 @@ int datasetPutHandler(Session *session)
 
     session_fclose(session, fp);
     fp = NULL;
+
+    /* An over-long record is truncated to the record length and the body is
+       written in full; the request then fails. Measured against real z/OSMF
+       version 29 (#243): a body whose second of three lines is 200 characters
+       lands in an FB/80 target as three records of 5, 80 and 6, and answers
+       500. Reporting it here rather than at the offending byte is the point --
+       aborting mid-body loses every record after it, and the previous content
+       is already gone either way, because the reference does not stage. */
+    if (rl.truncated) {
+        return handle_error(session, ERR_IO,
+            "Record truncated to the record length of the data set");
+    }
 
     /* ETag of the state just written -- see the member handler for why this
        is a re-read and not a hash of the request body. */
@@ -2484,11 +2486,6 @@ int memberPutHandler(Session *session)
                     bytes_read++;
 
                     switch (recline_put(&rl, c, &rec, &rec_len)) {
-                    case RECLINE_TOOLONG:
-                        free(record_buffer);
-                        session_fclose(session, fp);
-                        return handle_error(session, ERR_IO, "Record too long");
-
                     case RECLINE_RECORD:
                         if (write_record_open(session, &fp, dataset, member_mode, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                             free(record_buffer);
@@ -2566,11 +2563,6 @@ int memberPutHandler(Session *session)
                 bytes_remaining--;
 
                 switch (recline_put(&rl, c, &rec, &rec_len)) {
-                case RECLINE_TOOLONG:
-                    free(record_buffer);
-                    session_fclose(session, fp);
-                    return handle_error(session, ERR_IO, "Record too long");
-
                 case RECLINE_RECORD:
                     if (write_record_open(session, &fp, dataset, member_mode, rec, rec_len, &total_written, &line_count, data_type, content_max) < 0) {
                         free(record_buffer);
@@ -2608,6 +2600,18 @@ int memberPutHandler(Session *session)
 
     session_fclose(session, fp);
     fp = NULL;
+
+    /* An over-long record is truncated to the record length and the body is
+       written in full; the request then fails. Measured against real z/OSMF
+       version 29 (#243): a body whose second of three lines is 200 characters
+       lands in an FB/80 target as three records of 5, 80 and 6, and answers
+       500. Reporting it here rather than at the offending byte is the point --
+       aborting mid-body loses every record after it, and the previous content
+       is already gone either way, because the reference does not stage. */
+    if (rl.truncated) {
+        return handle_error(session, ERR_IO,
+            "Record truncated to the record length of the data set");
+    }
 
     /* ETag of the state that was just written, from a re-read of the closed
        member -- never from the request body. The write normalizes (records

--- a/src/reclines.c
+++ b/src/reclines.c
@@ -25,6 +25,7 @@ recline_init(RECLINE *rl, char *buf, size_t content_max)
 	rl->len         = 0;
 	rl->content_max = content_max;
 	rl->pending_lf  = 0;
+	rl->truncated   = 0;
 }
 
 #ifdef __MVS__
@@ -64,9 +65,12 @@ recline_put(RECLINE *rl, char c, char **rec, size_t *rec_len)
 	}
 
 	/* The terminator is never stored, so this counts content only: a line of
-	   exactly content_max characters fits. */
+	   exactly content_max characters fits. Past that the byte is dropped and
+	   the record is emitted short of the caller's line -- see reclines.h for
+	   why truncating beats failing here. */
 	if (rl->len >= rl->content_max) {
-		return RECLINE_TOOLONG;
+		rl->truncated = 1;
+		return RECLINE_MORE;
 	}
 
 	rl->buf[rl->len++] = c;

--- a/test/host/tstrecl.c
+++ b/test/host/tstrecl.c
@@ -80,16 +80,16 @@ static void feed(const char *bytes, size_t n)
 
 	for (i = 0; i < n; i++) {
 		act = recline_put(&g_rl, bytes[i], &rec, &rec_len);
-		if (act == RECLINE_TOOLONG) {
-			g_toolong = 1;
-			return;			/* the handler fails the request here */
-		}
+		/* No early exit: an over-long line no longer stops the stream, it
+		   loses its overflow and framing continues -- which is the whole
+		   point of #243. The handlers read rl.truncated after the body. */
 		if (act == RECLINE_RECORD && g_nrec < MAX_RECS) {
 			memcpy(g_rec[g_nrec], rec, rec_len);
 			g_reclen[g_nrec] = rec_len;
 			g_nrec++;
 		}
 	}
+	g_toolong = g_rl.truncated;
 }
 
 /* The end of the body: a trailing record only if content is pending. */
@@ -163,14 +163,40 @@ int main(void)
 	CHECK(rec_is(0, line80, 80), "LRECL: all 80 columns kept");
 	CHECK(canary_intact(80), "LRECL: nothing written past the record length");
 
-	/* 3. one column too many is still rejected, and before storing anything */
+	/* 3. one column too many loses the overflow, and the record still lands.
+	 *    Measured against real z/OSMF v29 (#243): it truncates to LRECL rather
+	 *    than rejecting, and reports the truncation once at the end. */
 	feed_start(80);
 	memcpy(stream, line81, 81);
 	memcpy(stream + 81, LF, 1);
 	feed(stream, 82);
-	CHECK_EQ(g_toolong, 1, "over-long: 81 columns into LRECL=80 rejected");
-	CHECK_EQ(g_nrec, 0, "over-long: no record emitted");
+	CHECK_EQ(g_toolong, 1, "over-long: 81 columns into LRECL=80 flagged truncated");
+	CHECK_EQ(g_nrec, 1, "over-long: the record is still emitted");
+	CHECK(rec_is(0, line81, 80), "over-long: emitted at exactly 80 columns");
 	CHECK(canary_intact(80), "over-long: nothing written past the record length");
+
+	/* 3b. and the stream survives it -- everything after the over-long line
+	 *     is written, which is the half of #243 that actually lost data. The
+	 *     shape is the one measured on z/OSMF: 5 / 80 / 6. */
+	feed_start(80);
+	{
+		char   body[256];	/* the measured body is 214 bytes -- stream[] is 128 */
+		size_t n = 0;
+
+		memcpy(body + n, "ERSTE", 5);   n += 5;
+		memcpy(body + n, LF, 1);        n += 1;
+		memset(body + n, 'X', 200);     n += 200;
+		memcpy(body + n, LF, 1);        n += 1;
+		memcpy(body + n, "DRITTE", 6);  n += 6;
+		memcpy(body + n, LF, 1);        n += 1;
+		feed(body, n);
+	}
+	CHECK_EQ(g_toolong, 1, "over-long mid-body: truncation flagged");
+	CHECK_EQ(g_nrec, 3, "over-long mid-body: all three records emitted");
+	CHECK(rec_is(0, "ERSTE", 5), "over-long mid-body: first record intact");
+	CHECK_EQ((int)g_reclen[1], 80, "over-long mid-body: second record cut to 80");
+	CHECK(rec_is(2, "DRITTE", 6), "over-long mid-body: the record AFTER it survives");
+	CHECK(canary_intact(80), "over-long mid-body: nothing past the record length");
 
 	/* 4. CRLF at exactly the record length -- the CR ends it, the LF is
 	 *    swallowed and must not open a blank record */
@@ -238,7 +264,9 @@ int main(void)
 
 	feed_start(1);
 	feed("AB" LF, 3);
-	CHECK_EQ(g_toolong, 1, "LRECL=1: two columns rejected");
+	CHECK_EQ(g_toolong, 1, "LRECL=1: two columns flagged truncated");
+	CHECK_EQ(g_nrec, 1, "LRECL=1: the record still lands");
+	CHECK(rec_is(0, "A", 1), "LRECL=1: cut to the single column");
 
 	/* 12. whatever the caller computes as the usable length is what gets
 	 *     enforced -- RECFM=V passes LRECL-4, so the RDW is not spent on
@@ -248,7 +276,7 @@ int main(void)
 	feed(stream, 4);
 	CHECK_EQ(g_toolong, 0, "content_max=4: four columns accepted");
 	feed(stream, 1);
-	CHECK_EQ(g_toolong, 1, "content_max=4: the fifth column is rejected");
+	CHECK_EQ(g_toolong, 1, "content_max=4: the fifth column is dropped");
 
 	return mbt_test_summary("TSTRECL");
 }

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -1497,7 +1497,7 @@ for COLS in 77 78 79 80; do
 done
 
 echo ""
-echo "--- Text framing: one column too many is still rejected ---"
+echo "--- Text framing: one column too many is truncated, not refused ---"
 
 awk 'BEGIN { s = ""; while (length(s) < 81) s = s "A"; print substr(s, 1, 81) }' \
 	> /tmp/curl_ds_wide.txt
@@ -1508,11 +1508,23 @@ BODY=$(curl -s -w '\n%{http_code}' \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TOOWIDE)")
 HTTP_CODE=$(echo "$BODY" | tail -1)
 CONTENT=$(echo "$BODY" | sed '$d')
-assert_http_status "500" "$HTTP_CODE" "an 81-column line is rejected"
-if echo "$CONTENT" | grep -qi "Record too long"; then
-	pass "the rejection names the reason (Record too long)"
+assert_http_status "500" "$HTTP_CODE" "an 81-column line reports 500"
+# The status stays 500, but the reason changed with #243: real z/OSMF truncates
+# the record to LRECL and writes it rather than refusing, so "Record too long"
+# no longer describes what happened.
+if echo "$CONTENT" | grep -qi "truncated"; then
+	pass "the failure names the truncation"
 else
-	fail "the rejection names the reason" "got: $CONTENT"
+	fail "the failure names the truncation" "got: $CONTENT"
+fi
+
+# ...and the record is there, cut to LRECL. The half of #243 that lost data was
+# that the write got abandoned instead.
+WIDE_RT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TOOWIDE)" | sed -n 1p)
+if [ "${#WIDE_RT}" = "80" ]; then
+	pass "the over-long record landed, cut to LRECL 80"
+else
+	fail "the over-long record landed, cut to LRECL 80" "got ${#WIDE_RT} columns"
 fi
 
 echo ""
@@ -2038,6 +2050,39 @@ printf 'ORIGINAL LINE ONE\nORIGINAL LINE TWO\n' > /tmp/curl_ds_atom_good.txt
 	printf 'LAST GOOD LINE\n'
 } > /tmp/curl_ds_atom_long.txt
 
+# What the target must hold after that PUT, measured against real z/OSMF v29
+# (#243): the over-long record is truncated to LRECL and the record AFTER it is
+# written. Three records of 15, 80 and 14 -- not the previous content, which
+# the reference does not preserve either, and not a body cut short at the
+# offending line, which is what mvsMF used to leave behind.
+assert_truncated_body() {
+	local uri="$1" label="$2"
+	local body n l1 l2 l3
+	body=$(curl -s -u "$AUTH" "$uri")
+	n=$(printf '%s\n' "$body" | grep -c .)
+	l1=$(printf '%s\n' "$body" | sed -n 1p)
+	l2=$(printf '%s\n' "$body" | sed -n 2p)
+	l3=$(printf '%s\n' "$body" | sed -n 3p)
+
+	if [ "$n" != "3" ]; then
+		fail "$label" "expected 3 records, got ${n}"
+		return
+	fi
+	if [ "$l1" != "FIRST GOOD LINE" ]; then
+		fail "$label" "record 1 is '${l1}'"
+		return
+	fi
+	if [ "${#l2}" != "80" ]; then
+		fail "$label" "record 2 is ${#l2} columns, expected it cut to LRECL 80"
+		return
+	fi
+	if [ "$l3" != "LAST GOOD LINE" ]; then
+		fail "$label" "record 3 is '${l3}' -- the record after the over-long one was lost"
+		return
+	fi
+	pass "$label (3 records, the long one cut to 80, the one after it kept)"
+}
+
 curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${ATOM_SEQ}" >/dev/null 2>&1 || true
 curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${ATOM_PDS}" >/dev/null 2>&1 || true
 
@@ -2060,18 +2105,10 @@ if [ "$HTTP_CODE" = "201" ] && [ "$HTTP_CODE2" = "201" ]; then
 		-H "X-IBM-Data-Type: text" -H "Expect:" \
 		--data-binary @/tmp/curl_ds_atom_long.txt \
 		"${BASE_URL}/zosmf/restfiles/ds/${ATOM_SEQ}")
-	assert_http_status "500" "$HTTP_CODE" "seq: over-long record is rejected"
+	assert_http_status "500" "$HTTP_CODE" "seq: over-long record reports 500"
 
-	# A mid-body failure is NOT yet atomic: the records written before the
-	# offending line are already committed. Reported as a skip rather than a
-	# failure so the suite stays green on known behaviour -- turn this into an
-	# assertion when #243 lands.
-	CONTENT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${ATOM_SEQ}")
-	if [ "$CONTENT" = "$(cat /tmp/curl_ds_atom_good.txt)" ]; then
-		pass "seq: a mid-body failure leaves the previous content intact (#243 fixed?)"
-	else
-		skip "seq: a mid-body failure still commits what it wrote (known, #243)"
-	fi
+	assert_truncated_body "${BASE_URL}/zosmf/restfiles/ds/${ATOM_SEQ}" \
+		"seq: over-long record truncated, body written in full"
 
 	# --- member: the same, where CLOSE is what commits (issue #243) ---
 	curl -s -o /dev/null -X PUT -u "$AUTH" -H "X-IBM-Data-Type: text" -H "Expect:" \
@@ -2082,14 +2119,10 @@ if [ "$HTTP_CODE" = "201" ] && [ "$HTTP_CODE2" = "201" ]; then
 		-H "X-IBM-Data-Type: text" -H "Expect:" \
 		--data-binary @/tmp/curl_ds_atom_long.txt \
 		"${BASE_URL}/zosmf/restfiles/ds/${ATOM_PDS}(KEEPME)")
-	assert_http_status "500" "$HTTP_CODE" "member: over-long record is rejected"
+	assert_http_status "500" "$HTTP_CODE" "member: over-long record reports 500"
 
-	CONTENT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${ATOM_PDS}(KEEPME)")
-	if [ "$CONTENT" = "$(cat /tmp/curl_ds_atom_good.txt)" ]; then
-		pass "member: a mid-body failure leaves the previous content intact (#243 fixed?)"
-	else
-		skip "member: a mid-body failure still commits what it wrote (known, #243)"
-	fi
+	assert_truncated_body "${BASE_URL}/zosmf/restfiles/ds/${ATOM_PDS}(KEEPME)" \
+		"member: over-long record truncated, body written in full"
 
 	# Re-seed: the mid-body case above deliberately damaged the member, and the
 	# #246 case below has to start from a known state or it measures the wrong


### PR DESCRIPTION
Fixes #243 — but not in the direction the issue proposed. **The premise was wrong, and it was never measured.**

## What real z/OSMF does

The issue states, under *What z/OSMF does*: "A failed write leaves the data set unchanged. That is the behaviour to aim for." Measured on z/OSMF version 29 / z/OS 05.29.00, with permission for the writes and both throwaway data sets removed afterwards (verified: 0 left behind):

```
PUT  "ERSTE\n" + "X"*200 + "\nDRITTE\n"   ->  500
     EDC5003I Truncation of a record occurred during a write to a file
GET                                       ->  ERSTE(5) | XXXXXX…(80) | DRITTE(6)
```

Three records. The over-long line is **truncated to LRECL** — not wrapped, not rejected — **the line after it is written normally**, and the 500 comes at the end. The previous content is gone, replaced in full. A rejected PUT to a member that did not exist also leaves the member behind.

So the reference neither preserves the old content nor aborts. **The real deviation was narrower and worse than the one described:** mvsMF stopped at the offending record and lost everything after it. The 92-line upload that left 54 records is exactly that — z/OSMF would have written all 92, one of them short.

## What changed

`recline_put()` drops the overflow, sets a sticky `truncated`, and keeps framing. `RECLINE_TOOLONG` is gone — nothing returns it any more, so the four write loops lose their abort arms, and both handlers check `rl.truncated` once after the body is committed. `rl` is initialised before any mode branch, so the check is valid on every path; binary mode never sets it, having its own fixed-length splitting.

Side by side, same body, same FB/80 target:

| | z/OSMF v29 | mvsMF before | mvsMF now |
|---|---|---|---|
| status | 500 | 500 | 500 |
| records | `ERSTE(5)` `XXX…(80)` `DRITTE(6)` | `ERSTE(5)` | `ERSTE(5)` `XXX…(80)` `DRITTE(6)` |
| rejected PUT to a new member | member remains | member remains | member remains |

**This is deliberately less strict, and less destructive**: it trades "refuse and lose the rest of the file" for "lose the overflow of one record", which is what the reference does. The status stays 500 on both sides, so nothing moves outside the enumerated z/OSMF status list.

## The directions this replaces

All three "Possible directions" on the issue are superseded. *Stage and rename* solves a problem the reference does not solve, and costs what the maintainer objected to on sight — a PUT becomes allocate/write/delete/rename for a sequential data set, and spends a directory entry per write for a member. *Validate before writing* has nothing to validate. *Document and accept* documents the one difference that actually costs the user data.

## One guarantee genuinely narrows

Both PUT docs promised that a body "whose very first line is over-long" leaves the target untouched (#246). It no longer does — that line is now truncated and written, so the target is opened and replaced. Measured rather than reasoned:

```
seeded:  ORIGINAL ONE / ORIGINAL TWO
PUT:     one 200-character line          -> 500
after:   one record of 80 columns
```

#246 now covers only requests that produce **no record at all** — a dropped connection, a body that never arrives. Both docs say so.

## Tests

`TSTRECL` drives the real state machine (it `#include`s `src/reclines.c`) and carries the measured shape as a case: 5 / 80 / 6, with **the record after the over-long one asserted present**. 7 host tests, 211 assertions, all passing.

The two `skip`s naming this issue in `curl-datasets.sh` are rewritten, not merely enabled — they asserted that the previous content survives, which is not the behaviour to aim for. The framing test's "Record too long" assertion becomes a truncation assertion plus a new one: the record landed, cut to 80.

**Full regression on mvsdev, thirteen suites, live build `7516c02` = HEAD: 707 passed, 0 failed, 4 skipped.** The four are Zowe CLI etag capability limits; the #243 pair is gone.

Refs #246, #257.
