### PR TITLE
Harden the session cookie, align the /zosmf/info payload, and write the common headers once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
 - **ntstore.c**: Small persistent key/value store (LRU + TTL) used by the console cursors/detections; lives in the httpd per-CGI context.
 - **mvsmfctx.c**: Wires the per-CGI context (`MVSMF_CTX`) to httpd's `http_cgictx_get`, lazy-initialising the kv-store.
 - **authapi.c**: `/zosmf/services/authenticate` token login (`authLoginHandler`, `AAPI0001`) and logout (`authLogoutHandler`, `AAPI0002`). The one route `identity_middleware` lets through without a resolved credential — a failed login has no ACEE and still has to reach the handler to get the z/OSMF-shaped 401 body. Documented in `docs/endpoints/auth/`.
-- **infoapi.c**: `/zosmf/info` endpoint — the unauthenticated liveness probe clients call before they hold a credential. It does not answer that way today: `identity_middleware` exempts only `/zosmf/services/authenticate`, so a credential-less request gets 401 (measured; #324).
+- **infoapi.c**: `/zosmf/info` endpoint. Authenticated like every other route — the "unauthenticated liveness probe" it was documented as until #324 never existed: `identity_middleware` exempts only `/zosmf/services/authenticate`, and the reference z/OSMF gates its own `/zosmf/info` too (measured — 401 with `WWW-Authenticate: Basic`, on every endpoint, even for a client sending `X-CSRF-ZOSMF-HEADER`). The 401 is the conformant answer; do not add an exemption for it.
 - **json.c**: JSON response builder with dynamic buffer management (`addJsonString`/`Esc`/`Number`/`Raw`, keyed arrays).
 - **common.c**: Shared utilities for parameter extraction, HTTP responses, and z/OSMF-compatible error formatting.
 - *(No `xlate.c`)* — the EBCDIC/ASCII tables live in libhttpd and are reached via `httpx->xlate_*`. See **Codepage Override**.
@@ -288,7 +288,7 @@ HTTP Request → cgistart (@@START, autocalled from httpd's libhttpd.a) → mvsm
 
 All endpoints are under `/zosmf/`:
 
-- `/zosmf/info` — system info (unauthenticated by design; 401s today, #324)
+- `/zosmf/info` — system info (authenticated, like the reference — see #324)
 - `/zosmf/restfiles/ds/...` — dataset + PDS member operations
 - `/zosmf/restjobs/jobs/...` — job operations
 - `/zosmf/restfiles/fs/...` — USS file operations

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -9,7 +9,7 @@ z/OSMF-compatible REST API for MVS 3.8j. All endpoints require Basic Auth unless
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | [`/zosmf/info`](info.md) | System information (no auth required) |
+| GET | [`/zosmf/info`](info.md) | System information |
 
 ## Authentication (`/zosmf/services`)
 

--- a/docs/endpoints/info.md
+++ b/docs/endpoints/info.md
@@ -56,17 +56,47 @@ port `8080`.
 
 ## Error Responses
 
-None. A `Host` header that cannot be parsed falls back to the defaults above and the
-request still returns 200. `/zosmf/info` is the unauthenticated liveness probe every
-client calls first and must not fail on a header quirk (issue #175). Nothing is written
-to the console: the client sent the header, so there is nothing for an operator to act on,
-and a polling client would repeat the message forever (issue #201).
+A `Host` header that cannot be parsed falls back to the defaults above and the request
+still returns 200: this is the first call every client makes and it must not fail on a
+header quirk (issue #175). Nothing is written to the console either — the client sent the
+header, so there is nothing for an operator to act on, and a polling client would repeat
+the message forever (issue #201).
+
+**A credential-less request is answered `401`.** The endpoint was documented here as the
+*unauthenticated* liveness probe until #324; it never was one. `identity_middleware` gates
+every route but `/zosmf/services/authenticate`, and that matches the reference — a real
+z/OSMF answers its own `/zosmf/info` with `401` and `WWW-Authenticate: Basic
+realm="defaultRealm"`, on every endpoint, and does not drop the challenge even for a
+client identifying itself with `X-CSRF-ZOSMF-HEADER`. Both measured. Do not add an
+exemption.
+
+## Deliberate deviations from the reference
+
+Recorded so they are not read as bugs by the next person holding the two responses side
+by side.
+
+**`zosmf_hostname` and `zosmf_port` describe the endpoint the client reached us on, not
+our own identity.** They are derived from `Host` and the `X-Forwarded-*` headers, so
+`Host: totally.made.up:9999` is answered with `"zosmf_hostname":"totally.made.up"`. The
+reference reports its own configured name instead — a client dialling one hostname gets a
+different one back. Ours is deliberate (issues #175, #260): behind a TLS-terminating
+reverse proxy the server's own name is the wrong answer for building self-referential
+URLs and the forwarded one is right, a case the reference gets wrong. `http_server_name()`
+is in the httpx vector if this is ever revisited.
+
+**`zos_version` stays free text** (`MVS 3.8j`) where the reference sends a dotted numeric
+(`05.29.00`). It is the truth, and no client parses it — Zowe prints it verbatim.
+
+**`zosmf_version` is a bare major** (`1`), matching the reference's shape (`29`) rather
+than its value; `zosmf_full_version` carries the real version. Clients compare the former
+as a string — Zowe's `CheckStatus.isZosVersionAtLeast` evaluates `zosmf_version >= "27"`
+— so `1` sorts below every z/OSMF level and clients pick their most conservative path.
 
 ## Examples
 
 ### Using curl
 ```bash
-curl http://mvs:1080/zosmf/info
+curl -u USER:PASS http://mvs:1080/zosmf/info
 ```
 
 ### Success Response
@@ -74,10 +104,15 @@ curl http://mvs:1080/zosmf/info
 {
     "zosmf_hostname": "mvs.example.org",
     "zosmf_port": "1080",
-    "zosmf_version": "1.0",
-    "zosmf_full_version": "V1R0M0",
+    "zosmf_version": "1",
+    "zosmf_full_version": "1.0.0-dev",
+    "plugins": [],
     "zosmf_saf_realm": "SAFRealm",
     "api_version": "1",
     "zos_version": "MVS 3.8j"
 }
 ```
+
+`plugins` is always empty — mvsMF has no plugin mechanism. The key is emitted rather than
+omitted because the reference always sends it; `zowe zosmf check status` then prints an
+empty list instead of a dangling heading.

--- a/include/common.h
+++ b/include/common.h
@@ -167,6 +167,19 @@ char *getHeaderParam(Session *session, const char *name) asm("CMN0003");
 const char *getRequestScheme(Session *session) asm("CMN0004");
 
 /**
+ * @brief Sends the headers every mvsMF response carries
+ *
+ * Cache-Control, Pragma, X-Content-Type-Options and Content-Language, written
+ * once for all fourteen response sites (#324). Framing stays with the caller:
+ * Content-Type, Content-Length and Transfer-Encoding depend on the status, and
+ * a 204 or 304 must carry none of them.
+ *
+ * @param session Current session context
+ * @return 0 on success, negative value on error
+ */
+int send_common_headers(Session *session) asm("CMN0016");
+
+/**
  * @brief Sends default HTTP headers for a response
  *
  * Sends standard HTTP headers including status code, content type,

--- a/src/authapi.c
+++ b/src/authapi.c
@@ -123,11 +123,7 @@ auth_send(Session *session, int status, const char *set_cookie, const char *json
 		}
 	}
 
-	rc = http_printf(httpc, "Cache-Control: no-store\r\n");
-	if (rc < 0) {
-		return rc;
-	}
-	rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n");
+	rc = send_common_headers(session);
 	if (rc < 0) {
 		return rc;
 	}

--- a/src/authapi.c
+++ b/src/authapi.c
@@ -42,8 +42,12 @@
  * credentials layout. http_get_token() returns the actual byte count. */
 #define AUTH_TOKEN_BUFSIZE    64
 
-/* "LtpaToken2=" + 44 base64 chars (32-byte token) + "; Path=/" fits easily. */
-#define AUTH_COOKIE_BUFSIZE   128
+/* "LtpaToken2=" (11) + base64 of the token + the attribute tail
+ * "; Path=/; HttpOnly; SameSite=Strict" (35).  Sized for the worst case
+ * AUTH_TOKEN_BUFSIZE allows -- 64 bytes base64 to 88 chars -- because a
+ * snprintf truncation here would silently drop an attribute and take the
+ * cookie's protection with it: 11 + 88 + 35 = 134. */
+#define AUTH_COOKIE_BUFSIZE   160
 
 /* ------------------------------------------------------------------ */
 /* Build the z/OSMF login body { returnCode, reasonCode, message }.    */
@@ -185,9 +189,21 @@ int authLoginHandler(Session *session)
 
 	/* Path=/ so the cookie is sent on the whole /zosmf API (the endpoint
 	   lives under /zosmf/services/, not root). No Secure attribute: the MVS
-	   deployment is plain HTTP and Secure would suppress the cookie. */
+	   deployment is plain HTTP and Secure would suppress the cookie.
+
+	   HttpOnly is NOT in that trade-off -- it is independent of TLS and works
+	   over plain HTTP. Without it the session token sits in document.cookie,
+	   so any XSS in the desktop lifts the whole session; that defeats #161's
+	   "no credential in the browser" goal by a second route, next to the
+	   Basic-cache one. The reference z/OSMF sends Path=/; Secure; HttpOnly.
+
+	   SameSite=Strict: every caller that needs the cookie is same-origin (the
+	   desktop is served from this httpd's DOCROOT). The cost is that a
+	   cross-site link into the desktop arrives without it and re-authenticates
+	   once; Lax would avoid that at the price of the CSRF protection. */
 	(void)snprintf(cookie, sizeof(cookie),
-	               "LtpaToken2=%s; Path=/", (char *)b64);
+	               "LtpaToken2=%s; Path=/; HttpOnly; SameSite=Strict",
+	               (char *)b64);
 
 	json = auth_body(0, 0, AUTH_MSG_SUCCESS);
 	rc = auth_send(session, HTTP_STATUS_OK, cookie, json);
@@ -218,9 +234,13 @@ int authLogoutHandler(Session *session)
 
 	/* Token invalidated: 204 No Content per the IBM logout spec; expire the
 	   cookie client-side (mirrors httpd's Sec-Token deletion). auth_send sends
-	   no body for a NULL json, and http_printf treats 204 as body-less. */
+	   no body for a NULL json, and http_printf treats 204 as body-less.
+
+	   The attributes mirror the cookie being replaced. They play no part in
+	   matching -- name, path and domain do -- but HttpOnly on the tombstone
+	   stops a script-set cookie of the same name from shadowing it. */
 	return auth_send(session, 204,
-	                 "LtpaToken2=deleted; Path=/; "
+	                 "LtpaToken2=deleted; Path=/; HttpOnly; SameSite=Strict; "
 	                 "expires=Thu, 01 Jan 1970 00:00:00 GMT",
 	                 NULL);
 }

--- a/src/common.c
+++ b/src/common.c
@@ -63,6 +63,45 @@ getRequestScheme(Session *session)
 	return "http";
 }
 
+/* The headers every mvsMF response carries, in one place.
+ *
+ * Before #324 fourteen call sites across common.c, authapi.c, dsapi.c and
+ * ussapi.c each wrote their own block, and they had drifted: two sites sent
+ * Cache-Control: no-cache where the rest sent no-store, auth_send sent neither
+ * Cache-Control nor the CORS header, and Content-Length: 0 for an empty body
+ * had been fixed in auth_send only.
+ *
+ * FRAMING STAYS WITH THE CALLER and must not move in here: Content-Type,
+ * Content-Length and Transfer-Encoding depend on the status. A 204 and a 304
+ * carry no body and no Content-Length, so a shared block that emitted one
+ * would break send_not_modified() and auth_send()'s 204 path.
+ *
+ * No Access-Control-Allow-Origin. The reference z/OSMF sends no CORS header at
+ * all, the Desktop is served from this httpd and is same-origin, and the
+ * wildcard could never have helped a cross-origin client anyway: browsers
+ * reject "*" for a credentialed request, and every mvsMF route is
+ * authenticated. It protected nothing and enabled nothing. If a cross-origin
+ * browser client is ever wanted, it needs an origin allowlist and
+ * Access-Control-Allow-Credentials, not a wildcard.
+ */
+__asm__("\n&FUNC	SETC 'send_common_headers'");
+int
+send_common_headers(Session *session)
+{
+	int rc;
+
+	if ((rc = http_printf(session->httpc,
+			"Cache-Control: no-store\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Pragma: no-cache\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"X-Content-Type-Options: nosniff\r\n")) < 0) return rc;
+	if ((rc = http_printf(session->httpc,
+			"Content-Language: en\r\n")) < 0) return rc;
+
+	return rc;
+}
+
 int
 sendDefaultHeaders(Session *session, int status, const char *content_type,
 					   size_t content_length)
@@ -88,17 +127,27 @@ sendDefaultHeaders(Session *session, int status, const char *content_type,
 		if (irc < 0) {
 			goto quit;
 		}
+	} else if (!content_type || strcmp(HTTP_CONTENT_TYPE_NONE, content_type) == 0) {
+		/* Content-Length: 0 for a body-less reply, not silence -- omitting it
+		   made httpd fall back to Transfer-Encoding: chunked on a bodiless
+		   401, where the reference sends Content-Length: 0 (#324).
+
+		   The test is the content type, NOT content_length == 0: a zero length
+		   also means "streaming, length not known yet", which is how
+		   jobsapi.c:704 and :860 read spool records -- they declare
+		   text/plain with length 0 and write the body afterwards. Announcing
+		   Content-Length: 0 there would truncate the response to nothing.
+		   HTTP_CONTENT_TYPE_NONE is the unambiguous "there is no body". */
+		irc = http_printf(session->httpc, "Content-Length: 0\r\n");
+		if (irc < 0) {
+			goto quit;
+		}
 	}
 
-  	irc = http_printf(session->httpc, "Cache-Control: no-store\r\n");
-  	if (irc < 0) {
+	irc = send_common_headers(session);
+	if (irc < 0) {
 		goto quit;
- 	}
-
-  	irc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n");
-  	if (irc < 0) {
-		goto quit;
-  	}
+	}
 
   	irc = http_printf(session->httpc, "\r\n");
   	if (irc < 0) {
@@ -230,15 +279,8 @@ send_not_modified(Session *session, const char *etag)
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc,
 			HTTP_STATUS_NOT_MODIFIED)) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Cache-Control: no-store\r\n")) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Pragma: no-cache\r\n")) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Access-Control-Allow-Origin: *\r\n")) < 0) return rc;
+	if ((rc = send_common_headers(session)) < 0) return rc;
 	if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag)) < 0) return rc;
-	if ((rc = http_printf(session->httpc,
-			"Access-Control-Expose-Headers: ETag\r\n")) < 0) return rc;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) return rc;
 
 	return rc;

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -130,18 +130,10 @@ static int send_standard_headers(Session *session, const char* content_type,
 
     session->headers_sent = 1;
     if ((rc = http_resp(session->httpc, HTTP_OK)) < 0) return rc;
-    if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) return rc;
+    if ((rc = send_common_headers(session)) < 0) return rc;
     if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", content_type)) < 0) return rc;
-    if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) return rc;
-    if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) return rc;
     if (etag) {
         if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag)) < 0) return rc;
-        /* ETag is not a CORS-safelisted response header: without this a
-           cross-origin client gets null from headers.get("ETag") and cannot
-           tell that apart from a server that has no ETag support at all.
-           Same-origin (httpd serving the Desktop) does not need it. */
-        if ((rc = http_printf(session->httpc,
-                "Access-Control-Expose-Headers: ETag\r\n")) < 0) return rc;
     }
     if ((rc = http_printf(session->httpc, "\r\n")) < 0) return rc;
 
@@ -1252,10 +1244,8 @@ int datasetListHandler(Session *session)
 	** truncation and emits no 206 on the files service at all (#274). */
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = send_common_headers(session)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
 	if ((rc = http_printf(session->httpc, "{\n")) < 0) goto quit;
@@ -1825,11 +1815,9 @@ int datasetPutHandler(Session *session)
     }
 
     if ((rc = http_printf(session->httpc, "Content-Type: application/json\r\n")) < 0) goto error;
-    if ((rc = http_printf(session->httpc, "Cache-Control: no-cache\r\n")) < 0) goto error;
+    if ((rc = send_common_headers(session)) < 0) goto error;
     if (etag_hdr) {
         if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag_hdr)) < 0) goto error;
-        if ((rc = http_printf(session->httpc,
-                "Access-Control-Expose-Headers: ETag\r\n")) < 0) goto error;
     }
     if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto error;
 
@@ -2193,10 +2181,8 @@ int memberListHandler(Session *session)
 	   than reading the directory a second time before the header goes out. */
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = send_common_headers(session)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
 	if ((rc = http_printf(session->httpc, "{\n")) < 0) goto quit;
@@ -2739,11 +2725,9 @@ int memberPutHandler(Session *session)
     }
 
     if ((rc = http_printf(session->httpc, "Content-Type: application/json\r\n")) < 0) goto error;
-    if ((rc = http_printf(session->httpc, "Cache-Control: no-cache\r\n")) < 0) goto error;
+    if ((rc = send_common_headers(session)) < 0) goto error;
     if (etag_hdr) {
         if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag_hdr)) < 0) goto error;
-        if ((rc = http_printf(session->httpc,
-                "Access-Control-Expose-Headers: ETag\r\n")) < 0) goto error;
     }
     if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto error;
 

--- a/src/infoapi.c
+++ b/src/infoapi.c
@@ -46,12 +46,16 @@ infoHandler(Session *session)
 	char *value = getHeaderParam(session, "Host"); // e.g. "example.org:8080"
 	if (value) {
 		/* A Host header this handler cannot make sense of must not fail the
-		   request: /zosmf/info is the unauthenticated liveness probe every
-		   client calls first, and it used to answer an odd Host by sending
-		   nothing at all and dropping the connection (issue #175). Fall back
-		   silently and still answer 200 -- the client sent the header, so the
-		   operator has nothing to act on, and a probing client would repeat
-		   the message on every poll (issue #201).
+		   request: /zosmf/info is the first call every client makes, and it
+		   used to answer an odd Host by sending nothing at all and dropping
+		   the connection (issue #175). Fall back silently and still answer
+		   200 -- the client sent the header, so the operator has nothing to
+		   act on, and a probing client would repeat the message on every poll
+		   (issue #201).
+
+		   Not "the unauthenticated probe" it was documented as until #324:
+		   this endpoint is gated like every other, and so is the reference's
+		   (measured -- it answers 401 with WWW-Authenticate: Basic).
 
 		   This fallback is only as good as the parser's honesty about
 		   failing: a value with no host name in front of the colon used to
@@ -77,10 +81,23 @@ infoHandler(Session *session)
 		goto quit;
 	}
 
+	/* zosmf_version is a bare major, the shape the reference uses (it sends
+	   "29"); zosmf_full_version carries our real version. Clients compare
+	   the former as a STRING -- Zowe's CheckStatus.isZosVersionAtLeast does
+	   `zosmf_version >= "27"` -- so "1" sorts below every z/OSMF level and
+	   they select their most conservative code path, which is what we want.
+
+	   The literal is the MAJOR of this project's version and has to be bumped
+	   with it; it cannot be derived from VERSION without parsing the string at
+	   runtime, which is not worth a GETMAIN on every request.
+
+	   plugins is empty rather than absent: we have none, and the reference
+	   always emits the key, so an empty array is the honest match. */
 	if (addJsonString(builder, "zosmf_hostname", hostname) < 0 ||
 		addJsonString(builder, "zosmf_port", port_str) < 0 ||
-		addJsonString(builder, "zosmf_version", VERSION) < 0 ||
+		addJsonString(builder, "zosmf_version", "1") < 0 ||
 		addJsonString(builder, "zosmf_full_version", VERSION) < 0 ||
+		addJsonRaw(builder, "plugins", "[]") < 0 ||
 		addJsonString(builder, "zosmf_saf_realm", "SAFRealm") < 0 ||
 		addJsonString(builder, "api_version", "1") < 0 ||
 		addJsonString(builder, "zos_version", "MVS 3.8j") < 0) {

--- a/src/ussapi.c
+++ b/src/ussapi.c
@@ -429,10 +429,8 @@ uss_stat_file(Session *session, UFS *ufs, const char *path)
 	// Send single-item response with full path in name
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = send_common_headers(session)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
 	rc = http_printf(session->httpc,
@@ -524,10 +522,8 @@ int ussListHandler(Session *session)
 	   a second open of every directory the client puts a limit on. */
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = send_common_headers(session)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", "application/json")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
 	if ((rc = http_printf(session->httpc, "{\n")) < 0) goto quit;
@@ -719,17 +715,10 @@ int ussGetHandler(Session *session)
 
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 200)) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
+	if ((rc = send_common_headers(session)) < 0) goto quit;
 	if ((rc = http_printf(session->httpc, "Content-Type: %s\r\n", content_type)) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Pragma: no-cache\r\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
 	if (etag_hdr) {
 		if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag_hdr)) < 0) goto quit;
-		/* ETag is not a CORS-safelisted response header: without this a
-		   cross-origin client gets null from headers.get("ETag") and
-		   cannot tell that apart from a server with no ETag support. */
-		if ((rc = http_printf(session->httpc,
-			"Access-Control-Expose-Headers: ETag\r\n")) < 0) goto quit;
 	}
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 
@@ -784,12 +773,7 @@ uss_handle_chtag(Session *session, const char *filepath, const char *body)
 		if (http_resp(session->httpc, 200) < 0) return -1;
 		if (http_printf(session->httpc,
 			"Content-Type: application/json\r\n") < 0) return -1;
-		if (http_printf(session->httpc,
-			"Cache-Control: no-store\r\n") < 0) return -1;
-		if (http_printf(session->httpc,
-			"Pragma: no-cache\r\n") < 0) return -1;
-		if (http_printf(session->httpc,
-			"Access-Control-Allow-Origin: *\r\n") < 0) return -1;
+		if (send_common_headers(session) < 0) return -1;
 		if (http_printf(session->httpc, "\r\n") < 0) return -1;
 
 		if (http_printf(session->httpc,
@@ -1004,12 +988,9 @@ int ussPutHandler(Session *session)
 	// sendDefaultHeaders(), which has nowhere to put the ETag.
 	session->headers_sent = 1;
 	if ((rc = http_resp(session->httpc, 204)) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Cache-Control: no-store\r\n")) < 0) goto quit;
-	if ((rc = http_printf(session->httpc, "Access-Control-Allow-Origin: *\r\n")) < 0) goto quit;
+	if ((rc = send_common_headers(session)) < 0) goto quit;
 	if (etag_hdr) {
 		if ((rc = http_printf(session->httpc, "ETag: %s\r\n", etag_hdr)) < 0) goto quit;
-		if ((rc = http_printf(session->httpc,
-			"Access-Control-Expose-Headers: ETag\r\n")) < 0) goto quit;
 	}
 	if ((rc = http_printf(session->httpc, "\r\n")) < 0) goto quit;
 

--- a/tests/curl-info.sh
+++ b/tests/curl-info.sh
@@ -11,9 +11,14 @@
 #                               else X-Forwarded-Proto, else 80 (issue #175)
 #
 # A Host header this handler cannot make sense of must never fail the
-# request: /zosmf/info is the unauthenticated liveness probe every client
-# calls first. Before #175 a port-less Host answered nothing at all and
-# dropped the connection (curl exit 52 / HTTP 000).
+# request: /zosmf/info is the first call every client makes. Before #175 a
+# port-less Host answered nothing at all and dropped the connection (curl
+# exit 52 / HTTP 000).
+#
+# The endpoint is NOT unauthenticated, though it was documented as such
+# until #324 -- including in this header. Every request below therefore
+# carries -u, and the last test pins the credential-less 401 down so the
+# exemption does not get added back off a stale doc line.
 #
 # Prerequisites:
 #   - Copy .env.example to .env at the repo root and fill in
@@ -76,6 +81,13 @@ trap 'rm -f "$BODYF"' EXIT
 # Every argument is passed to curl verbatim (use one -H per header).
 info() {
 	CODE=$(curl -s -u "$AUTH" -o "$BODYF" -w '%{http_code}' "$@" "$INFO_URL")
+	BODY=$(cat "$BODYF")
+}
+
+# The same call with NO credentials at all -- not even an empty -u, which would
+# still send an Authorization header and test something else.
+info_anon() {
+	CODE=$(curl -s -o "$BODYF" -w '%{http_code}' "$@" "$INFO_URL")
 	BODY=$(cat "$BODYF")
 }
 
@@ -200,6 +212,21 @@ if [ -n "$(echo "$BODY" | jq -r '.zosmf_version // empty' 2>/dev/null)" ]; then
 else
 	fail "zosmf_version is present" "missing or empty"
 fi
+
+# =========================================================================
+# 6. Authentication is required (issue #324)
+# =========================================================================
+echo ""
+echo "--- authentication ---"
+
+# This endpoint was documented as the unauthenticated liveness probe until
+# #324 and never was one. The reference z/OSMF gates its own /zosmf/info the
+# same way -- measured: 401 with WWW-Authenticate: Basic realm="defaultRealm",
+# on every endpoint, and not dropped even for a client sending
+# X-CSRF-ZOSMF-HEADER. This test exists so the exemption does not get added
+# back by someone who finds a stale doc line.
+info_anon -H "Host: ${TEST_HOST}:${MVSMF_PORT}"
+assert_http_status "401" "$CODE" "a credential-less request is refused"
 
 # =========================================================================
 # Summary


### PR DESCRIPTION
Everything in #324 that does not depend on the outstanding browser measurement:
the cookie hardening, the `/zosmf/info` payload, the auth-claim correction, and
the header consolidation the rest of the issue needs as a foundation. **A1
(`WWW-Authenticate`) is not here** — it waits on whether a browser `fetch`
actually pops the native dialog, which decides whether the special case is
needed at all.

## The session cookie was missing `HttpOnly`

`src/authapi.c` built `"LtpaToken2=%s; Path=/"`. The comment there correctly
justified dropping `Secure` — plain HTTP would suppress the cookie — but is
silent on `HttpOnly`, which is independent of TLS and works over plain HTTP.
Without it the session token sits in `document.cookie`, so any XSS in the
Desktop lifts the whole session. That defeats #161's "no credential in the
browser" goal by a second route, next to the Basic-cache one. The reference
sends `Path=/; Secure; HttpOnly`.

Added `HttpOnly` and `SameSite=Strict`, on the logout tombstone as well so a
script-set cookie of the same name cannot shadow it. `SameSite=Strict` costs one
re-authentication when a cross-site link leads into the Desktop; `Lax` would
avoid that and give up the CSRF protection.

The longer attribute tail outgrows the cookie buffer in the worst case
`AUTH_TOKEN_BUFSIZE` allows — `11 + 88 + 35 = 134 > 128` — and an `snprintf`
truncation there would silently drop an attribute and its protection with it, so
the buffer goes to 160.

## `/zosmf/info` payload

`zosmf_version` becomes a bare major (`"1"`), the shape the reference uses (it
sends `"29"`), with `zosmf_full_version` keeping the real version. Clients
compare that field as a **string** — Zowe's `CheckStatus.isZosVersionAtLeast`
evaluates `zosmf_version >= "27"` — so `"1"` sorts below every z/OSMF level and
clients pick their most conservative code path.

`plugins` is emitted as an empty array. We have none; the reference always sends
the key, and `zowe zosmf check status` then prints an empty list instead of a
dangling heading.

## The auth claim was wrong in six places

`/zosmf/info` was documented as the unauthenticated liveness probe in
`CLAUDE.md` (2×), `docs/endpoints/README.md`, `docs/endpoints/info.md`,
`tests/curl-info.sh` and `src/infoapi.c`. It never was one: `identity_middleware`
exempts only `/zosmf/services/authenticate`. The reference gates its own
`/zosmf/info` the same way — measured, `401` with `WWW-Authenticate: Basic
realm="defaultRealm"`, on every endpoint, and not dropped even for a client
sending `X-CSRF-ZOSMF-HEADER`.

So our 401 is the conformant answer and the documentation moves, not the code.
`tests/curl-info.sh` gains the credential-less 401 as an assertion: the suite
sent `-u` on every request and asserted nothing about the claim in its own
header comment. #175's behaviour is untouched — an unparsable `Host` must still
not fail the request; only the "because it is unauthenticated" justification is
gone.

## Fourteen header blocks became one

`sendDefaultHeaders()` was not the only place mvsMF wrote response headers.
Fourteen sites across `common.c`, `authapi.c`, `dsapi.c` and `ussapi.c` each
wrote their own, and they had drifted:

- `dsapi.c` sent `Cache-Control: no-cache` on two write paths where everything
  else sent `no-store`
- `auth_send` sent neither `Cache-Control` nor the CORS header
- the `Content-Length: 0` correction for an empty body had been made in
  `auth_send` alone — with a comment describing exactly the chunked-empty-body
  problem the other paths still had

`send_common_headers()` now writes `Cache-Control`, `Pragma`,
`X-Content-Type-Options` and `Content-Language`. **Framing deliberately stays
with the caller**: `Content-Type`, `Content-Length` and `Transfer-Encoding`
depend on the status, and a 204 or 304 carries none of them, so folding framing
into the shared block would break `send_not_modified()` and `auth_send()`'s 204
path.

`X-Content-Type-Options: nosniff` is new and matches the reference. Its
`X-XSS-Protection` is **not** copied: the header is deprecated and ignored by
current browsers, so aligning literally would carry over a Liberty default
rather than a protection.

### The CORS wildcard was never doing anything

`Access-Control-Allow-Origin: *` is gone, along with
`Access-Control-Expose-Headers` which only had meaning beside it. Beyond the
reference sending no CORS header and the Desktop being same-origin: browsers
**reject `*` for a credentialed request**, and every mvsMF route is
authenticated. The wildcard could not have served a cross-origin browser client
at any point. A future one needs an origin allowlist plus
`Access-Control-Allow-Credentials`.

### One trap avoided

`sendDefaultHeaders()` now announces `Content-Length: 0` on a body-less reply.
The test is the **content type**, not a zero length: a zero length also means
"streaming, length not yet known", which is how `jobsapi.c:704` and `:860`
declare the spool reads before writing the body. Keying on `content_length == 0`
would have announced `Content-Length: 0` there and truncated every spool
response to nothing. `HTTP_CONTENT_TYPE_NONE` is the unambiguous "there is no
body", and all five callers that pass it were checked.

## Verification

Deployed and activated on mvsdev; `?fn=version` reports `24a29b7` = this branch's
HEAD, so the measurements below are of this build and not the previous one.

```
$ curl -s -D- -o /dev/null http://mvsdev.lan:8080/zosmf/info
HTTP/1.1 401 Unauthorized
Content-Length: 0                 <- was Transfer-Encoding: chunked
Cache-Control: no-store
Pragma: no-cache
X-Content-Type-Options: nosniff   <- new
Content-Language: en              <- new
                                  <- no Access-Control-* at all

$ curl -s -u … http://mvsdev.lan:8080/zosmf/info
{"zosmf_hostname":"mvsdev.lan","zosmf_port":"8080","zosmf_version":"1",
 "zosmf_full_version":"1.0.0-dev","plugins":[],"zosmf_saf_realm":"SAFRealm",
 "api_version":"1","zos_version":"MVS 3.8j"}

$ curl -s -D- -o /dev/null -u … -X POST …/zosmf/services/authenticate
Set-Cookie: LtpaToken2=<redacted>; Path=/; HttpOnly; SameSite=Strict
```

Full curl suites against that build — **587 passed, 0 failed**:

| Suite | Result |
|---|---|
| `curl-info.sh` | 41 / 41 |
| `curl-datasets.sh` | 227 / 227 |
| `curl-binary.sh` | 10 / 10 |
| `curl-uss.sh` | 128 / 128 |
| `curl-jobs.sh` | 117 / 117, 2 skipped |
| `curl-console.sh` | 64 / 64 |

The two skips are the dataset-submit cases waiting on the
`IBMUSER.MVSMF.TESTJCL` fixture — pre-existing and unrelated. `curl-jobs` and
`curl-binary` are the ones that matter for the header refactor: they exercise
the streaming spool reads and the raw binary payload paths.

## Note for whoever adds a header next

`include/common.h` had a **duplicate `asm()` symbol** at one point during this
work — `CMN0020` was already taken — and neither `cc370` nor `ld370` said
anything. Check the symbol is free before adding one; the build will not.

Refs #324
