### PR TITLE
Report an allocation failure the way z/OSMF reports it, and stop WTOing a client error

### DIFF
--- a/docs/endpoints/datasets/authorization.md
+++ b/docs/endpoints/datasets/authorization.md
@@ -71,8 +71,11 @@ Practical consequences when reasoning about these checks:
   section of `CLAUDE.md`.
 - `POST /zosmf/restfiles/ds/{dsn}` — allocation goes through SVC 99 rather than
   an open, so mvsMF makes no decision of its own. **RAKF still refuses it**
-  (measured), but the refusal comes back as a generic allocation failure,
-  indistinguishable from running out of space, and writes `MVSMF102E`. See #317.
+  (measured), and the refusal is deliberately indistinguishable from any other
+  allocation failure — `500 {"category":8,"rc":900,"reason":7,"message":"Dynamic
+  allocation Error"}` — because that is byte for byte what the reference answers
+  for both. See #317, and do not add an authorization body here: it would put
+  mvsMF ahead of the thing it clones.
 
 ## What a refusal looks like
 

--- a/docs/endpoints/datasets/create.md
+++ b/docs/endpoints/datasets/create.md
@@ -45,11 +45,20 @@ work in #228. RAKF gates DADSM regardless: measured, an ordinary userid
 allocating under a foreign qualifier is refused, nothing is created, and
 `RAKF0005` is logged.
 
-What is wrong is the report. A refusal and a request for more space than the
-volume has answer **byte for byte the same** —
-`500 {"rc":8,"category":6,"reason":2,"message":"Dataset allocation failed"}` — so
-a client cannot tell "you may not create here" from "there is no room", and both
-also write `MVSMF102E` to the console. Tracked as #317.
+A refusal and a request for more space than the volume has answer **byte for
+byte the same**, and that is correct: measured, a real z/OSMF answers both with
+
+```
+500 {"category":8,"rc":900,"reason":7,"message":"Dynamic allocation Error"}
+```
+
+mvsMF sends exactly that since #317. It *can* tell the two apart — `__dsalcf()`
+returns different codes — and deliberately does not, because the reference does
+not. Do not "improve" this into a distinct authorization error; the suite asserts
+the sameness.
+
+Nothing is written to the console for either case (#317 retired `MVSMF102E`).
+A denial still shows up as RAKF's own `RAKF0005`/`RAKF000A`.
 
 ## Examples
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -62,7 +62,7 @@ member not found, record too long) produce **no** console message.
 | Id | Text | Meaning and action |
 |---|---|---|
 | `MVSMF101E` | `OPEN FOR WRITE FAILED dsn ERRNO=n` | `fopen()` for write failed on an existing data set. Not a client error: enqueue held by another job, no space, or a security failure. |
-| `MVSMF102E` | `ALLOCATE FAILED dsn RC=n` | Dynamic allocation of a new data set failed. `RC` is the `__dsalcf()` code. |
+| ~~`MVSMF102E`~~ | *retired (#317)* | Was issued for every failed data set create. Both reachable causes are client errors — a name the caller may not allocate under, or parameters that do not fit — so it is reported in the HTTP response only. A denial still appears on the console as RAKF's own `RAKF0005`/`RAKF000A`. The id is not reused. |
 | `MVSMF103E` | `DELETE FAILED name RC=n ERRNO=n` | Scratch/uncatalog failed after the data set was found. `name` is the data set, or `DSN(MEMBER)` for a member delete. |
 | `MVSMF104E` | `RENAME old TO new FAILED RC=n` | Data set rename failed after the target was confirmed free. |
 | `MVSMF105E` | `RENAME dsn(old) TO (new) FAILED RC=n` | Member rename failed after the target was confirmed free. |

--- a/include/dsapi_err.h
+++ b/include/dsapi_err.h
@@ -22,6 +22,31 @@
 #define REASON_PATTERN_TOO_LONG			9	// Member pattern longer than the handler accepts
 #define REASON_ETAG_MISMATCH			10	// If-Match precondition failed (issue #152)
 
+/* Dynamic allocation failure -- the reference's own report, measured (#317).
+ *
+ * A real z/OSMF answers a POST that fails to allocate with
+ *
+ *   500 {"category":8,"rc":900,"reason":7,"message":"Dynamic allocation Error"}
+ *
+ * and it answers EXACTLY that whether the caller lacked authority for the name
+ * or asked for more space than exists -- byte for byte, both measured. So these
+ * are not category 6 reason codes and do not belong in the block above: they are
+ * one complete report, and the four values travel together.
+ *
+ * Do not make the two cases distinguishable here. mvsMF can tell them apart
+ * (__dsalcf() answers RC=4 for the denial and RC=12 for the space failure) and
+ * deliberately does not pass that on, because the reference does not. That is
+ * the same rule that made #228 ADD a distinct body for a read denial: there the
+ * reference draws the line, here it does not.
+ *
+ * rc 900 is not a typo and not a SAF code. z/OSMF's `rc` is not always the
+ * 0/4/8/12 the rest of this file uses -- copy the measured value.
+ */
+#define CATEGORY_DYNALLOC			8
+#define RC_DYNALLOC_ERROR			900
+#define REASON_DYNALLOC_ERROR			7
+#define ERR_MSG_DYNALLOC_ERROR			"Dynamic allocation Error"
+
 // Error messages for Category 6
 #define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
 #define ERR_MSG_DATASET_ALLOC_FAILED	"Dataset allocation failed"

--- a/include/mvsmfmsg.h
+++ b/include/mvsmfmsg.h
@@ -76,8 +76,13 @@
 /** MVSMF101E fopen() for write failed; not a client error (enqueue, space, RACF) */
 #define MSG_DS_OPEN_WRITE	"MVSMF101E OPEN FOR WRITE FAILED %s ERRNO=%d"
 
-/** MVSMF102E dynamic allocation of a new data set failed */
-#define MSG_DS_ALLOC_FAILED	"MVSMF102E ALLOCATE FAILED %s RC=%d"
+/* MVSMF102E retired in #317. It fired on every failed create, and both
+ * reachable causes are the client's: a name they may not allocate under, or
+ * space/DCB parameters that do not fit. Client-caused conditions are reported
+ * in the HTTP response and nowhere else -- see the rules at the top of this
+ * file. Nothing is lost on the security side: RAKF logs its own denial.
+ * The id is burned, not reusable, so that an operator searching old logs for
+ * MVSMF102E does not find a different message wearing it. */
 
 /** MVSMF103E scratch/uncatalog failed; %s is the data set or DSN(MEMBER) */
 #define MSG_DS_DELETE_FAILED	"MVSMF103E DELETE FAILED %s RC=%d ERRNO=%d"

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -3088,10 +3088,16 @@ int datasetCreateHandler(Session *session)
 	/* Allocate the dataset */
 	rc = __dsalcf(ddname, "%s", opts);
 	if (rc != 0) {
-		wtof(MSG_DS_ALLOC_FAILED, dsname, rc);
+		/* No WTO. Both reachable failures are the client's -- a name they may
+		   not use, or parameters that do not fit -- and a client-caused
+		   condition belongs in the response and nowhere else: consapi.c reads
+		   the Master Trace Table, so one retried create becomes a flood served
+		   back out of mvsMF's own console API. The security case is not lost
+		   either way, because RAKF logs the denial itself (RAKF0005/RAKF000A,
+		   with the userid and the data set name). */
 		return sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
-			CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_ALLOC_FAILED,
-			ERR_MSG_DATASET_ALLOC_FAILED, NULL, 0);
+			CATEGORY_DYNALLOC, RC_DYNALLOC_ERROR, REASON_DYNALLOC_ERROR,
+			ERR_MSG_DYNALLOC_ERROR, NULL, 0);
 	}
 
 	/* Free the DD allocation */

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2384,6 +2384,42 @@ fi
 #    S913, and the client still sees the correct 500 above.
 assert_no_new_abend "$ABEND_BEFORE" "auth: a refused request performs no operation (no handler abend)"
 
+# --- Allocation failures report what z/OSMF reports (issue #317) ---
+#
+# Measured on a real z/OSMF: a create refused for authority and a create asking
+# for more space than exists BOTH answer, byte for byte,
+#
+#   500 {"category":8,"rc":900,"reason":7,"message":"Dynamic allocation Error"}
+#
+# The sameness is the contract, not a defect. mvsMF can separate the two cases
+# -- __dsalcf() answers RC=4 and RC=12 -- and must not, because the reference
+# does not. The assertion below fails if someone later "improves" it, which is
+# the whole reason it exists. (The authority half needs a second userid and
+# lives in the next section; this one covers the parameter half, which any id
+# can provoke.)
+
+echo ""
+echo "--- Allocation failure report (issue #317) ---"
+
+RESP=$(curl -s -w '\n%{http_code}' -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary '{"dsorg":"PS","alcunit":"CYL","primary":999999,"secondary":1,"recfm":"FB","lrecl":80,"blksize":800}' \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.TOOBIG317")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+CONTENT=$(echo "$RESP" | sed '$d')
+ALLOC_FAIL_BODY="$CONTENT"
+
+assert_http_status "500" "$HTTP_CODE" "alloc: an impossible SPACE request fails"
+assert_json_field "$CONTENT" '.category' "8" "alloc: category matches z/OSMF"
+assert_json_field "$CONTENT" '.rc' "900" "alloc: rc matches z/OSMF"
+assert_json_field "$CONTENT" '.reason' "7" "alloc: reason matches z/OSMF"
+assert_json_field "$CONTENT" '.message' "Dynamic allocation Error" "alloc: message matches z/OSMF"
+
+# nothing may be left behind by a failed create
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.TOOBIG317")
+assert_http_status "404" "$HTTP_CODE" "alloc: a failed create leaves nothing behind"
+
 # --- Non-admin refusals (needs a second, ordinary userid) ---
 #
 # The checks above run as whoever MVSMF_USER is. On a system where that is an
@@ -2463,6 +2499,27 @@ else
 	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X DELETE -u "$AUTH2" \
 		"${BASE_URL}/zosmf/restfiles/ds/${OWN}")
 	assert_http_status "204" "$HTTP_CODE" "auth2: delete in own qualifier"
+
+	# #317: a create refused for authority must be INDISTINGUISHABLE from the
+	# space failure above -- that is what the reference does.
+	RESP=$(curl -s -w '\n%{http_code}' -X POST -u "$AUTH2" \
+		-H "Content-Type: application/json" \
+		--data-binary '{"dsorg":"PS","alcunit":"TRK","primary":1,"secondary":1,"recfm":"FB","lrecl":80,"blksize":800}' \
+		"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.HOLE317")
+	HTTP_CODE=$(echo "$RESP" | tail -1)
+	CONTENT=$(echo "$RESP" | sed '$d')
+	assert_http_status "500" "$HTTP_CODE" "auth2: create under another user's qualifier is refused"
+
+	if [ -n "${ALLOC_FAIL_BODY:-}" ] && [ "$CONTENT" = "$ALLOC_FAIL_BODY" ]; then
+		pass "auth2: the refusal is indistinguishable from a space failure (matches z/OSMF)"
+	else
+		fail "auth2: the refusal is indistinguishable from a space failure (matches z/OSMF)" \
+			"authority body '${CONTENT}' differs from space body '${ALLOC_FAIL_BODY:-<unset>}'"
+	fi
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.HOLE317")
+	assert_http_status "404" "$HTTP_CODE" "auth2: the refused create created nothing"
 
 	curl -s -o /dev/null -X DELETE -u "$AUTH" \
 		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}" || true


### PR DESCRIPTION
Aligns the data set create failure report with the reference, and retires the
console message it wrote on the way.

Fixes #317

## What the reference does

Two `POST`s against a real z/OSMF (v29 / z/OS 05.29.00) — one refused for
authority, one asking for far more space than exists. Neither created anything.

```
both -> 500 {"category":8,"rc":900,"reason":7,"message":"Dynamic allocation Error"}
```

**Byte for byte identical.** So the premise this issue was opened on — that mvsMF
answers a refusal and a space failure the same way, and should not — was wrong.
That *is* the reference behaviour. Both proposed fixes were withdrawn after
measuring; what was left is a plain conformance gap in the four values:

| | category | rc | reason | message |
|---|---|---|---|---|
| reference | 8 | 900 | 7 | `Dynamic allocation Error` |
| mvsMF, before | 6 | 8 | 2 | `Dataset allocation failed` |

## The part that will be tempting to undo

mvsMF *can* tell the two cases apart — `__dsalcf()` answers `RC=4` for the denial
and `RC=12` for the space failure — and now deliberately throws that away.

That looks like the opposite of #228, which *added* a distinct body for a data
set read denial. It is the same rule applied twice: there the reference draws the
line (`category 4` / `LMOPEN error`, with the explanation in `details[]`), here it
does not. Following the reference means following it in both directions, and
mvsMF does not get to be more informative than the thing it clones. The suite
asserts the two bodies are **identical**, so an "improvement" that separates them
fails it.

`rc 900` is copied, not derived — z/OSMF's `rc` is not always the SAF-style
0/4/8/12 the rest of `dsapi_err.h` uses.

## MVSMF102E retired

It fired on every failed create, and both reachable causes are the client's: a
name they may not allocate under, or parameters that do not fit. CLAUDE.md's rule
is that a client-caused condition goes in the HTTP response and nowhere else, and
the reason is concrete here — `consapi.c` reads the Master Trace Table, so a
client retrying a refused create floods mvsMF's own console API with mvsMF's own
message.

Nothing is lost on the security side, which is what made this an easy call once
measured: **RAKF logs the denial itself**, with the userid and the data set name.

```
RAKF0005 INVALID ATTEMPT TO ACCESS RESOURCE
RAKF000A  MVSCE02 ,HTTPD   ,DATASET ,IBMUSER.CURL.HOLE317
```

The id stays burned in `mvsmfmsg.h` and struck through in `docs/messages.md`, so
an operator searching old logs for `MVSMF102E` does not find a different message
wearing it.

## Verified on MVS

Deployed and activated on mvsdev (`fn=version` = the built HEAD).

```
authority (MVSCE02 -> IBMUSER.*): {"rc":900,"category":8,"reason":7,"message":"Dynamic allocation Error"}
space     (IBMUSER 999999 CYL) : {"rc":900,"category":8,"reason":7,"message":"Dynamic allocation Error"}
MVSMF102E lines in the MTT: 4 before, 4 after
```

`curl-datasets.sh` 227/227 (up from 218; the authority half needs the ordinary
userid from `MVSMF_USER2`), `make test-host` 211/211.

## Deliberately not fixed here

`dsapi.c`'s two **delete** paths also answer `REASON_DATASET_ALLOC_FAILED` —
"Dataset allocation failed" for a failed `remove()`, where nothing was allocated.
They keep the old constant rather than inheriting a message about dynamic
allocation, which would have made them read worse. What the reference sends for a
failed delete is unmeasured, so correcting it is a separate change with its own
probe.
