### PR TITLE
Authorize dataset access explicitly instead of relying on the ambient OPEN check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,10 @@ MBT_MVS_DEPS_HLQ=IBMUSER.DEPS
 # JES settings
 MBT_JES_JOBCLASS=A
 MBT_JES_MSGCLASS=H
+
+# Optional: an ordinary (non-admin) userid.
+# The dataset suite's authorization tests need one -- an admin is permitted for
+# almost every attribute, so a READ or UPDATE refusal is unreachable with it and
+# those paths go untested. Leave unset to skip that section.
+MVSMF_USER2=
+MVSMF_PASS2=

--- a/docs/endpoints/datasets/authorization.md
+++ b/docs/endpoints/datasets/authorization.md
@@ -1,0 +1,75 @@
+# Authorization (data set endpoints)
+
+Every data set endpoint makes an explicit RACF decision before it touches
+anything. Before issue #228 the decision happened by accident, inside OPEN,
+under whatever ACEE the address space held at the time; now the operation is
+authorized against the caller's own identity first, and the open is a second
+net rather than the only one.
+
+## Attribute per operation
+
+The class is always `DATASET`. A member operation is authorized on the
+**library**, never on `DSN(MEMBER)`: RACF profiles cover data sets, and there is
+no member-level profile to ask about.
+
+| Endpoint | Operation | Resource | Attribute |
+|---|---|---|---|
+| `GET /ds/{dsn}` | read a sequential data set | the data set | READ |
+| `GET /ds/{dsn}/member` | list members | the library | READ |
+| `GET /ds/{dsn}({mbr})` | read a member | the library | READ |
+| `PUT /ds/{dsn}` | write a sequential data set | the data set | UPDATE |
+| `PUT /ds/{dsn}({mbr})` | write a member | the library | UPDATE |
+| `PUT /ds/{dsn}({mbr})` + `request:rename` | rename a member | the library | UPDATE |
+| `PUT /ds/{dsn}` + `request:rename` | rename a data set | **both names** | ALTER |
+| `DELETE /ds/{dsn}({mbr})` | delete a member (STOW) | the library | UPDATE |
+| `DELETE /ds/{dsn}` | uncatalog and scratch | the data set | ALTER |
+
+A data set rename checks the **source and the target**. Checking only the source
+would let a caller with ALTER over their own qualifier move a data set into a
+namespace they have no authority over.
+
+## Not authorized here
+
+- `GET /zosmf/restfiles/ds?dslevel=` — the listing reads the catalog and the
+  VTOC and opens nothing, so it has no check at all. That is deliberate and
+  matches the reference implementation; see issue #229 and the *Authorization*
+  section of `CLAUDE.md`.
+- `POST /zosmf/restfiles/ds/{dsn}` — allocation goes through SVC 99 rather than
+  an open. It is gated only by whatever the allocation itself enforces.
+
+## What a refusal looks like
+
+```
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/json
+
+{"rc":8,"category":4,"reason":0,"message":"LMOPEN error",
+ "details":["Authorization failed - You may not use this protected data set."]}
+```
+
+**500 is the conformant status, not 403.** Measured against a real z/OSMF
+(version 29 / z/OS 05.29.00): a read of a data set the caller may not open
+answers 500 with `category 4`, `rc 8`, `reason 0` and the explanation in
+`details[]`. 403 is absent from the z/OSMF status list *and* is not what the
+reference sends. `category 4` here is measured rather than documented.
+
+The reference's own `details[]` text ends `Open 913 abend.`, because OPEN is what
+refused it. mvsMF refuses before the open, so it stops one clause earlier — it
+does not claim an abend it did not take. The variant that *does* carry the abend
+belongs to the recovery path (#315).
+
+## The refusal is decided before existence
+
+Every check runs ahead of the operation's first catalog or VTOC access —
+including ahead of the `is_pds()` probe on the read and write paths. A caller who
+may not touch a name therefore gets the same answer whether or not it exists, so
+the check cannot be used to enumerate. A 404 from these endpoints always means
+"you were allowed to ask, and it is not there".
+
+## Console
+
+A refused request writes **nothing** to the console. RAKF logs `RAKF0005` for a
+denial it catches inside OPEN, but not for the RACHECK this pre-check issues, and
+mvsMF does not add a message of its own: a client polling a denied endpoint would
+turn one refusal into a flood, which its own console API would then serve back
+(see *Operator Messages* in `CLAUDE.md`).

--- a/docs/endpoints/datasets/authorization.md
+++ b/docs/endpoints/datasets/authorization.md
@@ -28,6 +28,41 @@ A data set rename checks the **source and the target**. Checking only the source
 would let a caller with ALTER over their own qualifier move a data set into a
 namespace they have no authority over.
 
+## What RAKF actually grants (measured, both distributions)
+
+The attribute column above is only half the picture; the other half is what the
+security manager answers. On MVS 3.8j that is RAKF, and its shipped profile set
+is nearly identical on MVS/CE and TK5:
+
+```
+DATASET *                     READ        <- everyone, on everything
+DATASET *          ADMIN      ALTER
+DATASET *          STCGROUP   ALTER
+DATASET SYS1.SECURE.*         NONE        (RAKFADM: UPDATE)
+...
+```
+
+Read that table on its own and you conclude that an ordinary user cannot write
+anywhere, and that adding an UPDATE check would break every non-admin write.
+**That conclusion is wrong**, and the reason is not in the table: RAKF grants a
+user full access to data sets under their own userid implicitly, with no profile
+line for it. Measured — `MVSCE02` gets READ, UPDATE *and* ALTER on
+`MVSCE02.TEST.DATA`, while getting READ-only on `IBMUSER.*` and `SYS1.PARMLIB`,
+and nothing at all on `SYS1.SECURE.*`.
+
+Practical consequences when reasoning about these checks:
+
+- An **admin** userid is nearly useless for testing a refusal: `ADMIN`/`RAKFADM`
+  hold ALTER through the generic profile, so only `SYS1.SECURE.*` (where RAKFADM
+  is capped at UPDATE) can refuse anything, and only for ALTER.
+- An **ordinary** userid is the one that exercises READ and UPDATE refusals.
+  `MVSMF_USER2`/`MVSMF_PASS2` in `.env` enable that section of
+  `tests/curl-datasets.sh`.
+- RAKF resolution is **not** "most specific wins": a universal `NONE` line is
+  overridden by a group grant from the *generic* profile, while a group line on
+  the specific profile does bind. Matching is by group membership across
+  profiles.
+
 ## Not authorized here
 
 - `GET /zosmf/restfiles/ds?dslevel=` — the listing reads the catalog and the

--- a/docs/endpoints/datasets/create.md
+++ b/docs/endpoints/datasets/create.md
@@ -37,6 +37,13 @@ On successful completion, this request returns HTTP status code 201 (Created).
 - HTTP 500 (Internal Server Error)
     - Dataset allocation failed (e.g. dataset already exists, no space)
 
+## Authorization
+
+**No explicit check.** Allocation goes through SVC 99 rather than an open, so it
+was not part of the pre-check work in issue #228 and is gated only by whatever
+the allocation itself enforces. It is the one data set-mutating operation without
+an explicit check. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/delete.md
+++ b/docs/endpoints/datasets/delete.md
@@ -27,6 +27,16 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 - HTTP 500 (Internal Server Error)
     - Delete operation failed
 
+## Authorization
+
+Requires **ALTER** on the data set in class `DATASET` (issue #228). The check runs
+before any catalog, VTOC or data set access, so a refusal is indistinguishable
+from "does not exist".
+
+A refusal answers **HTTP 500** with `category 4`, `rc 8`, `reason 0` and the
+explanation in `details[]` — the shape a real z/OSMF sends; 403 is not a z/OSMF
+status. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/get.md
+++ b/docs/endpoints/datasets/get.md
@@ -50,6 +50,16 @@ On successful completion, this request returns HTTP status code 200 (OK) with th
 - Binary/record mode for FB datasets uses DSCB-based record count calculation to determine exact end-of-data
 - Binary/record mode for PDS members reads until fread returns 0 (no DSCB-based limit)
 
+## Authorization
+
+Requires **READ** on the data set in class `DATASET` (issue #228). The check runs
+before any catalog, VTOC or data set access, so a refusal is indistinguishable
+from "does not exist".
+
+A refusal answers **HTTP 500** with `category 4`, `rc 8`, `reason 0` and the
+explanation in `details[]` — the shape a real z/OSMF sends; 403 is not a z/OSMF
+status. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/list.md
+++ b/docs/endpoints/datasets/list.md
@@ -82,6 +82,15 @@ Entries skipped by `start` are not charged against `X-IBM-Max-Items`, and
 - Only NONVSAM datasets are listed
 - `*` and `**` wildcards are treated identically (both match any number of qualifiers)
 
+## Authorization
+
+**None.** This listing reads the catalog and the VTOC and opens nothing, so no
+RACF check is reached: any authenticated caller can enumerate any qualifier.
+
+That is deliberate and matches the reference — real z/OSMF lists a data set the
+same userid cannot open, and z/OS does not gate `LISTCAT LEVEL()` per entry
+either. See issue #229 and [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/members-delete.md
+++ b/docs/endpoints/datasets/members-delete.md
@@ -29,6 +29,16 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 - HTTP 500 (Internal Server Error)
     - Delete operation failed
 
+## Authorization
+
+Requires **UPDATE** on the library in class `DATASET` (issue #228). The check runs
+before any catalog, VTOC or data set access, so a refusal is indistinguishable
+from "does not exist".
+
+A refusal answers **HTTP 500** with `category 4`, `rc 8`, `reason 0` and the
+explanation in `details[]` — the shape a real z/OSMF sends; 403 is not a z/OSMF
+status. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/members-get.md
+++ b/docs/endpoints/datasets/members-get.md
@@ -112,6 +112,16 @@ now told apart by a catalog lookup and a filtered directory read.
 ## Limitations
 - Binary/record mode: no DSCB-based record count limit (reads until fread returns 0). This works correctly for PDS members but may include padding for the last block.
 
+## Authorization
+
+Requires **READ** on the library in class `DATASET` (issue #228). The check runs
+before any catalog, VTOC or data set access, so a refusal is indistinguishable
+from "does not exist".
+
+A refusal answers **HTTP 500** with `category 4`, `rc 8`, `reason 0` and the
+explanation in `details[]` — the shape a real z/OSMF sends; 403 is not a z/OSMF
+status. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -147,6 +147,16 @@ curl -H 'X-IBM-Max-Items: 2' \
 ## Limitations
 - No member statistics (TTR, size, dates) are returned yet
 
+## Authorization
+
+Requires **READ** on the library in class `DATASET` (issue #228). The check runs
+before any catalog, VTOC or data set access, so a refusal is indistinguishable
+from "does not exist".
+
+A refusal answers **HTTP 500** with `category 4`, `rc 8`, `reason 0` and the
+explanation in `details[]` — the shape a real z/OSMF sends; 403 is not a z/OSMF
+status. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/members-put.md
+++ b/docs/endpoints/datasets/members-put.md
@@ -124,6 +124,16 @@ from the dataset's own DCB (LRECL, or BLKSIZE for RECFM=U). Records above
 1024 bytes used to overrun a fixed stack buffer and abend the handler
 (issue #198) — the binary path was affected as well as text.
 
+## Authorization
+
+Requires **UPDATE** on the library in class `DATASET` (issue #228). The check runs
+before any catalog, VTOC or data set access, so a refusal is indistinguishable
+from "does not exist".
+
+A refusal answers **HTTP 500** with `category 4`, `rc 8`, `reason 0` and the
+explanation in `details[]` — the shape a real z/OSMF sends; 403 is not a z/OSMF
+status. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/docs/endpoints/datasets/put.md
+++ b/docs/endpoints/datasets/put.md
@@ -93,6 +93,16 @@ from the dataset's own DCB (LRECL, or BLKSIZE for RECFM=U). Records above
 1024 bytes used to overrun a fixed conversion buffer and abend the handler
 (issue #198).
 
+## Authorization
+
+Requires **UPDATE** on the data set (ALTER on both names for a rename) in class `DATASET` (issue #228). The check runs
+before any catalog, VTOC or data set access, so a refusal is indistinguishable
+from "does not exist".
+
+A refusal answers **HTTP 500** with `category 4`, `rc 8`, `reason 0` and the
+explanation in `details[]` — the shape a real z/OSMF sends; 403 is not a z/OSMF
+status. See [authorization.md](authorization.md).
+
 ## Examples
 
 ### Using curl

--- a/include/common.h
+++ b/include/common.h
@@ -76,6 +76,47 @@
 #define RC_AUTH    12   /**< Authorization error */
 #define RC_SEVERE  16   /**< Severe error */
 
+/** @brief The z/OSMF error report for an authorization refusal (#228, #315)
+ *
+ * Measured against a real z/OSMF (version 29 / z/OS 05.29.00): a member read of
+ * a data set the caller may not open answers
+ *
+ *   500 {"category":4,"rc":8,"reason":0,"message":"LMOPEN error",
+ *        "details":["ISRZ002 Authorization failed - You may not use this
+ *                    protected data set. Open 913 abend."]}
+ *
+ * So 500 is the conformant status for a denial and always was -- 403 is wrong
+ * twice over, being absent from the z/OSMF list (#250) and not what the
+ * reference sends. The status is the one field mvsMF already had right.
+ *
+ * `category 4` is MEASURED, not documented. It is defined in neither
+ * zosmferr.h nor jobsapi_msg.h, and those two already disagree with each other
+ * (CATEGORY_VSAM 3 vs 7, CATEGORY_UNEXPECTED 7 vs 8), so do not promote it to a
+ * general "authorization category" on the strength of one observation.
+ *
+ * The reason stays the reference's 0 rather than becoming a project-specific
+ * code: fidelity is the point, and the distinction the project would otherwise
+ * carry in `reason` is in `details[]` here, which is where the reference puts
+ * it. The name exists for readability, not to introduce a new code.
+ *
+ * `message` is the reference's string verbatim. `ISRZ002` is deliberately NOT
+ * reproduced -- it is an ISPF message id, and mvsMF runs no ISPF library
+ * management, so quoting it would name a component that is not there.
+ */
+#define CATEGORY_AUTHORIZATION 4
+#define REASON_NOT_AUTHORIZED  0
+#define ERR_MSG_NOT_AUTHORIZED "LMOPEN error"
+
+/** Default `details[]` sentence for a refusal caught by a pre-check.
+ *
+ * The reference's own text ends "Open 913 abend." -- true for it, since OPEN is
+ * what refused. A pre-check that answers before the fopen() has taken no abend,
+ * so it stops one clause earlier. #315 supplies the abend-carrying variant for
+ * the ESTAE path.
+ */
+#define ERR_MSG_DENIED_DETAIL \
+	"Authorization failed - You may not use this protected data set."
+
 /**
  * @brief Gets a query parameter from the request URL
  *
@@ -226,6 +267,26 @@ int send_not_modified(Session *session, const char *etag) asm("CMN0013");
  * @return 0 when everything was sent, -1 otherwise
  */
 int send_all(Session *session, const UCHAR *buf, int len) asm("CMN0014");
+
+/**
+ * @brief Answers a request refused by an authorization check (issue #228)
+ *
+ * Sends the z/OSMF error report a denial produces -- see
+ * CATEGORY_AUTHORIZATION above for the measurement it mirrors.
+ *
+ * It lives here rather than in dsapi.c because the same body has a second
+ * producer: #315 maps the router's S913 ESTAE recovery onto it, so a denial
+ * caught by OPEN and one refused by a pre-check answer identically. Two copies
+ * would drift, and a client would see two bodies for one condition.
+ *
+ * @param session The session
+ * @param detail  One sentence for the `details[]` array, or NULL for the
+ *                default. It must not claim an abend the caller did not take:
+ *                the reference always reaches the S913 and says so, a
+ *                pre-check that refuses first has not.
+ * @return 0 on success, negative on send failure
+ */
+int send_not_authorized(Session *session, const char *detail) asm("CMN0015");
 
 /**
  * @brief Reads the full request body into a malloc'd buffer

--- a/include/json.h
+++ b/include/json.h
@@ -114,6 +114,18 @@ int addJsonRaw(JsonBuilder *builder, const char *key, const char *raw)		asm("JSO
 int startJsonArrayKey(JsonBuilder *builder, const char *key)				asm("JSON00D");
 
 /**
+ * @brief Adds a bare string element to an open array (no key).
+ *
+ * The keyed adders above cannot produce an array of plain strings -- every one
+ * of them emits "key":value -- and the arrays this builder emitted until now
+ * held objects, which startJsonObject() handles. An error report's "details"
+ * is an array of sentences, so it needs this.
+ *
+ * Escapes as addJsonStringEsc() does; a NULL value emits null.
+ */
+int addJsonArrayString(JsonBuilder *builder, const char *value)				asm("JSON00E");
+
+/**
  * @brief Starts a new JSON object
  *
  * Adds an opening brace and prepares for object members.

--- a/src/common.c
+++ b/src/common.c
@@ -181,10 +181,29 @@ sendErrorResponse(Session *session, int status, int category, int rc,
 		}
 	}
 
+	/* "details" is an ARRAY of sentences, which is what z/OSMF sends and what
+	 * a client parses. It used to be emitted as a bare string, and only
+	 * because no caller had ever passed one -- the parameter had zero users
+	 * until #228. Emitting details[0] as a string would have shipped a shape
+	 * no reference response has. */
 	if (details && details_count > 0) {
-		irc = addJsonString(builder, "details", details[0]);
+		int i;
+
+		irc = startJsonArrayKey(builder, "details");
 		if (irc < 0) {
-		goto quit;
+			goto quit;
+		}
+
+		for (i = 0; i < details_count; i++) {
+			irc = addJsonArrayString(builder, details[i]);
+			if (irc < 0) {
+				goto quit;
+			}
+		}
+
+		irc = endArray(builder);
+		if (irc < 0) {
+			goto quit;
 		}
 	}
 
@@ -223,6 +242,30 @@ send_not_modified(Session *session, const char *etag)
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) return rc;
 
 	return rc;
+}
+
+/* The z/OSMF error report for an authorization refusal (issue #228).
+ *
+ * The shape is measured, not designed -- see CATEGORY_AUTHORIZATION in
+ * common.h. The one field mvsMF already had right is the status: 500 is what
+ * the reference answers, because the reference takes the same S913 OPEN abend
+ * and says so in its own details[] text.
+ *
+ * `detail` is the caller's, because the two producers of this body cannot claim
+ * the same thing. The reference always reaches the abend; a pre-check that
+ * refuses before the fopen() has not abended, and must not say it did.
+ */
+__asm__("\n&FUNC    SETC 'send_not_authorized'");
+int
+send_not_authorized(Session *session, const char *detail)
+{
+	const char *details[1];
+
+	details[0] = detail ? detail : ERR_MSG_DENIED_DETAIL;
+
+	return sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+			CATEGORY_AUTHORIZATION, RC_ERROR, REASON_NOT_AUTHORIZED,
+			ERR_MSG_NOT_AUTHORIZED, details, 1);
 }
 
 //

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -10,6 +10,7 @@
 #include <clibio.h>
 #include <osdcb.h>
 #include <errno.h>
+#include <racf.h>
 
 #include "dsapi.h"
 #include "dsapi_err.h"
@@ -53,6 +54,61 @@ static int dataset_etag(Session *session, const char *dataset,
                         long max_records, char *out, size_t outlen);
 static int check_if_match(Session *session, const char *dataset,
                           long max_records);
+static int require_access(Session *session, const char *dsname, int attr);
+
+/* Authorization gate for a data set operation (issue #228).
+ *
+ * Every operation in this file used to authorize by accident: it ends in an
+ * fopen()/remove()/rename(), and OPEN performs a RACF check under whatever ACEE
+ * sits in ASXBSENV. That gate is real -- measured, RAKF refuses with RAKF0005
+ * and an S913 -- but the field is address-space-wide, so the identity it runs
+ * under is shared between httpd's workers and outlives an abend
+ * (mvslovers/httpd#176). http_check_auth() passes the caller's own ACEE in the
+ * parameter list to racf_auth(), which serializes set/RACHECK/restore under
+ * lock(asxb), so the decision here is race-free whatever another worker is
+ * doing to ASXBSENV.
+ *
+ * It closes ONE direction, and knowing which matters when reading this. If
+ * ASXBSENV holds a MORE privileged identity, OPEN permits what the caller may
+ * not have -- nothing catches that today, and this does. If it holds a LESS
+ * privileged one, OPEN refuses an entitled caller and the request abends; this
+ * said yes, so that case is unchanged. And because a denial leaves the client's
+ * ACEE behind (httpd#176), every denial today seeds the first case -- which is
+ * why refusing before the abend is worth more than the wire-level tidiness.
+ *
+ * The resource is the DATASET profile name. For a member operation that is the
+ * PDS, never dsname(member): RACF profiles cover data sets, and there is no
+ * member granularity to ask for.
+ *
+ * Returns 0 when permitted. On refusal the response has already been sent and
+ * the caller must return without touching the data set.
+ */
+__asm__("\n&FUNC    SETC 'require_access'");
+static int require_access(Session *session, const char *dsname, int attr)
+{
+    int rc = http_check_auth(session->httpc, "DATASET", dsname, attr);
+
+    /* The contract is 0 = permitted, 8 and up = refused, -1 = unauthenticated,
+     * with SAF rc 4 ("no profile covers the resource") normalized to 0 by
+     * httpd. Both non-zero cases are spelled out on purpose: `rc != 0` would
+     * report an unauthenticated request as a permission problem, and the
+     * natural widened idiom `rc <= 4` would read -1 as ALLOWED. */
+    if (rc == 0) {
+        return 0;
+    }
+
+    if (rc < 0) {
+        /* Unreachable by construction -- identity_middleware answers 401 for a
+         * request with no resolved ACEE before any handler runs. Handled anyway
+         * so a future change to that gate cannot turn "no identity" into
+         * "identity refused". */
+        return sendErrorResponse(session, HTTP_STATUS_UNAUTHORIZED,
+            CATEGORY_AUTHORIZATION, RC_ERROR, REASON_NOT_AUTHORIZED,
+            ERR_MSG_NOT_AUTHORIZED, NULL, 0);
+    }
+
+    return send_not_authorized(session, NULL);
+}
 
 // Helper function for HTTP headers
 //
@@ -1299,6 +1355,18 @@ int datasetGetHandler(Session *session)
         return handle_error(session, ERR_INVALID_PARAM, "Dataset name is required");
     }
 
+    /* Authorize before anything looks at the data set (issue #228).
+       Ahead of is_pds(), not after it: is_pds() reads the catalog and the VTOC
+       (__locate + __dscbdv), so gating later would let a caller without READ
+       tell a PDS from a sequential or absent name by whether the answer is 400
+       or the refusal -- the same existence oracle the delete and rename paths
+       close by checking before their __locate().
+       Also ahead of the ETag work, because dataset_etag() opens the data set to
+       hash it, and a check after that is a check after the first read. */
+    if (require_access(session, dsname, RACF_ATTR_READ) != 0) {
+        return 0;
+    }
+
     // Reject PDS - this endpoint is for sequential datasets only
     if (is_pds(dsname)) {
         return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
@@ -1398,6 +1466,15 @@ int datasetPutHandler(Session *session)
         if (ct && strstr(ct, "application/json") != NULL) {
             return process_rename(session, dsname, NULL);
         }
+    }
+
+    /* Authorize the write once, here (issue #228). Two read-opens follow before
+       the output open -- the existence probe that keeps fopen("w") from
+       auto-allocating with the wrong DCB (#65), and check_if_match()'s ETag
+       hash -- and neither is an operation of its own, so neither gets a READ
+       check of its own. One request, one decision. */
+    if (require_access(session, dsname, RACF_ATTR_UPDATE) != 0) {
+        return 0;
     }
 
     // Reject PDS - this endpoint is for sequential datasets only
@@ -2021,6 +2098,15 @@ int memberListHandler(Session *session)
 		goto quit;
 	}
 
+	/* Authorize before the directory is read (issue #228). This listing is
+	   unlike the dslevel one in #229: it opens the PDS with BPAM, so it has
+	   always been gated implicitly, and the explicit check replaces an accident
+	   rather than closing a hole. */
+	if (require_access(session, dsname, RACF_ATTR_READ) != 0) {
+		rc = 0;
+		goto quit;
+	}
+
 	method	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_METHOD");
 	path	= (char *) http_get_env(session->httpc, (const UCHAR *) "REQUEST_PATH");
 
@@ -2168,6 +2254,13 @@ int memberGetHandler(Session *session)
     // Create dataset path
     snprintf(dataset, sizeof(dataset), "%s(%s)", dsname, member);
 
+    /* Authorize on the PDS, not on dsname(member) (issue #228): RACF profiles
+       cover data sets, so a member read is READ on the library. Ahead of the
+       ETag work for the same reason as datasetGetHandler -- hashing opens. */
+    if (require_access(session, dsname, RACF_ATTR_READ) != 0) {
+        return 0;
+    }
+
     // Parse X-IBM-Data-Type header
     data_type_str = (char *) http_get_env(session->httpc,
         (const UCHAR *) "HTTP_X-IBM-Data-Type");
@@ -2259,6 +2352,12 @@ int memberPutHandler(Session *session)
         if (ct && strstr(ct, "application/json") != NULL) {
             return process_rename(session, dsname, member);
         }
+    }
+
+    /* UPDATE on the library (issue #228). Writing a member -- new or existing --
+       is an update of the PDS; there is no member-level profile to ask about. */
+    if (require_access(session, dsname, RACF_ATTR_UPDATE) != 0) {
+        return 0;
     }
 
     // Validate dsname and member individually (not combined — qualified form fits MAX_QUALIFIED_DSN)
@@ -2755,6 +2854,12 @@ process_rename(Session *session, const char *target_dsn,
 		}
 		free(body);
 
+		/* UPDATE on the library (issue #228): both the old and the new member
+		   are in target_dsn, so one check covers the whole STOW. */
+		if (require_access(session, target_dsn, RACF_ATTR_UPDATE) != 0) {
+			return 0;
+		}
+
 		rc = __renmem(target_dsn, from_member, target_member);
 		if (rc == 0) {
 			return sendDefaultHeaders(session, 204, "application/json", 0);
@@ -2787,6 +2892,19 @@ process_rename(Session *session, const char *target_dsn,
 				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
 		}
 		free(body);
+
+		/* ALTER on BOTH names (issue #228), before the locate so the 404 does
+		   not become an existence oracle for a caller who may not rename.
+		   The target is checked too, and not out of caution: gating only the
+		   source would let a caller with ALTER over their own qualifier move a
+		   data set INTO a namespace they have no authority over, which is an
+		   escalation the source check cannot see. */
+		if (require_access(session, from_dsn, RACF_ATTR_ALTER) != 0) {
+			return 0;
+		}
+		if (require_access(session, target_dsn, RACF_ATTR_ALTER) != 0) {
+			return 0;
+		}
 
 		// Verify the source data set exists
 		memset(dsn44, ' ', sizeof(dsn44));
@@ -2993,6 +3111,15 @@ int datasetDeleteHandler(Session *session)
 			ERR_MSG_INVALID_ALLOC_PARAMS, NULL, 0);
 	}
 
+	/* ALTER before the catalog is even consulted (issue #228). The order is
+	   deliberate: authorizing after the locate would make the 404 an existence
+	   oracle for anyone who may not delete the name -- they would learn whether
+	   it exists from which error came back. Authorizing first, a caller without
+	   ALTER learns nothing either way. */
+	if (require_access(session, dsname, RACF_ATTR_ALTER) != 0) {
+		return 0;
+	}
+
 	/* Check if dataset exists via catalog locate */
 	memset(dsn44, ' ', sizeof(dsn44));
 	memcpy(dsn44, dsname, strlen(dsname));
@@ -3044,6 +3171,14 @@ int memberDeleteHandler(Session *session)
 	}
 
 	snprintf(dataset, sizeof(dataset), "%s(%s)", dsname, member);
+
+	/* Deleting a member is a STOW against the directory, so UPDATE on the
+	   library -- not ALTER, which is the attribute for scratching the data set
+	   itself (issue #228). Before the existence probe, same oracle argument as
+	   datasetDeleteHandler. */
+	if (require_access(session, dsname, RACF_ATTR_UPDATE) != 0) {
+		return 0;
+	}
 
 	/* Verify member exists by attempting to open it */
 	fp = fopen(dataset, "r");

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -102,12 +102,20 @@ static int require_access(Session *session, const char *dsname, int attr)
          * request with no resolved ACEE before any handler runs. Handled anyway
          * so a future change to that gate cannot turn "no identity" into
          * "identity refused". */
-        return sendErrorResponse(session, HTTP_STATUS_UNAUTHORIZED,
+        sendErrorResponse(session, HTTP_STATUS_UNAUTHORIZED,
             CATEGORY_AUTHORIZATION, RC_ERROR, REASON_NOT_AUTHORIZED,
             ERR_MSG_NOT_AUTHORIZED, NULL, 0);
+    } else {
+        send_not_authorized(session, NULL);
     }
 
-    return send_not_authorized(session, NULL);
+    /* -1, NOT the send's return code. Both senders answer 0 when the response
+     * went out fine, so returning theirs would tell the caller "permitted" for
+     * every refusal that was successfully delivered -- the handler sends the
+     * refusal and then does the thing anyway. The client sees a correct 500,
+     * the data set is opened regardless, and the only trace is the S913 on the
+     * console. Measured exactly that way before this line existed. */
+    return -1;
 }
 
 // Helper function for HTTP headers

--- a/src/json.c
+++ b/src/json.c
@@ -244,6 +244,48 @@ addJsonStringEsc(JsonBuilder *builder, const char *key, const char *value)
 }
 
 int
+addJsonArrayString(JsonBuilder *builder, const char *value)
+{
+    const char *p;
+    char one[2];
+
+    if (!builder) {
+        return -1;
+    }
+
+    if (!builder->is_first) {
+        if (append_string(builder, ",") < 0) return -1;
+    }
+
+    if (!value) {
+        if (append_string(builder, "null") < 0) return -1;
+        builder->is_first = 0;
+        return 0;
+    }
+
+    /* Same piecewise escaping as addJsonStringEsc(), and for the same reason:
+     * no fixed temp buffer, so the element length is not capped. */
+    if (append_string(builder, "\"") < 0) return -1;
+    one[1] = '\0';
+    for (p = value; *p; p++) {
+        int rc;
+        switch (*p) {
+        case '"':  rc = append_string(builder, "\\\""); break;
+        case '\\': rc = append_string(builder, "\\\\"); break;
+        case '\r': rc = append_string(builder, "\\r");  break;
+        case '\n': rc = append_string(builder, "\\n");  break;
+        case '\t': rc = append_string(builder, "\\t");  break;
+        default:   one[0] = *p; rc = append_string(builder, one); break;
+        }
+        if (rc < 0) return -1;
+    }
+    if (append_string(builder, "\"") < 0) return -1;
+
+    builder->is_first = 0;
+    return 0;
+}
+
+int
 addJsonBool(JsonBuilder *builder, const char *key, int value)
 {
     if (!builder || !key) {

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -8,6 +8,7 @@
 #include <clibmtt.h>
 #include <clibppa.h>
 #include <clibwto.h>
+#include <racf.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,6 +23,12 @@
 #ifndef BUILD_ID
 #define BUILD_ID "unknown"     /* fallback if the generated header is absent */
 #endif
+
+/* fn=checkauth reply sentinels.  Kept out of the SAF rc range (0/4/8/12...) and
+ * out of http_check_auth()'s -1 so a probe answer is never ambiguous. */
+#define PROBE_NOT_RUN   (-901)  /* this call was not made for the given &via= */
+#define PROBE_NO_ACEE   (-902)  /* unauthenticated: nothing to check against */
+#define PROBE_BAD_ATTR  (-903)  /* unknown &attr=; nothing was called at all */
 
 /* --- fn=syslog diagnostic ----------------------------------------------
  * Probe whether we can read the system log (SYSLOG) off the JES2 spool from
@@ -1020,6 +1027,86 @@ int testHandler(Session *session) {
                      " \"first_close_rc\": %d }\n",
                      want, ok, open_rc, close_errors, first_close_rc);
 
+    /* --- fn=checkauth (issue #228) --------------------------------- */
+    /* First CGI consumer of httpd's http_check_auth() vector entry, and the
+     * measurement tool for #228's attribute column. It exists before any
+     * handler is gated, for two reasons that both fail late otherwise.
+     *
+     * The vector resolves into the RUNNING httpd (httpx is
+     * http_get_httpx(session->httpd)), so a live build older than the entry
+     * makes the macro dereference past what the server actually filled. That
+     * is an abend, not a link error, and `make deps` cannot see it -- the same
+     * shape as the httpstat() lesson.
+     *
+     * And the attribute a given operation needs is a claim about what RAKF
+     * enforces, not about what this code intends. RAKF is not RACF and is not
+     * in the mvslovers org; measuring what it answers beats proposing a table.
+     *
+     * &via=raw (the default) calls libc370's racf_auth() directly -- no vector,
+     * so it cannot be taken down by the half being verified -- and shows the
+     * UNNORMALIZED SAF rc, the only way to see rc 4 ("no profile covers this")
+     * as distinct from rc 0. &via=vector adds the httpd call; &via=both runs
+     * raw first so its answer is already on the wire if the vector call dies.
+     *
+     * Read-only: RACHECK answers a question, it changes nothing. A denial does
+     * write the security log entry RAKF writes for any refusal.
+     */
+  } else if (strcmp(fn, "checkauth") == 0) {
+    char *dsn =
+        (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_DSN");
+    char *cls =
+        (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_CLASS");
+    char *attrname =
+        (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_ATTR");
+    char *via =
+        (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_VIA");
+    ACEE *acee = http_get_acee(session->httpc);
+    int attr = RACF_ATTR_READ;
+    int raw_rc = PROBE_NOT_RUN;
+    int vec_rc = PROBE_NOT_RUN;
+
+    if (!dsn)
+      dsn = "SYS1.PARMLIB";
+    if (!cls)
+      cls = "DATASET";
+    if (!via)
+      via = "raw";
+    if (!attrname)
+      attrname = "read";
+
+    /* An unknown &attr= must not silently mean READ: racf_auth() maps an
+     * invalid value to ALTER, so a typo would measure the strictest attribute
+     * while the reply claimed the one that was asked for. */
+    if (strcmp(attrname, "read") == 0) {
+      attr = RACF_ATTR_READ;
+    } else if (strcmp(attrname, "update") == 0) {
+      attr = RACF_ATTR_UPDATE;
+    } else if (strcmp(attrname, "control") == 0) {
+      attr = RACF_ATTR_CONTROL;
+    } else if (strcmp(attrname, "alter") == 0) {
+      attr = RACF_ATTR_ALTER;
+    } else {
+      attr = PROBE_BAD_ATTR;
+    }
+
+    if (attr != PROBE_BAD_ATTR) {
+      if (strcmp(via, "raw") == 0 || strcmp(via, "both") == 0) {
+        raw_rc = acee ? racf_auth(acee, cls, dsn, attr) : PROBE_NO_ACEE;
+      }
+      if (strcmp(via, "vector") == 0 || strcmp(via, "both") == 0) {
+        vec_rc = http_check_auth(session->httpc, cls, dsn, attr);
+      }
+    }
+
+    rc = http_printf(session->httpc,
+                     "{ \"fn\": \"checkauth\", \"class\": \"%s\","
+                     " \"resource\": \"%s\", \"attr\": \"%s\","
+                     " \"attr_value\": %d, \"via\": \"%s\","
+                     " \"acee\": \"%s\","
+                     " \"racf_auth_rc\": %d, \"http_check_auth_rc\": %d }\n",
+                     cls, dsn, attrname, attr, via,
+                     acee ? "non-null" : "NULL", raw_rc, vec_rc);
+
     /* --- fn=help (default) ---------------------------------------- */
   } else {
     rc = http_printf(
@@ -1036,6 +1123,7 @@ int testHandler(Session *session) {
         " \"?fn=intrdr&n=1..25      (internal-reader open/close cycles, no records; libc370#115 bisect)\","
         " \"?fn=job&jobname=NAME    (raw JCT completion + JCTJTFLG bits per job; mvsmf#305)\","
         " \"?fn=userid              (http_get_userid() vs. direct ACEE decode)\","
+        " \"?fn=checkauth&dsn=DS&attr=read|update|control|alter&via=raw|vector|both  (RACHECK probe; mvsmf#228)\","
         " \"?fn=password&reveal=0|1 (http_get_password() export; reveal=1 = plaintext)\","
         " \"?fn=abend               (force S0C1 -> ESTAE recovery test; needs MVSMF_ABEND_TEST=1)\""
         " ] }\n");

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -134,6 +134,30 @@ assert_json_field_exists() {
 	fi
 }
 
+# Count handler-abend lines currently in the Master Trace Table.
+#
+# A refusal cannot be verified from its response. The response is correct
+# either way: the gate sends the 500 and then, if it fails to stop the handler,
+# the operation runs anyway and abends at OPEN. The client sees exactly the same
+# bytes. The only observable difference is the S913 on the console -- which is
+# how that bug was found, and why this exists.
+mtt_abend_count() {
+	curl -s -u "$AUTH" "${BASE_URL}/zosmf/test?fn=mtt&step=3" 2>/dev/null \
+		| grep -c "HANDLER ABEND" || true
+}
+
+assert_no_new_abend() {
+	local before="$1"
+	local label="$2"
+	local after
+	after=$(mtt_abend_count)
+	if [ "$after" = "$before" ]; then
+		pass "$label"
+	else
+		fail "$label" "handler abend lines went from ${before} to ${after}: the refusal was sent but the operation ran anyway"
+	fi
+}
+
 assert_json_field_absent() {
 	local json="$1"
 	local expr="$2"
@@ -2274,6 +2298,11 @@ echo "--- Authorization: refusal and its control (issue #228) ---"
 DENY_DS="SYS1.SECURE.NOSUCH"
 ALLOW_DS="${MVSMF_USER}.CURL.NOSUCH228"
 
+# The console baseline. Every refusal below has to leave it untouched: a gate
+# that sends the refusal and then performs the operation anyway is invisible in
+# the response and shows up only here.
+ABEND_BEFORE=$(mtt_abend_count)
+
 # 1. delete: ALTER refused
 RESP=$(curl -s -w '\n%{http_code}' -X DELETE -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${DENY_DS}")
@@ -2347,6 +2376,13 @@ else
 	fail "auth: the refusal is decided before existence is consulted" \
 		"denied=${DENY_CODE} permitted=${ALLOW_CODE}, expected 500 and 404 on two equally absent names"
 fi
+
+# 6. The one that response assertions cannot make: a refused request must not
+#    have done the thing. If the gate returns "permitted" for a delivered
+#    refusal -- which is what happens if it hands back the send's return code,
+#    since a successful send is 0 -- the handler carries on to the open, abends
+#    S913, and the client still sees the correct 500 above.
+assert_no_new_abend "$ABEND_BEFORE" "auth: a refused request performs no operation (no handler abend)"
 
 # --- Cleanup: delete PDS ---
 echo ""

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2247,6 +2247,107 @@ fi
 curl -s -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${SLOW_SEQ}" >/dev/null 2>&1 || true
 rm -f /tmp/curl_ds_slow.txt /tmp/curl_ds_expect.txt
 
+# =========================================================================
+# Authorization (issue #228)
+# =========================================================================
+#
+# Every check below has to come in a PAIR. A refusal on its own proves nothing:
+# a gate that always denies and a gate that works look identical from one
+# request, and a gate that never runs looks identical to a permitted answer.
+# Only the contrast shows that the decision is actually being made.
+#
+# The target is deliberately a name under SYS1.SECURE.* that DOES NOT EXIST.
+# RAKF gives RAKFADM only UPDATE there, so ALTER is refused even for an admin
+# id, which is what makes the refusal reachable with ordinary test credentials.
+# And because the name does not exist, a gate that wrongly permitted would fall
+# through to the catalog lookup and answer 404 -- nothing is ever scratched, so
+# the test cannot damage the security configuration it points at.
+#
+# NOT covered here, and not coverable as an admin: a READ or UPDATE refusal.
+# The generic profile is DATASET * READ with ALTER for ADMIN/STCGROUP, so an
+# admin id is permitted for every attribute except the SYS1.SECURE.* ALTER
+# above. Those two paths need a non-admin userid.
+
+echo ""
+echo "--- Authorization: refusal and its control (issue #228) ---"
+
+DENY_DS="SYS1.SECURE.NOSUCH"
+ALLOW_DS="${MVSMF_USER}.CURL.NOSUCH228"
+
+# 1. delete: ALTER refused
+RESP=$(curl -s -w '\n%{http_code}' -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${DENY_DS}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+CONTENT=$(echo "$RESP" | sed '$d')
+DENY_CODE="$HTTP_CODE"
+assert_http_status "500" "$HTTP_CODE" "auth: delete without ALTER is refused"
+assert_json_field "$CONTENT" '.category' "4" "auth: refusal category"
+assert_json_field "$CONTENT" '.rc' "8" "auth: refusal rc"
+assert_json_field "$CONTENT" '.reason' "0" "auth: refusal reason"
+assert_json_field "$CONTENT" '.message' "LMOPEN error" "auth: refusal message"
+
+# details is an ARRAY, which is the shape z/OSMF sends. It was emitted as a
+# bare string until #228 -- unnoticed, because nothing passed one.
+assert_json_field "$CONTENT" '.details | type' "array" "auth: details is an array"
+assert_json_field_exists "$CONTENT" '.details[0]' "auth: details carries a sentence"
+
+# The refusal must not name an abend it did not take: the reference's own text
+# ends "Open 913 abend", true where OPEN refused, false for a pre-check.
+if echo "$CONTENT" | jq -r '.details[0]' 2>/dev/null | grep -qi "abend"; then
+	fail "auth: refusal does not claim an abend" "details mentions an abend"
+else
+	pass "auth: refusal does not claim an abend"
+fi
+
+# 2. the control: same verb, a name the caller MAY alter. Must get past the
+#    gate and fail on the catalog lookup instead.
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${ALLOW_DS}")
+ALLOW_CODE="$HTTP_CODE"
+assert_http_status "404" "$HTTP_CODE" "auth: delete with ALTER reaches the catalog"
+
+# 3. rename INTO a protected namespace: the source is permitted, so only the
+#    target-side check can refuse this. Without it, ALTER over your own
+#    qualifier would be enough to move a data set anywhere.
+RESP=$(curl -s -w '\n%{http_code}' -X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${ALLOW_DS}\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${DENY_DS}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+CONTENT=$(echo "$RESP" | sed '$d')
+assert_http_status "500" "$HTTP_CODE" "auth: rename into a protected name is refused"
+assert_json_field "$CONTENT" '.category' "4" "auth: rename refusal category"
+
+# 4. control for 3: both names permitted, so it must reach the catalog.
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${ALLOW_DS}\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${ALLOW_DS}2")
+assert_http_status "404" "$HTTP_CODE" "auth: rename with ALTER on both names reaches the catalog"
+
+# 5. A refusal must not be distinguishable from "does not exist", or the gate
+#    becomes the existence oracle it was added to prevent.
+#
+#    Test 1 already proves it, read the other way round: DENY_DS does not exist,
+#    so if the check ran after the catalog lookup the answer would have been
+#    404. It answered the refusal, therefore the check precedes the lookup and
+#    an existing and an absent denied name are indistinguishable.
+#
+#    Deliberately NOT tested by deleting a protected data set that does exist.
+#    The only such names here belong to the RAKF configuration, and a suite that
+#    aims DELETE at the live security configuration destroys the system the day
+#    a profile change makes the gate permit it. The inference above costs
+#    nothing and risks nothing.
+#    Both names in tests 1 and 2 are absent. Only the authority differs, and the
+#    answers differ -- so the answer is decided by authority, before existence is
+#    ever consulted. A denied caller therefore learns nothing about what exists.
+if [ "$DENY_CODE" = "500" ] && [ "$ALLOW_CODE" = "404" ]; then
+	pass "auth: the refusal is decided before existence is consulted"
+else
+	fail "auth: the refusal is decided before existence is consulted" \
+		"denied=${DENY_CODE} permitted=${ALLOW_CODE}, expected 500 and 404 on two equally absent names"
+fi
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2384,6 +2384,90 @@ fi
 #    S913, and the client still sees the correct 500 above.
 assert_no_new_abend "$ABEND_BEFORE" "auth: a refused request performs no operation (no handler abend)"
 
+# --- Non-admin refusals (needs a second, ordinary userid) ---
+#
+# The checks above run as whoever MVSMF_USER is. On a system where that is an
+# admin, only ONE attribute is refusable (ALTER under a prefix the admin group
+# does not hold), so READ and UPDATE refusals are unreachable and the suite
+# cannot see a regression in either. Set MVSMF_USER2/MVSMF_PASS2 to an ordinary
+# userid to cover them.
+#
+# This is also the only place the refusal is verified by its EFFECT rather than
+# its answer: the target exists and holds known content, so a gate that sends
+# the refusal and performs the operation anyway is caught here even if the
+# console is not consulted.
+
+echo ""
+echo "--- Authorization: non-admin refusals (issue #228) ---"
+
+if [ -z "${MVSMF_USER2:-}" ] || [ -z "${MVSMF_PASS2:-}" ]; then
+	skip "auth: non-admin refusals (set MVSMF_USER2/MVSMF_PASS2 to enable)"
+else
+	AUTH2="${MVSMF_USER2}:${MVSMF_PASS2}"
+	VICTIM="${MVSMF_USER}.CURL.A228"
+	ABEND_BEFORE2=$(mtt_abend_count)
+
+	curl -s -o /dev/null -X POST -u "$AUTH" \
+		-H "Content-Type: application/json" \
+		--data-binary '{"dsorg":"PS","alcunit":"TRK","primary":1,"secondary":1,"recfm":"FB","lrecl":80,"blksize":800}' \
+		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}"
+	curl -s -o /dev/null -X PUT -u "$AUTH" -H "Content-Type: text/plain" \
+		--data-binary "ORIGINAL CONTENT" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}"
+
+	# READ is permitted -- the generic profile grants it -- so this is the
+	# control that proves the id is not simply refused everything.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH2" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}")
+	assert_http_status "200" "$HTTP_CODE" "auth2: read of another user's data set is permitted"
+
+	# UPDATE and ALTER on someone else's data set are not.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH2" \
+		-H "Content-Type: text/plain" --data-binary "OVERWRITTEN" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}")
+	assert_http_status "500" "$HTTP_CODE" "auth2: write to another user's data set is refused"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X DELETE -u "$AUTH2" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}")
+	assert_http_status "500" "$HTTP_CODE" "auth2: delete of another user's data set is refused"
+
+	# The effect, which is the part the response cannot show.
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}")
+	assert_http_status "200" "$HTTP_CODE" "auth2: the refused delete did not delete"
+
+	CONTENT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${VICTIM}")
+	if echo "$CONTENT" | grep -q "ORIGINAL CONTENT"; then
+		pass "auth2: the refused write did not write"
+	else
+		fail "auth2: the refused write did not write" "content is now: ${CONTENT}"
+	fi
+
+	assert_no_new_abend "$ABEND_BEFORE2" "auth2: no handler abend from any refusal"
+
+	# An ordinary user keeps full control of their own qualifier -- RAKF grants
+	# the owner READ/UPDATE/ALTER implicitly, which the generic DATASET * READ
+	# rule alone would not suggest. If this breaks, the checks are too strict.
+	OWN="${MVSMF_USER2}.CURL.OWN228"
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH2" \
+		-H "Content-Type: application/json" \
+		--data-binary '{"dsorg":"PS","alcunit":"TRK","primary":1,"secondary":1,"recfm":"FB","lrecl":80,"blksize":800}' \
+		"${BASE_URL}/zosmf/restfiles/ds/${OWN}")
+	assert_http_status "201" "$HTTP_CODE" "auth2: create in own qualifier"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH2" \
+		-H "Content-Type: text/plain" --data-binary "own data" \
+		"${BASE_URL}/zosmf/restfiles/ds/${OWN}")
+	assert_http_status "204" "$HTTP_CODE" "auth2: write in own qualifier"
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X DELETE -u "$AUTH2" \
+		"${BASE_URL}/zosmf/restfiles/ds/${OWN}")
+	assert_http_status "204" "$HTTP_CODE" "auth2: delete in own qualifier"
+
+	curl -s -o /dev/null -X DELETE -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}" || true
+fi
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"


### PR DESCRIPTION
Adopts `http_check_auth()` so every data set operation makes an explicit,
race-free authorization decision instead of relying on the one OPEN happens to
make.

Fixes #228

## Why the decision moves

The implicit gate is real — measured, RAKF refuses inside OPEN with `RAKF0005`
and an S913 — but it runs under ASXBSENV, which is address-space-wide. So the
identity mvsMF authorizes against is shared between httpd's workers and outlives
an abend (mvslovers/httpd#176). `http_check_auth()` passes the caller's own ACEE
in the parameter list to `racf_auth()`, which serializes set/RACHECK/restore
under `lock(asxb)` — race-free whatever another worker is doing.

**It closes one direction, and only one.** If ASXBSENV holds a *more* privileged
identity, OPEN permits what the caller may not have — nothing caught that before,
and this does. If it holds a *less* privileged one, OPEN refuses an entitled
caller and the request abends; the pre-check said yes, so that case is unchanged.
The two halves connect, which is what makes this worth doing: a denial today
*leaves* the client's ACEE in ASXBSENV, so saying no is precisely what seeds the
case the pre-check exists to catch.

## Attributes — measured, not proposed

The issue's table was explicitly a proposal. It was settled with a probe
(`?fn=checkauth`, in this PR) against RAKF's actual answers rather than against
what the code intends.

| Operation | Resource | Attribute |
|---|---|---|
| read a sequential data set / a member / a member list | data set, or the library | READ |
| write a sequential data set / a member; delete or rename a member | data set, or the library | UPDATE |
| scratch a data set | data set | ALTER |
| rename a data set | **both names** | ALTER |

A member operation authorizes on the **library**, never `DSN(MEMBER)` — RACF
profiles cover data sets, so there is no member granularity to ask for. That
answers the issue's "member-level granularity" question.

A data set rename checks source **and** target. Gating only the source would let
a caller with ALTER over their own qualifier move a data set *into* a namespace
they have no authority over — an escalation the source check cannot see.

## Ordering: before the catalog, and before `is_pds()`

Every check runs ahead of the operation's first catalog or VTOC access. Gating
after `__locate()` would make the 404 an existence oracle for anyone who may not
touch the name: they would learn whether it exists from which error came back.

`is_pds()` is part of that, and it is the one that is easy to miss — it calls
`__locate()` + `__dscbdv()`, so a check placed after it leaks "is this a PDS" to
a caller with no READ. The gate sits ahead of it on both the read and the write
path.

The write paths get **one** check, not two. Both have read-opens before the
output open — the existence probe that stops `fopen("w")` auto-allocating with
the wrong DCB (#65) and `check_if_match()`'s ETag hash — and neither is an
operation of its own. That is the `:1009` note from the issue, which turned out
to have a second case the issue did not know about (`dataset_etag()`).

## The refusal body — 500, not 403

Measured against a real z/OSMF (v29 / z/OS 05.29.00): a read of a data set the
caller may not open answers

```
500 {"category":4,"rc":8,"reason":0,"message":"LMOPEN error",
     "details":["ISRZ002 Authorization failed - You may not use this protected data set. Open 913 abend."]}
```

**The reference takes the same S913 and says so on the wire.** So 500 was already
correct, and the issue's original "wrong status, should be 403" acceptance
criterion was wrong twice over — 403 is absent from the z/OSMF list (#250) *and*
not what the reference sends. It is withdrawn; the measurement is in the issue.

This PR emits the reference's shape, minus one clause and one id:

- `ISRZ002` is not reproduced — an ISPF message id, and mvsMF runs no ISPF
  library management.
- the text stops before `Open 913 abend.`, because this refuses *before* any
  open. Claiming an abend that did not happen would be a lie in the one field
  that explains the refusal. #315 owns the variant that did abend.

`sendErrorResponse()` emitted `details` as a bare **string**, a shape no
reference response has. It went unnoticed because the parameter had zero callers
until now. It emits an array, which needed `addJsonArrayString()` — every
existing adder is keyed, and the arrays this builder produced held objects.

## Verified on MVS

Deployed and activated on mvsdev (`fn=version` = the built HEAD each time).

- **The vector entry works.** mvsMF is the first CGI consumer of
  `http_check_auth`, and `httpx` resolves into the *running* httpd, so a live
  build older than the entry would dereference past what the server filled — an
  abend, and `make deps` cannot see it. `?fn=checkauth&via=both` returns
  agreeing answers from the raw `racf_auth()` and the vector call, with no abend.
  That is the issue's acceptance gate, measured rather than assumed.
- **A denial answers the refusal, a permitted request reaches the catalog.**
  `DELETE SYS1.SECURE.NOSUCH` → 500 with the body above; `DELETE
  <userid>.CURL.NOSUCH228` → 404. Two equally absent names, so the answer is
  decided by authority before existence — the oracle property.
- **The rename target check fires.** Rename *into* `SYS1.SECURE.*` from a
  permitted source → 500. Only the target-side check can produce that.
- **No abend.** Bracketed between two console markers (`D T` … `D A,L`), the
  window containing both refusals holds no `MVSMF99E`, no `IEC150I`, nothing.
  That is the second acceptance criterion.
- **No regression:** `curl-datasets.sh` 218/218 (23 authorization tests, of
  which 9 need the ordinary userid), `make test-host` 211/211.

## Two things a reviewer should not read as oversights

- **`datasetCreateHandler` (POST) is not gated.** It allocates with SVC 99 rather
  than an open, so it was not in the issue's enumerated site list — and it is now
  the one data set-mutating operation without an explicit check. Documented as
  such. Worth its own issue; deliberately not folded in here.
- **The `dslevel` listing is not gated**, per #229 (closed): it opens nothing,
  and the reference does not gate it either.

## Measured with an ordinary userid — and it found a bug that green tests did not

The first round of this PR shipped a gate that **looked** like it worked. Thirteen
response assertions passed. The refusal body was correct, byte for byte.

`require_access()` returned whatever the error send returned, and both senders
answer 0 on success — so every *successfully delivered* refusal told the caller
"permitted". The handler sent the 500 and then did the thing anyway:

```
RAKF0005 INVALID ATTEMPT TO ACCESS RESOURCE
RAKF000A  MVSCE02 ,HTTPD   ,DATASET ,SYS1.SECURE.CNTL
IEC150I 913-38,IFG0194C,...,SYS1.SECURE.CNTL
MVSMF901E HANDLER ABEND S913 U0000 FOR GET .../SYS1.SECURE.CNTL(PROFILES)
MVSMF902W HEADERS ALREADY SENT, NO ERROR RESPONSE POSSIBLE
```

Two things hid it. The response is identical either way, so no response assertion
can see it. And an **admin** userid holds ALTER through RAKF's generic
`DATASET *` rule, so it is permitted for every attribute except one — the paths
that abend were never reached.

Both are fixed: `require_access()` returns -1 and never the sender's rc, and the
suite now brackets every refusal with a Master Trace Table count of handler
abends, plus a non-admin section that verifies a refusal by its **effect** — the
target exists, holds known content, and must still hold it afterwards.

### What the ordinary userid actually measures

| | own qualifier | another user's | `SYS1.PARMLIB` | `SYS1.SECURE.*` |
|---|---|---|---|---|
| READ | permitted | permitted | permitted | refused |
| UPDATE | permitted | refused | refused | refused |
| ALTER | permitted | refused | refused | refused |

**No regression for non-admin users**, which was the open question: create, write
and delete in one's own qualifier all still work (201 / 204 / 204).

That result is not predictable from RAKF's profile table, and this is the part
worth carrying forward. Reading it alone — `DATASET *` grants READ, with ALTER
only to `ADMIN`/`STCGROUP`, and no line anywhere for a user's own qualifier —
leads to the conclusion that an ordinary user can write nowhere and that these
checks break every such user. **RAKF grants the owner full access implicitly**,
with no profile line for it. MVS/CE and TK5 ship the same profile set, so the
attribute choices here are portable. Recorded in
`docs/endpoints/datasets/authorization.md`, because the table invites the wrong
inference.

## Console visibility — a trade worth noticing

A refused request now writes **nothing** to the console. `RAKF0005` appears for a
denial RAKF catches inside OPEN, but not for the RACHECK this pre-check issues,
and mvsMF deliberately adds no message of its own: a client polling a denied
endpoint would turn one refusal into a flood, and `consapi.c` reads the Master
Trace Table, so that flood would come straight back out of its own console API.

So the change trades an abend plus a `RAKF0005` audit line for a clean 500 and
silence. Recording it here rather than deciding it in a PR.
