### PR TITLE
Report a failed delete as a delete failure, not an allocation failure

### DIFF
--- a/docs/endpoints/datasets/create.md
+++ b/docs/endpoints/datasets/create.md
@@ -35,7 +35,10 @@ On successful completion, this request returns HTTP status code 201 (Created).
 - HTTP 400 (Bad Request)
     - Missing or invalid allocation parameters
 - HTTP 500 (Internal Server Error)
-    - Dataset allocation failed (e.g. dataset already exists, no space)
+    - `{"category":8,"rc":900,"reason":7,"message":"Dynamic allocation Error"}`
+      — every allocation failure, whatever the cause: the name already exists,
+      no space, parameters that do not fit, or no authority for the name. The
+      reference answers all of them identically; see the *Authorization* section.
 
 ## Authorization
 

--- a/docs/endpoints/datasets/delete.md
+++ b/docs/endpoints/datasets/delete.md
@@ -25,7 +25,11 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 - HTTP 404 (Not Found)
     - Dataset not found in catalog
 - HTTP 500 (Internal Server Error)
-    - Delete operation failed
+    - `{"rc":8,"category":6,"reason":11,"message":"Dataset delete failed"}` —
+      the scratch or uncatalog failed after the data set was found. The caller was authorized and the target existed, so what is left
+      is an enqueue held elsewhere or an I/O error; `MVSMF103E` carries the
+      detail to the operator. (Reason 11 since #319; it reported the allocation
+      failure's reason 2 before, which was never right for a delete.)
 
 ## Authorization
 

--- a/docs/endpoints/datasets/members-delete.md
+++ b/docs/endpoints/datasets/members-delete.md
@@ -27,7 +27,11 @@ On successful completion, this request returns HTTP status code 204 (No Content)
 - HTTP 404 (Not Found)
     - Member not found
 - HTTP 500 (Internal Server Error)
-    - Delete operation failed
+    - `{"rc":8,"category":6,"reason":11,"message":"Dataset delete failed"}` —
+      the STOW delete failed after the member was found. The caller was authorized and the target existed, so what is left
+      is an enqueue held elsewhere or an I/O error; `MVSMF103E` carries the
+      detail to the operator. (Reason 11 since #319; it reported the allocation
+      failure's reason 2 before, which was never right for a delete.)
 
 ## Authorization
 

--- a/include/dsapi_err.h
+++ b/include/dsapi_err.h
@@ -12,7 +12,9 @@
 
 // Reason codes for Category 6 (Service error)
 #define REASON_PDS_NOT_SEQUENTIAL		1	// Dataset is PDS, not sequential
-#define REASON_DATASET_ALLOC_FAILED		2	// Dataset allocation failed
+/* 2 is burned: it meant "Dataset allocation failed" in shipped responses, and
+ * was reported for failed deletes too (#319). Do not reuse it. The create path
+ * answers the reference's own report now -- see CATEGORY_DYNALLOC below. */
 #define REASON_INVALID_ALLOC_PARAMS		3	// Invalid or missing allocation parameters
 #define REASON_DATASET_NOT_FOUND		4	// Dataset not found
 #define REASON_MEMBER_NOT_FOUND			5	// PDS member not found
@@ -21,6 +23,7 @@
 #define REASON_RENAME_FAILED			8	// Rename operation failed
 #define REASON_PATTERN_TOO_LONG			9	// Member pattern longer than the handler accepts
 #define REASON_ETAG_MISMATCH			10	// If-Match precondition failed (issue #152)
+#define REASON_DELETE_FAILED			11	// Scratch/uncatalog or STOW delete failed (issue #319)
 
 /* Dynamic allocation failure -- the reference's own report, measured (#317).
  *
@@ -49,8 +52,8 @@
 
 // Error messages for Category 6
 #define ERR_MSG_PDS_NOT_SEQUENTIAL		"Dataset is a partitioned dataset (PDS). Use /ds/{dataset-name}({member-name}) to access members"
-#define ERR_MSG_DATASET_ALLOC_FAILED	"Dataset allocation failed"
 #define ERR_MSG_INVALID_ALLOC_PARAMS	"Invalid or missing allocation parameters"
+#define ERR_MSG_DELETE_FAILED		"Dataset delete failed"
 #define ERR_MSG_DATASET_NOT_FOUND	"Dataset not found"
 #define ERR_MSG_MEMBER_NOT_FOUND	"PDS member not found"
 #define ERR_MSG_INVALID_RENAME_REQUEST	"Unsupported request; only 'rename' is supported"

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -3151,8 +3151,8 @@ int datasetDeleteHandler(Session *session)
 	if (rc != 0) {
 		wtof(MSG_DS_DELETE_FAILED, dsname, rc, errno);
 		return sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
-			CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_ALLOC_FAILED,
-			ERR_MSG_DATASET_ALLOC_FAILED, NULL, 0);
+			CATEGORY_SERVICE, RC_ERROR, REASON_DELETE_FAILED,
+			ERR_MSG_DELETE_FAILED, NULL, 0);
 	}
 
 	/* Send HTTP 204 No Content */
@@ -3208,8 +3208,8 @@ int memberDeleteHandler(Session *session)
 	if (rc != 0) {
 		wtof(MSG_DS_DELETE_FAILED, dataset, rc, errno);
 		return sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
-			CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_ALLOC_FAILED,
-			ERR_MSG_DATASET_ALLOC_FAILED, NULL, 0);
+			CATEGORY_SERVICE, RC_ERROR, REASON_DELETE_FAILED,
+			ERR_MSG_DELETE_FAILED, NULL, 0);
 	}
 
 	/* Send HTTP 204 No Content */


### PR DESCRIPTION
Both delete handlers answered `{"rc":8,"category":6,"reason":2,"message":"Dataset allocation failed"}` when `remove()` failed — for an operation that allocated nothing.

Fixes #319

## Why it was left until now

#317 moved the create path onto the reference's measured `Dynamic allocation Error` report and deliberately left these two on the old constants: had they inherited the new ones, they would have gone from misleading to worse — a message about *dynamic allocation* on a scratch. That left `REASON_DATASET_ALLOC_FAILED` / `ERR_MSG_DATASET_ALLOC_FAILED` with no other user, so they are removed and both sites get `REASON_DELETE_FAILED` / `"Dataset delete failed"`.

**Reason 11, not the vacated 2.** A code that has meant "allocation failed" in shipped responses should not quietly start meaning something else; 2 is burned in the header with the reason why.

## No z/OSMF measurement, and none is possible

Every other conformance change in this run was settled by measuring the reference (#266, #274, #228, #317). This one cannot be, and it is worth saying why so it is not re-attempted:

The condition is *"the data set was found and the scratch then failed"* — an enqueue held elsewhere, an I/O error. Provoking that on a real system means **deleting real data sets** and arranging for the delete to fail. The one variant that is safe to probe — a delete refused for authority — answers a different question, and one #228 already settled: since the pre-checks landed, such a request never reaches `remove()`.

So these values are chosen, the way every other `REASON_*` in `dsapi_err.h` was chosen. What matters is that they name the operation that failed.

## MVSMF103E stays

Unlike the `MVSMF102E` retired in #317, this is **not** a client error. The caller was authorized (#228) and the target existed (`__locate` succeeded), so what is left is an enqueue or an I/O problem — precisely what an operator can act on. `docs/messages.md` already describes it that way.

## Testing

The failure path is **not reachable from the suite**: it needs a scratch that fails on demand, which means holding an exclusive enqueue from outside the test. The change is enforced by the compiler — the old constants no longer exist — and the success paths are covered as before.

`curl-datasets.sh` 227/227, `make test-host` 211/211, deployed and activated on mvsdev.

Also fixes a leftover from #317: `create.md` still described the old `Dataset allocation failed` body.