### PR TITLE
Wait for a slow client instead of abandoning its write

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -242,4 +242,33 @@ int send_all(Session *session, const UCHAR *buf, int len) asm("CMN0014");
 int read_request_content(Session *session, char **content,
                         size_t *content_size) asm("CMN0020");
 
+/**
+ * @brief Reads exactly @p len bytes, waiting out an empty receive buffer
+ *
+ * httpd sets every accepted socket non-blocking, so a recv() that finds
+ * the buffer empty returns -1/EWOULDBLOCK at once -- "the client has not
+ * sent it yet", not an error. Reads one byte at a time (MVS 3.8j TCP/IP
+ * ring buffer bug); see the note above receive_raw_data() in common.c.
+ *
+ * @param httpc Client connection
+ * @param buf Destination buffer
+ * @param len Number of bytes to read
+ * @return Bytes read -- short only on peer close -- or -1 on error/timeout
+ */
+int receive_raw_data(HTTPC *httpc, char *buf, int len) asm("CMN0021");
+
+/**
+ * @brief Reads up to @p len bytes, waiting out an empty receive buffer
+ *
+ * The bulk counterpart of receive_raw_data(): one recv() of up to @p len
+ * bytes, retried on EWOULDBLOCK against the same budget. Used where the
+ * caller already tolerates a short read and wants the larger granularity.
+ *
+ * @param httpc Client connection
+ * @param buf Destination buffer
+ * @param len Maximum number of bytes to read
+ * @return Bytes read (>0), 0 on orderly close, -1 on error/timeout
+ */
+int receive_raw_some(HTTPC *httpc, char *buf, int len) asm("CMN0022");
+
 #endif // COMMON_H

--- a/src/common.c
+++ b/src/common.c
@@ -366,7 +366,21 @@ send_all(Session *session, const UCHAR *buf, int len)
 // still what carries the read across the gap.
 //
 // 200 retries x 50 ms = 10 s without a single byte before giving up, the
-// same budget send_all() spends on a stalled send.
+// same budget send_all() spends on a stalled send. Note the shape: retries
+// resets on every byte received, so the budget is per stall, not per
+// request. A client dribbling one byte every 9 s holds its worker -- and,
+// mid-body, an open DCB on the target -- for as long as it keeps dribbling.
+// That is the unavoidable price of waiting for slow clients; the guard
+// against it is httpd's client timeout, not this loop.
+//
+// MSG_RECV_TIMEOUT stays even though #247 widened its reach from the four
+// read_request_content() callers to every data set PUT. A ten second silence
+// mid-request is an operator-visible symptom -- a held worker is precisely
+// what #217 taught us to look for -- and it cannot flood the console the way
+// a client-caused 404 can, because one stuck request emits at most one WTO
+// per 10 s. MSG_SEND_TIMEOUT is the same policy on the send side; having one
+// direction report a stall and the other stay silent would be worse than
+// either choice made consistently.
 //
 
 #define RAW_RECV_MAX_RETRIES 200

--- a/src/common.c
+++ b/src/common.c
@@ -346,11 +346,33 @@ send_all(Session *session, const UCHAR *buf, int len)
 // when a multi-byte recv() spans the internal buffer wrap-around point.
 // DO NOT change to multi-byte recv().
 //
+// The EWOULDBLOCK arm below is not a nicety, it is what makes a slow client
+// work at all. httpd puts every accepted socket in non-blocking mode
+// (FIONBIO, httpd.c), so a recv() that finds the receive buffer empty
+// returns -1/EWOULDBLOCK immediately -- and an empty buffer mid-body means
+// "the client has not sent the next byte yet", not "the client is gone".
+// mvsMF consumes a text body at roughly 130 KB/s, so ANY client sending
+// slower than that drains the buffer within the first second; measured on
+// mvsdev, a 240 KB PUT throttled to 100 KB/s ran the buffer dry after
+// 0.6 s. A bare recv() there fails a perfectly healthy upload -- and, with
+// the target already open for output, replaces the resource with whatever
+// arrived first (#247, and the destruction half of #246).
+//
+// A client sending `Expect: 100-continue` is the same failure at byte zero:
+// it holds the body back until an interim response arrives, so the very
+// first read finds nothing. Answering that expectation is httpd's job
+// (httpd#207) -- but even once it does, the interim response and the
+// client's first data segment are a round trip apart, so waiting here is
+// still what carries the read across the gap.
+//
+// 200 retries x 50 ms = 10 s without a single byte before giving up, the
+// same budget send_all() spends on a stalled send.
+//
 
 #define RAW_RECV_MAX_RETRIES 200
 
 __asm__("\n&FUNC    SETC 'recv_raw_data'");
-static int
+int
 receive_raw_data(HTTPC *httpc, char *buf, int len)
 {
 	int total = 0;
@@ -380,6 +402,48 @@ receive_raw_data(HTTPC *httpc, char *buf, int len)
 	}
 
 	return total;
+}
+
+//
+// The bulk counterpart: one recv() of up to len bytes, retried on
+// EWOULDBLOCK against the same budget.
+//
+// Read granularity is deliberately left alone. The binary record paths in
+// dsapi.c have always read up to one LRECL per call, and turning them into
+// byte-at-a-time reads would be a throughput change dressed up as a bug fix.
+// What they were missing is only the wait -- so that is all this adds. The
+// caller already handles a short read; every one of them loops until the
+// declared length is in.
+//
+
+__asm__("\n&FUNC    SETC 'recv_raw_some'");
+int
+receive_raw_some(HTTPC *httpc, char *buf, int len)
+{
+	int n = 0;
+	int retries = 0;
+	unsigned ecb = 0;
+	int sockfd = httpc->socket;
+
+	while (1) {
+		n = recv(sockfd, buf, len, 0);
+		if (n >= 0) {
+			return n;
+		}
+		if (errno == EINTR) continue;
+		if (errno != EWOULDBLOCK) {
+			return -1;
+		}
+		if (++retries > RAW_RECV_MAX_RETRIES) {
+			wtof(MSG_RECV_TIMEOUT, retries);
+			return -1;
+		}
+		// Zeroed on this frame every time -- an ECB that outlives one
+		// wait returns instantly from every later one, which is the busy
+		// spin this wait exists to avoid. Same reason as send_op_pause().
+		ecb = 0;
+		cthread_timed_wait((void *)&ecb, 5, 0);
+	}
 }
 
 //

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1486,14 +1486,14 @@ int datasetPutHandler(Session *session)
             
             // Read chunk size as ASCII hex string
             while (i < sizeof(chunk_size_str)-1) {
-                if (recv(session->httpc->socket, &c, 1, 0) != 1) {
+                if (receive_raw_data(session->httpc, &c, 1) != 1) {
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading chunk size");
                 }
                 if (c == 0x0D) { // ASCII CR \r
                     chunk_size_str[i] = '\0';
-                    recv(session->httpc->socket, &c, 1, 0);  // Read ASCII LF \n
+                    receive_raw_data(session->httpc, &c, 1);  // Read ASCII LF \n
                     break;
                 }
                 chunk_size_str[i++] = c;
@@ -1533,7 +1533,7 @@ int datasetPutHandler(Session *session)
 
                 // Read final CRLF
                 char crlf[2] = {0};
-                if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
+                if (receive_raw_data(session->httpc, crlf, 2) != 2) {
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading final line ending");
@@ -1558,7 +1558,7 @@ int datasetPutHandler(Session *session)
                     int n;
                     if (to_read > space) to_read = space;
 
-                    n = recv(session->httpc->socket, record_buffer + record_pos, to_read, 0);
+                    n = receive_raw_some(session->httpc, record_buffer + record_pos, (int)to_read);
                     if (n <= 0) {
                         free(record_buffer);
                         session_fclose(session, fp);
@@ -1584,7 +1584,7 @@ int datasetPutHandler(Session *session)
                    here (as this did) turned every line split across two chunks
                    into two records. */
                 while (bytes_read < chunk_size) {
-                    if (recv(session->httpc->socket, &c, 1, 0) != 1) {
+                    if (receive_raw_data(session->httpc, &c, 1) != 1) {
                         free(record_buffer);
                         session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error reading chunk data");
@@ -1608,7 +1608,7 @@ int datasetPutHandler(Session *session)
 
             /* Read chunk trailer (CRLF) */
             char crlf[2];
-            if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
+            if (receive_raw_data(session->httpc, crlf, 2) != 2) {
                 free(record_buffer);
                 session_fclose(session, fp);
                 return handle_error(session, ERR_IO, "Error reading chunk trailer");
@@ -1626,7 +1626,7 @@ int datasetPutHandler(Session *session)
                 int n;
                 if (to_read > space) to_read = space;
 
-                n = recv(session->httpc->socket, record_buffer + record_pos, to_read, 0);
+                n = receive_raw_some(session->httpc, record_buffer + record_pos, (int)to_read);
                 if (n <= 0) {
                     free(record_buffer);
                     session_fclose(session, fp);
@@ -1665,7 +1665,7 @@ int datasetPutHandler(Session *session)
                than Content-Length allowed whenever a CR stood alone. */
             char c;
             while (bytes_remaining > 0) {
-                if (recv(session->httpc->socket, &c, 1, 0) != 1) {
+                if (receive_raw_data(session->httpc, &c, 1) != 1) {
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading data");
@@ -2385,14 +2385,14 @@ int memberPutHandler(Session *session)
             
             // Read chunk size as ASCII hex string
             while (i < sizeof(chunk_size_str)-1) {
-                if (recv(session->httpc->socket, &c, 1, 0) != 1) {
+                if (receive_raw_data(session->httpc, &c, 1) != 1) {
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading chunk size");
                 }
                 if (c == '\r') {
                     chunk_size_str[i] = '\0';
-                    recv(session->httpc->socket, &c, 1, 0);  // Read \n
+                    receive_raw_data(session->httpc, &c, 1);  // Read \n
                     break;
                 }
                 chunk_size_str[i++] = c;
@@ -2429,7 +2429,7 @@ int memberPutHandler(Session *session)
 
                 // Read final CRLF
                 char crlf[2] = {0};
-                if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
+                if (receive_raw_data(session->httpc, crlf, 2) != 2) {
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading final line ending");
@@ -2454,7 +2454,7 @@ int memberPutHandler(Session *session)
                     int n;
                     if (to_read > space) to_read = space;
 
-                    n = recv(session->httpc->socket, record_buffer + record_pos, to_read, 0);
+                    n = receive_raw_some(session->httpc, record_buffer + record_pos, (int)to_read);
                     if (n <= 0) {
                         free(record_buffer);
                         session_fclose(session, fp);
@@ -2478,7 +2478,7 @@ int memberPutHandler(Session *session)
                    state deliberately survives the chunk boundary -- see the
                    sequential handler. */
                 while (bytes_read < chunk_size) {
-                    if (recv(session->httpc->socket, &c, 1, 0) != 1) {
+                    if (receive_raw_data(session->httpc, &c, 1) != 1) {
                         free(record_buffer);
                         session_fclose(session, fp);
                         return handle_error(session, ERR_IO, "Error reading chunk data");
@@ -2502,7 +2502,7 @@ int memberPutHandler(Session *session)
             
             // Read chunk trailer (CRLF)
             char crlf[2];
-            if (recv(session->httpc->socket, crlf, 2, 0) != 2) {
+            if (receive_raw_data(session->httpc, crlf, 2) != 2) {
                 free(record_buffer);
                 session_fclose(session, fp);
                 return handle_error(session, ERR_IO, "Error reading chunk trailer");
@@ -2520,7 +2520,7 @@ int memberPutHandler(Session *session)
                 int n;
                 if (to_read > space) to_read = space;
 
-                n = recv(session->httpc->socket, record_buffer + record_pos, to_read, 0);
+                n = receive_raw_some(session->httpc, record_buffer + record_pos, (int)to_read);
                 if (n <= 0) {
                     free(record_buffer);
                     session_fclose(session, fp);
@@ -2555,7 +2555,7 @@ int memberPutHandler(Session *session)
                replaces the old read-ahead. */
             char c;
             while (bytes_remaining > 0) {
-                if (recv(session->httpc->socket, &c, 1, 0) != 1) {
+                if (receive_raw_data(session->httpc, &c, 1) != 1) {
                     free(record_buffer);
                     session_fclose(session, fp);
                     return handle_error(session, ERR_IO, "Error reading data");
@@ -2869,9 +2869,9 @@ int datasetCreateHandler(Session *session)
 
 				/* Read chunk size line (ASCII hex + CRLF) */
 				while (i < (int)sizeof(chunk_hdr) - 1) {
-					if (recv(session->httpc->socket, &c, 1, 0) != 1) break;
+					if (receive_raw_data(session->httpc, &c, 1) != 1) break;
 					if (c == 0x0D) {	/* ASCII CR */
-						recv(session->httpc->socket, &c, 1, 0); /* LF */
+						receive_raw_data(session->httpc, &c, 1); /* LF */
 						break;
 					}
 					chunk_hdr[i++] = c;
@@ -2885,14 +2885,14 @@ int datasetCreateHandler(Session *session)
 				if (chunk_size == 0) {
 					/* Read trailing CRLF */
 					char crlf[2];
-					recv(session->httpc->socket, crlf, 2, 0);
+					receive_raw_data(session->httpc, crlf, 2);
 					break;
 				}
 
 				/* Read chunk data */
 				n = 0;
 				while (n < chunk_size) {
-					int r = recv(session->httpc->socket, local_body + body_size + n, 1, 0);
+					int r = receive_raw_data(session->httpc, local_body + body_size + n, 1);
 					if (r != 1) break;
 					n++;
 					if (body_size + n >= sizeof(local_body) - 1) break;
@@ -2902,7 +2902,7 @@ int datasetCreateHandler(Session *session)
 				/* Read chunk trailing CRLF */
 				{
 					char crlf[2];
-					recv(session->httpc->socket, crlf, 2, 0);
+					receive_raw_data(session->httpc, crlf, 2);
 				}
 			}
 		} else if (cl) {
@@ -2912,8 +2912,8 @@ int datasetCreateHandler(Session *session)
 				content_length = sizeof(local_body) - 1;
 
 			while (body_size < content_length) {
-				int r = recv(session->httpc->socket,
-					local_body + body_size, 1, 0);
+				int r = receive_raw_data(session->httpc,
+					local_body + body_size, 1);
 				if (r != 1) break;
 				body_size++;
 			}

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2178,6 +2178,75 @@ curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${ATOM_SEQ}" >/dev/
 curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${ATOM_PDS}" >/dev/null 2>&1 || true
 rm -f /tmp/curl_ds_atom_good.txt /tmp/curl_ds_atom_long.txt
 
+# =========================================================================
+# A client slower than the server must not fail the write (issue #247)
+# =========================================================================
+echo ""
+echo "--- Slow and Expect: 100-continue clients (issue #247) ---"
+
+SLOW_SEQ="${MVSMF_USER}.CURL.SLOWSEQ"
+
+# Deliberately NO -H "Expect:" in this section. Every other PUT in this suite
+# suppresses that header, and that workaround is exactly what hid #247 for so
+# long -- these two cases exist to keep it visible.
+#
+# Both provoke the same thing: an empty socket receive buffer at a moment the
+# handler wants a byte. httpd's sockets are non-blocking, so recv() answers
+# EWOULDBLOCK at once, and mvsMF used to read that as "client gone" and abandon
+# the write with 500 -- over a target already open for output.
+
+curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}" >/dev/null 2>&1 || true
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	-d '{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":3120,"alcunit":"TRK","primary":5,"secondary":5}' \
+	"${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}")
+
+if [ "$HTTP_CODE" = "201" ]; then
+	# 800 records = 64 KB, comfortably more than the socket receive buffer
+	awk 'BEGIN { while (i++ < 800) printf "%-79s\n", "SLOW CLIENT RECORD " i }' \
+		> /tmp/curl_ds_slow.txt
+
+	# --- a body arriving slower than mvsMF consumes it (~130 KB/s) ---
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+		-H "X-IBM-Data-Type: text" --limit-rate 32k \
+		--data-binary @/tmp/curl_ds_slow.txt \
+		"${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}")
+	assert_http_status "204" "$HTTP_CODE" "slow client: throttled PUT succeeds"
+
+	RECS=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}" | grep -c .)
+	if [ "$RECS" = "800" ]; then
+		pass "slow client: all 800 records written"
+	else
+		fail "slow client: all 800 records written" "got ${RECS}"
+	fi
+
+	# --- Expect: 100-continue, the header curl adds by itself above 1 MB ---
+	# Set explicitly so the case stays cheap: curl honours a manual header the
+	# same way, holding the body back until an interim response arrives or its
+	# 1 s expect100 timeout expires. Either way the handler's first read finds
+	# an empty buffer, which is #247 at byte zero.
+	printf 'EXPECT LINE ONE\nEXPECT LINE TWO\n' > /tmp/curl_ds_expect.txt
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+		-H "X-IBM-Data-Type: text" -H "Expect: 100-continue" \
+		--data-binary @/tmp/curl_ds_expect.txt \
+		"${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}")
+	assert_http_status "204" "$HTTP_CODE" "Expect: 100-continue PUT succeeds"
+
+	RECS=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}" | grep -c .)
+	if [ "$RECS" = "2" ]; then
+		pass "Expect: 100-continue: body written in full"
+	else
+		fail "Expect: 100-continue: body written in full" "expected 2 records, got ${RECS}"
+	fi
+else
+	fail "slow client" "could not create ${SLOW_SEQ}"
+fi
+
+curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}" >/dev/null 2>&1 || true
+rm -f /tmp/curl_ds_slow.txt /tmp/curl_ds_expect.txt
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"


### PR DESCRIPTION
Fixes #247.

## What the issue got right, and what it understated

The correlation in #247 is real: `Expect: 100-continue` fails every time, and
suppressing the header fixes it. The issue flags the mechanism inside the read
as unestablished and worth pinning down before assuming a fix. It was worth it —
the mechanism turns out to be wider than the header.

httpd sets every accepted socket non-blocking (`FIONBIO`, `httpd.c:719`), so a
`recv()` that finds the receive buffer empty returns `-1`/`EWOULDBLOCK`
*immediately*. All 22 `recv()` calls in `dsapi.c` treated that as a fatal read
error. An empty buffer mid-body does not mean the client is gone — it means the
next byte has not arrived yet.

mvsMF consumes a text body at about 130 KB/s, so **any client slower than that**
drains the buffer within the first second. Measured on mvsdev, 240 KB, `Expect:`
suppressed, well under curl's 1 MB threshold:

| Rate | Result |
|---|---|
| full | 204 (1.8 s → ~133 KB/s) |
| 200 KB/s | 204 |
| **100 KB/s** | **500 after 0.64 s** |
| **50 KB/s** | **500 after 1.00 s** |

The data set was left with 816 of 3000 records — the destruction half of #246,
reachable with no `Expect` header anywhere in sight. `Expect: 100-continue` is
one instance of this bug, not its cause: it makes the buffer empty at byte zero
instead of halfway through.

## Why 100 Continue alone would not have fixed it

The interim response and the client's first data segment are a round trip apart.
Send the 25 bytes, call `recv()` microseconds later, and the buffer is still
empty — the same 500, one RTT later. The wait is what carries the read across
the gap, and it is what this PR adds. httpd sends the interim response in
mvslovers/httpd#207; the two halves are independent and this one stands alone.

## The change

`receive_raw_data()` has always had the EWOULDBLOCK wait — it just was not
reachable from `dsapi.c`. It is exported **unchanged** (the ring-buffer
workaround is untouched, only `static` is dropped) and now serves the byte and
CRLF reads. `receive_raw_some()` is new and gives the four bulk binary reads the
same budget without changing their granularity: they have always read up to one
LRECL per call, and turning them byte-at-a-time would be a throughput change
dressed up as a bug fix. Budget is 200 × 50 ms = 10 s without a single byte,
the same one `send_all()` spends on a stalled send.

## Tests

Two cases in `tests/curl-datasets.sh`, both of which deliberately **do not**
pass `-H "Expect:"` — every other PUT in that suite does, and that workaround is
what kept this invisible:

- a 64 KB body at `--limit-rate 32k`, which starves the buffer with no `Expect`
  header at all
- an explicit `-H "Expect: 100-continue"` on a two-line body. curl honours a
  manually set header the same way it honours its own, holding the body back for
  its 1 s `expect100-timeout` — verified against a local listener that answers
  nothing: first body byte at exactly 1.00 s. That keeps the case cheap: no
  1.4 MB fixture needed to reproduce #247.

Both fail against the current build and need the deployed module to pass, so
they are the live check for this PR.

## Verified on mvsdev

Build `095c29e` deployed and activated (`fn=version` confirms it), with httpd
still **not** answering the expectation — so this is the mvsMF half standing on
its own:

| Case | Before | After |
|---|---|---|
| 240 KB @ 200 KB/s, no `Expect` | 204 | 204 (1.9 s) |
| 240 KB @ 100 KB/s, no `Expect` | **500 after 0.64 s**, 816/3000 records | 204 (2.3 s), 3000 records |
| 240 KB @ 50 KB/s, no `Expect` | **500 after 1.00 s**, 816/3000 records | 204 (4.7 s), 3000 records |
| 1.44 MB, curl adds `Expect` itself — the #247 repro | **500 after 0.12 s** | 204 (12.2 s), 18000 records |
| explicit `Expect: 100-continue`, 2 lines | **500** | 204 (1.05 s), 2 records |

The 1.05 s on the last row is curl's `expect100-timeout`, i.e. mvslovers/httpd#208
still outstanding. It disappears once httpd sends the interim response; the
upload already succeeds without it.

Suites, all against the deployed build: `curl-datasets.sh` 195/195,
`curl-binary.sh` 10/10, `curl-uss.sh` 128/128, `curl-jobs.sh` 111/111 + 2
skipped. The atomicity cases in `curl-datasets.sh` matter here specifically —
they PUT a `Content-Length` and then close the sending half, and they still pass,
so the new wait has not blurred an orderly close into a stall.

## Two tradeoffs stated rather than left to be discovered

**The budget is per stall, not per request.** `retries` resets on every byte, so
a client dribbling one byte every 9 s holds its worker — and mid-body an open
DCB on the target — for as long as it keeps dribbling. That is the unavoidable
price of waiting for slow clients at all; the bound on it is httpd's client
timeout, not this loop. Given the #199/#217 history with held workers it should
be a stated cost, not a surprise.

**`MSG_RECV_TIMEOUT`'s reach widened** from the four `read_request_content()`
callers to every data set PUT. It stays: a ten second silence mid-request is an
operator-visible symptom of exactly the kind #217 taught us to watch for, it is
self-limiting at one WTO per 10 s per stuck request so it cannot flood
`/restconsoles` the way a client-caused 404 loop can, and `MSG_SEND_TIMEOUT` is
already the same policy on the send side. Dropping it would be a catalog-level
decision about both directions, not a side effect of this fix.

Final build `968db13` deployed and re-verified: `curl-datasets.sh` 195/195.

## Both halves now measured together

mvslovers/httpd#208 has since been built, deployed and activated on mvsdev, so
the second half is live too. What that adds on top of the numbers above:

| | mvsMF fix only | + httpd#208 |
|---|---|---|
| PUT, explicit `Expect: 100-continue` | 204 in 1.05 s | 204 in **0.068 s** |
| PUT 1.44 MB, curl adds `Expect` itself | 204 in 12.2 s, 18000 records | 204 in 11.1 s, 18000 records |

The second is the original #247 repro. The ~1 s that disappears in both rows is
curl's `expect100-timeout`, which this PR made survivable and httpd#208 makes
unnecessary.

Full regression against both changes deployed: `curl-datasets.sh` 195/195,
`curl-binary.sh` 10/10, `curl-uss.sh` 128/128, `curl-jobs.sh` 111/111 + 2
skipped, `curl-console.sh` 64/64.
