### PR TITLE
Answer a denial OPEN caught the way a denial is answered

### DIFF
--- a/docs/endpoints/datasets/authorization.md
+++ b/docs/endpoints/datasets/authorization.md
@@ -95,8 +95,14 @@ reference sends. `category 4` here is measured rather than documented.
 
 The reference's own `details[]` text ends `Open 913 abend.`, because OPEN is what
 refused it. mvsMF refuses before the open, so it stops one clause earlier — it
-does not claim an abend it did not take. The variant that *does* carry the abend
-belongs to the recovery path (#315).
+does not claim an abend it did not take.
+
+**A denial OPEN catches answers the same report**, with the abend clause restored
+(#315). That happens when a pre-check and OPEN disagree, and on the handlers
+outside `dsapi.c` that have no pre-check. The console still shows `RAKF0005` and
+`MVSMF901E` there, because an abend really did happen and it costs the CGI its
+storage subpool — that is a thing an operator must know, unlike the refusal
+itself.
 
 ## The refusal is decided before existence
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -83,7 +83,7 @@ member not found, record too long) produce **no** console message.
 
 | Id | Text | Meaning and action |
 |---|---|---|
-| `MVSMF901E` | `HANDLER ABEND Sxxx Unnnn FOR method path` | A handler abended and the router's ESTAE caught it. The client gets a 500 naming the abend code (issue #256). The method and path say which request did it. |
+| `MVSMF901E` | `HANDLER ABEND Sxxx Unnnn FOR method path` | A handler abended and the router's ESTAE caught it. The client gets a 500 naming the abend code (issue #256) — except for **S913**, insufficient authority to open, which is a refusal rather than a failure and is answered with the authorization report instead (#315). The message is still issued for it: an abend costs the CGI its storage subpool whatever caused it. The method and path say which request did it. |
 | `MVSMF902W` | `HEADERS ALREADY SENT, NO ERROR RESPONSE POSSIBLE` | The abend came after the response had started, so the client sees a truncated body rather than an error. Always follows a `MVSMF901E`. |
 | `MVSMF903W` | `SESSION FILE TABLE FULL, FILE NOT TRACKED` | More data sets are open in one request than `MAX_SESSION_FILES`. The untracked file is not closed if the handler abends. |
 | `MVSMF904I` | `RECOVERY CLOSING dsn (DD:ddname)` | Recovery is closing a data set the abending handler left open. Informational; it accompanies a `MVSMF901E`. |

--- a/include/abendmsg.h
+++ b/include/abendmsg.h
@@ -45,4 +45,27 @@
  */
 void abend_message(char *buf, size_t size, unsigned sys, unsigned usr);
 
+/**
+ * The `details[]` sentence for an abend that is an authorization denial, or
+ * NULL when this abend is something else (issue #315).
+ *
+ * S913 means insufficient authority to open, and that is the whole test. Do
+ * NOT widen it to the rest of the IEC1xx family: `SYS1.STGINDEX` produces
+ * `IEC143I 213-04` / S213, which is "cannot be opened sequentially" -- a
+ * different condition that must keep the generic abend body.
+ *
+ * The text ends with the abend, unlike the sentence a pre-check produces
+ * (`ERR_MSG_DENIED_DETAIL` in common.h). That difference is deliberate and is
+ * the only one: here OPEN refused and the task really did abend, so saying so
+ * matches both the truth and the reference, whose own text reads
+ * "... Open 913 abend."  A pre-check refuses before any open and must not
+ * claim it.
+ *
+ * Returns a string literal -- no buffer, nothing writable. MVSMF is RENT and
+ * this runs in the recovery path.
+ *
+ * @param sys   system completion code, 0 for a user abend.
+ */
+const char *abend_denial_detail(unsigned sys);
+
 #endif /* ABENDMSG_H */

--- a/src/abendmsg.c
+++ b/src/abendmsg.c
@@ -12,6 +12,10 @@
 #define ABEND_D37	0xD37
 #define ABEND_E37	0xE37
 
+/* Insufficient authority to open. The one abend code that is an authorization
+ * decision rather than a failure. */
+#define ABEND_913	0x913
+
 #ifdef __MVS__
 __asm__("\n&FUNC	SETC 'abend_message'");
 #endif
@@ -36,4 +40,21 @@ abend_message(char *buf, size_t size, unsigned sys, unsigned usr)
 	} else {
 		snprintf(buf, size, "Internal server error (abend S%03X)", sys);
 	}
+}
+
+/*
+ * Whether an abend is a denial, and what to say about it. See abendmsg.h.
+ */
+#ifdef __MVS__
+__asm__("\n&FUNC	SETC 'abend_denial_detail'");
+#endif
+const char *
+abend_denial_detail(unsigned sys)
+{
+	if (sys != ABEND_913) {
+		return NULL;
+	}
+
+	return "Authorization failed - You may not use this protected data set."
+	       " Open 913 abend.";
 }

--- a/src/router.c
+++ b/src/router.c
@@ -156,10 +156,31 @@ int handle_request(Router *router, Session *session)
         wtof(MSG_HANDLER_ABEND, sys, usr, method, path);
         session_cleanup(session);
         if (!session->headers_sent) {
-            // the abend code is all the caller gets -- the console message
-            // stays behind on the system (#256)
-            abend_message(msg, sizeof(msg), sys, usr);
-            sendErrorResponse(session, 500, 6, 8, 99, msg, NULL, 0);
+            /* An S913 is not a failure, it is a refusal OPEN made, and the
+               reference reports it as one -- measured, a real z/OSMF answers a
+               data set it may not open with category 4 / "LMOPEN error" and the
+               explanation in details[], and takes the same S913 doing it. So
+               this is the same body a pre-check produces (#228), differing only
+               in the sentence: that one has abended and says so.
+
+               Every other abend keeps the generic report with its code (#256).
+               S213 in particular must not fall in here -- it is "cannot open
+               sequentially", not a denial. */
+            const char *denial = abend_denial_detail(sys);
+
+            if (denial) {
+                const char *details[1];
+
+                details[0] = denial;
+                sendErrorResponse(session, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                    CATEGORY_AUTHORIZATION, RC_ERROR, REASON_NOT_AUTHORIZED,
+                    ERR_MSG_NOT_AUTHORIZED, details, 1);
+            } else {
+                // the abend code is all the caller gets -- the console message
+                // stays behind on the system (#256)
+                abend_message(msg, sizeof(msg), sys, usr);
+                sendErrorResponse(session, 500, 6, 8, 99, msg, NULL, 0);
+            }
         } else {
             wtof(MSG_HEADERS_SENT);
         }

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -92,6 +92,66 @@ static int abend_test_enabled(void) {
   return v && (v[0] == '1' || v[0] == 'Y' || v[0] == 'y');
 }
 
+/* --- fn=denyopen (issue #315) -------------------------------------------
+ * Take a real S913 through the real ESTAE, to check that the router answers a
+ * denial OPEN caught with the reference's authorization report rather than the
+ * generic abend body.
+ *
+ * It exists because #228 made the natural way unreachable. That issue's own
+ * live check was "MVSCE02 against SYS1.SECURE.CNTL(PROFILES)", which used to
+ * abend -- the pre-checks now refuse it before the fopen(), which is the entire
+ * point of them. So the only remaining way into this branch on a healthy system
+ * is to open a data set without asking first, which is what this does.
+ *
+ * That is not a hole: the branch it verifies is a safety net for the cases the
+ * pre-checks do not cover -- a pre-check and OPEN disagreeing, and the handlers
+ * outside dsapi.c -- and a net nobody can reach is a net nobody can test.
+ *
+ * Gated exactly like fn=abend: an abend costs the CGI its storage subpool
+ * (mvslovers/httpd#154), so this must never be reachable in production.
+ * Handled before any response byte is written, so headers_sent is still 0 and
+ * the router can send its recovery response.
+ */
+__asm__("\n&FUNC	SETC 'testDenyOpen'");
+static int testDenyOpen(Session *session) {
+  char *dsn = (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_DSN");
+  FILE *fp;
+
+  if (!abend_test_enabled()) {
+    return sendErrorResponse(
+        session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE, RC_ERROR,
+        REASON_SERVER_ERROR,
+        "fn=denyopen is disabled. Set MVSMF_ABEND_TEST=1 in the server "
+        "environment to enable the denial-recovery test hook.",
+        NULL, 0);
+  }
+
+  if (!dsn)
+    dsn = "SYS1.SECURE.CNTL(PROFILES)";
+
+  /* No authorization check on purpose -- that is what is being bypassed. If
+   * the caller may read this, nothing abends and the handle is closed again;
+   * the probe is only meaningful with an id that may not. */
+  fp = fopen(dsn, "r");
+  if (fp) {
+    fclose(fp);
+    return sendErrorResponse(
+        session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE, RC_ERROR,
+        REASON_SERVER_ERROR,
+        "fn=denyopen: the data set opened, so nothing was denied. Use an id "
+        "that may not read it.",
+        NULL, 0);
+  }
+
+  /* fopen() returned NULL without abending: the open failed for some other
+   * reason (not cataloged, wrong DSORG). Also not what this probe is for. */
+  return sendErrorResponse(
+      session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE, RC_ERROR,
+      REASON_SERVER_ERROR,
+      "fn=denyopen: the open failed without abending, so it was not a denial.",
+      NULL, 0);
+}
+
 __asm__("\n&FUNC	SETC 'testAbend'");
 static int testAbend(Session *session) {
   if (!abend_test_enabled()) {
@@ -341,6 +401,9 @@ int testHandler(Session *session) {
 
   if (strcmp(fn, "jesabend") == 0)
     return testJesAbend(session);
+
+  if (strcmp(fn, "denyopen") == 0)
+    return testDenyOpen(session);
 
   session->headers_sent = 1;
   if ((rc = http_resp(session->httpc, 200)) < 0)
@@ -1125,7 +1188,8 @@ int testHandler(Session *session) {
         " \"?fn=userid              (http_get_userid() vs. direct ACEE decode)\","
         " \"?fn=checkauth&dsn=DS&attr=read|update|control|alter&via=raw|vector|both  (RACHECK probe; mvsmf#228)\","
         " \"?fn=password&reveal=0|1 (http_get_password() export; reveal=1 = plaintext)\","
-        " \"?fn=abend               (force S0C1 -> ESTAE recovery test; needs MVSMF_ABEND_TEST=1)\""
+        " \"?fn=abend               (force S0C1 -> ESTAE recovery test; needs MVSMF_ABEND_TEST=1)\","
+        " \"?fn=denyopen&dsn=DS      (open without authorizing -> S913 -> denial recovery; needs MVSMF_ABEND_TEST=1)\""
         " ] }\n");
   }
 

--- a/test/host/tstabnd.c
+++ b/test/host/tstabnd.c
@@ -17,6 +17,13 @@
  *      so a buffer that shrinks below the text would ship a cut-off sentence
  *      and nothing would surface it.
  *   4. A user abend renders as U0100, not as S000.
+ *   5. S913 is classified as an authorization denial and nothing else is
+ *      (#315). That one abend is a refusal OPEN made rather than a failure,
+ *      so the router answers it with the reference's authorization report
+ *      instead of the generic abend body. S213 is the trap: it comes out of
+ *      the same IEC1xx family and means "cannot be opened sequentially", so
+ *      folding it in would report an ordinary open failure as a permission
+ *      problem.
  *
  * ====================================================================
  * This test drives the REAL function: src/abendmsg.c is #included below.
@@ -110,6 +117,37 @@ int main(void)
 		abend_message(small, 10, 0xD37, 0);
 		CHECK_EQ((int) strlen(small), 9, "short buffer: truncated to fit");
 		CHECK(small[10] == (char) CANARY, "short buffer: nothing written past it");
+	}
+
+	/* 6. S913 is a denial; nothing else is (#315) */
+	{
+		const char *d = abend_denial_detail(0x913);
+
+		CHECK(d != NULL, "S913: classified as an authorization denial");
+		CHECK(d && strstr(d, "Authorization failed") != NULL,
+		      "S913: the sentence names the authorization failure");
+
+		/* The pre-check in dsapi.c refuses before any open and stops one
+		 * clause earlier. This path did abend, and the reference's own text
+		 * says so -- if the two ever became identical, one of them would be
+		 * lying about what happened. */
+		CHECK(d && strstr(d, "913 abend") != NULL,
+		      "S913: the sentence names the abend, unlike a pre-check refusal");
+
+		/* the trap: same message family, different condition */
+		CHECK(abend_denial_detail(0x213) == NULL,
+		      "S213: not a denial (cannot open sequentially)");
+		CHECK(abend_denial_detail(0x0C4) == NULL, "S0C4: not a denial");
+		CHECK(abend_denial_detail(0xD37) == NULL, "SD37: not a denial");
+		CHECK(abend_denial_detail(0x0B37) == NULL, "SB37: not a denial");
+		CHECK(abend_denial_detail(0) == NULL,
+		      "a user abend is not a denial (sys is 0)");
+
+		/* 913 must be matched as the hex completion code, not as decimal 913
+		 * -- the router derives sys with a shift and a mask, so a decimal
+		 * comparison would silently match S391 instead */
+		CHECK(abend_denial_detail(913) == NULL,
+		      "decimal 913 (S391) is not the denial code");
 	}
 
 	return mbt_test_summary("TSTABND");


### PR DESCRIPTION
The router's ESTAE turned every abend into the generic body, so a permission problem and a protection exception read alike. An S913 is not a failure — it is a refusal OPEN made — and the reference reports it as one.

Fixes #315

## The change

```
S913  -> 500 {"rc":8,"category":4,"reason":0,"message":"LMOPEN error",
              "details":["Authorization failed - You may not use this protected data set. Open 913 abend."]}
other -> unchanged: 500 {"rc":8,"category":6,"reason":99,"message":"Internal server error (abend Sxxx)"}
```

Same report the #228 pre-checks produce, differing in one clause: this path really did abend and says so — which is also what the reference's own text does. A pre-check refuses before any open and must not claim it.

**S213 stays out.** Same IEC1xx family, different condition — "cannot be opened sequentially", which `SYS1.STGINDEX` produces. Folding it in would report an ordinary open failure as a permission problem. Pinned by the host test, along with 913 being matched as a **hex** completion code: the router derives `sys` with a shift and a mask, so a decimal comparison would silently match `S391`.

The classification lives in `abendmsg.c`, not `router.c`, so the host test drives the real function — `router.c` cannot compile on the host.

## Verified live on MVS

```
1. S913  (MVSCE02, fn=denyopen on SYS1.SECURE.CNTL(PROFILES))
   {"rc":8,"category":4,"reason":0,"message":"LMOPEN error",
    "details":["Authorization failed - You may not use this protected data set. Open 913 abend."]}

2. CONTROL S0C1 (fn=abend)
   {"rc":8,"category":6,"reason":99,"message":"Internal server error (abend S0C1)"}
```

The control is the point: only 913 is special-cased, everything else keeps the code-carrying body from #256. Console for the same window:

```
RAKF0005 INVALID ATTEMPT TO ACCESS RESOURCE
RAKF000A  MVSCE02 ,HTTPD   ,DATASET ,SYS1.SECURE.CNTL
IEC150I 913-38,IFG0194C,...,SYS1.SECURE.CNTL
MVSMF901E HANDLER ABEND S913 U0000 FOR GET /zosmf/test
MVSMF901E HANDLER ABEND S0C1 U0000 FOR GET /zosmf/test
```

This mattered beyond ticking a box: whether `sendErrorResponse()` can put a `details[]` array on the wire *from the recovery path* is exactly what a host test cannot answer.

`make test-host` 220/220 (TSTABND 14 → 23 assertions), `curl-datasets.sh` 227/227.

## MVSMF901E is still issued for an S913

Unlike a refusal, an abend costs the CGI its storage subpool whatever caused it (mvslovers/httpd#154). That is something an operator must know, so this is not the `MVSMF102E` case from #317.

## fn=denyopen, and why the branch needed a hook to reach at all

#228 removed the natural way in. Its own live check — `MVSCE02` against `SYS1.SECURE.CNTL(PROFILES)` — is now refused *before* the `fopen()`, which is the entire point of those pre-checks. What is left for this branch is the cases they do not cover: a pre-check and OPEN disagreeing, and the handlers outside `dsapi.c`. A net nobody can reach is a net nobody can test, so `fn=denyopen` opens a data set without asking first.

Gated exactly like `fn=abend` on `MVSMF_ABEND_TEST`, because an abend is never free.