### PR TITLE
Document authapi.c and drop the stale cgxstart references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ clangd provides IDE diagnostics (configured in `.clangd`).
 HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsmf.c (router setup)
   → router.c (URL decode, method parse, route match, path var extraction)
     → Middleware chain (identity_middleware in mvsmf.c; logmw.c present but disabled)
-      → API handler (dsapi.c, jobsapi.c, ussapi.c, consapi.c, infoapi.c)
+      → API handler (dsapi.c, jobsapi.c, ussapi.c, consapi.c, authapi.c, infoapi.c)
         → JSON response (json.c)
 ```
 
@@ -277,21 +277,23 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
 - **consapi.c**: Console services handlers — issue command (SVC 34/MGCR), collect response, detect unsolicited keyword, hardcopy log. Reads console data from the Master Trace Table (libc370 `clibmtt`).
 - **ntstore.c**: Small persistent key/value store (LRU + TTL) used by the console cursors/detections; lives in the httpd per-CGI context.
 - **mvsmfctx.c**: Wires the per-CGI context (`MVSMF_CTX`) to httpd's `http_cgictx_get`, lazy-initialising the kv-store.
-- **infoapi.c**: `/zosmf/info` endpoint (no auth required).
+- **authapi.c**: `/zosmf/services/authenticate` token login (`authLoginHandler`, `AAPI0001`) and logout (`authLogoutHandler`, `AAPI0002`). The one route `identity_middleware` lets through without a resolved credential — a failed login has no ACEE and still has to reach the handler to get the z/OSMF-shaped 401 body. Documented in `docs/endpoints/auth/`.
+- **infoapi.c**: `/zosmf/info` endpoint — the unauthenticated liveness probe clients call before they hold a credential. It does not answer that way today: `identity_middleware` exempts only `/zosmf/services/authenticate`, so a credential-less request gets 401 (measured; #324).
 - **json.c**: JSON response builder with dynamic buffer management (`addJsonString`/`Esc`/`Number`/`Raw`, keyed arrays).
 - **common.c**: Shared utilities for parameter extraction, HTTP responses, and z/OSMF-compatible error formatting.
 - *(No `xlate.c`)* — the EBCDIC/ASCII tables live in libhttpd and are reached via `httpx->xlate_*`. See **Codepage Override**.
-- **testapi.c**: Internal `/zosmf/test` endpoint for exercising libc370 functions in isolation (`fn=version`, `fn=mtt`, `fn=cmd`, catalog/DSCB probes, …). The CGI launcher (`cgistart`, providing `@@START`) is autocalled from httpd's `libhttpd.a` — the old local `cgxstart.c` is excluded from the build.
+- **testapi.c**: Internal `/zosmf/test` endpoint for exercising libc370 functions in isolation (`fn=version`, `fn=mtt`, `fn=cmd`, catalog/DSCB probes, …). The CGI launcher (`cgistart`, providing `@@START`) is autocalled from httpd's `libhttpd.a`; this repo carries no launcher of its own.
 
 ### REST API Structure
 
 All endpoints are under `/zosmf/`:
 
-- `/zosmf/info` — system info (unauthenticated)
+- `/zosmf/info` — system info (unauthenticated by design; 401s today, #324)
 - `/zosmf/restfiles/ds/...` — dataset + PDS member operations
 - `/zosmf/restjobs/jobs/...` — job operations
 - `/zosmf/restfiles/fs/...` — USS file operations
 - `/zosmf/restconsoles/...` — console services (issue, collect, detections, hardcopy log)
+- `/zosmf/services/authenticate` — token login (POST) and logout (DELETE)
 
 Endpoint documentation lives in `docs/endpoints/` (with a curl & Zowe cookbook in `docs/examples.md`).
 

--- a/project.toml
+++ b/project.toml
@@ -22,14 +22,13 @@ cflags = ["-I", "include", '-DVERSION=\"$(PROJECT_VERSION)\"']
 
 # Single load module: a CGI program that runs under httpd.  It includes its
 # own request router + API handlers; the CGI launcher (cgistart, providing
-# @@START) is no longer carried as a local cgxstart.c copy -- it is autocalled
-# from httpd's client library (libhttpd.a), and the http_* API is reached at
-# runtime through the httpx callback table (httpcgi.h).
+# @@START) is not carried here at all -- it is autocalled from httpd's client
+# library (libhttpd.a), and the http_* API is reached at runtime through the
+# httpx callback table (httpcgi.h).
 [[module]]
 name = "MVSMF"
 startup = "crt1"
 sources = ["src/*.c"]
-exclude = ["src/cgxstart.c"]
 
 # Unit test for the persistent name/value store (MVS-only: __getm/lock/STCK).
 # norent: mbtcheck.h keeps file-static counters; a standalone test needs them

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -112,7 +112,10 @@ int main(int argc, char **argv)
 		crt->crtapp2 = httpc;
 	}
 
-	/* TODO (mig): move this into cgxstart.c */
+	/* TODO (mig): factor this wiring out of main() into a local init helper.
+	 * The original target, a local cgxstart.c, no longer exists -- the CGI
+	 * launcher comes from libhttpd now and is shared by every CGI, so mvsMF's
+	 * own router setup cannot move there. */
 	init_router(&router);
 	init_session(&session, &router, httpd, httpc);
 


### PR DESCRIPTION
Closes the two remaining items of #182. P0 (the per-path codepage rule) and P1
(the build order behind it) landed in #207; P2-1 and P2-2 went with them. This
is P2-3 and P2-4.

## P2-3 — `authapi.c` was invisible in `CLAUDE.md`

`authapi` appeared **0** times, although `src/authapi.c` ships
`authLoginHandler` / `authLogoutHandler`, both routed at `src/mvsmf.c:130-131`
and documented under `docs/endpoints/auth/`. Three places needed it, and it is
easy to fix two and leave the third: the request pipeline, the key-source-files
list, and the "REST API Structure" group list. All three are updated.

The new entry records the one thing about this file that is not obvious from
its name: it is the single route `identity_middleware` lets through without a
resolved credential, because a failed login has no ACEE and still has to reach
the handler to produce the z/OSMF-shaped 401.

## P2-4 — `cgxstart` outlived the file

The issue assumed `src/cgxstart.s` was still on disk. It is not —
`git ls-files | grep -i cgxstart` returns nothing. Three stale references:

- `CLAUDE.md` described the launcher as "the old local `cgxstart.c` … excluded
  from the build";
- `project.toml`'s `exclude = ["src/cgxstart.c"]` named a file that does not
  exist, so it excluded nothing;
- `src/mvsmf.c` carried `TODO (mig): move this into cgxstart.c`.

The comment and the exclude are gone. The TODO is kept, because the refactor it
asks for is still worth doing — but its destination cannot be `cgxstart.c`: the
launcher comes from `libhttpd.a` and is shared by every CGI, so mvsMF's own
router setup has to go into a local helper instead. The reworded TODO says
that, rather than pointing the next reader at a file that will not be found.

## One thing beyond the two items, called out rather than slipped in

`/zosmf/info` is documented — here, in `docs/endpoints/info.md:60` and in the
root `CLAUDE.md` — as the unauthenticated liveness probe. It is not one. A
credential-less `GET /zosmf/info` on mvsdev answers **401**, from mvsMF's own
`identity_middleware`, which exempts only `/zosmf/services/authenticate`.

That is #182's P2-5, the item filed as "unverifiable from this repo". It is
verifiable from a live system and it resolves the other way: the doc is right
and the code is wrong. Which layer answers is settled rather than inferred — a
credential-less `POST /zosmf/services/authenticate` reaches its handler and
returns a JSON body, so httpd is not the gate.

Correcting the doc to "`/info` requires auth" would record a conformance
violation as the design, which is the failure mode #182 exists to prevent, so
the wording stays and gains a pointer to #324 — where the actual fix lives,
together with the credential-less regression test `tests/curl-info.sh` claims to
have (line 14) but does not (line 78 sends `-u` on every request).

Note for #324: those two pointers (`CLAUDE.md:281` and `:291`) have to come out
again when the middleware is fixed, or the doc ships a stale bug reference.

## Not included

Five further sources are missing from the key-source-files list — `abendmsg.c`,
`hostparse.c`, `jclines.c`, `reclines.c`, `spoolln.c`. Outside #182's five
enumerated items; tracked separately rather than widened into this PR.

## Verification

`make` is green — removing the `exclude` changes nothing about which files
compile, because the excluded name had no file behind it.

Fixes #182
