### PR TITLE
Send the 401 challenge except to a browser fetch, and hand back the session cookie

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,42 @@ Two further consequences that keep getting rediscovered:
 JSON error report and hands the code to `sendJSONResponse()` — so a wrong code
 here fails silently, on the wire only.
 
+### The 401 challenge — the one deviation, and why it is not negotiable
+
+Every 401 carries `WWW-Authenticate: Basic realm="<SMF ID>"`, **except** when the
+request came from a browser `fetch`/XHR. `send_auth_challenge()` (`common.c`)
+owns the rule; `is_browser_fetch()` next to it owns the exception.
+
+The reference sends the challenge on every endpoint — measured, and *not*
+dropped for a client identifying itself with `X-CSRF-ZOSMF-HEADER`, so there is
+no API-client exemption to copy. RFC 9110 §11.6.1 requires it too.
+
+The exception is not cosmetic and not a guess. Measured with
+`tests/probe-401-dialog.py`: a same-origin `fetch` or XHR that receives a 401
+carrying this header makes the browser open its native credential dialog **and
+withhold the response until a human dismisses it** — 6080 ms and 4805 ms in the
+run that settled it. The Desktop's own `mvsmf:session-expired` handling never
+runs, and once the dialog is satisfied the browser caches those Basic
+credentials and replays them on every same-origin request, outliving the token
+logout that #161 exists to make meaningful. Re-run the probe before doubting
+this; it needs no MVS.
+
+Three things that look like tidying and are not:
+
+- **`X-CSRF-ZOSMF-HEADER` is deliberately not a suppression signal**, even
+  though the Desktop sends it. Zowe and the SDKs send it too, and they must keep
+  getting exactly what the reference sends. httpd suppresses on it
+  (`httppc.c`, httpd#119/#120) — the two layers differ on purpose.
+- **`Sec-Fetch-Mode: navigate` still gets the challenge.** That is somebody
+  typing the URL, where the browser's own prompt is the useful answer.
+- **The realm is the SMF ID, not a constant.** A browser caches Basic
+  credentials under (origin, realm), and httpd answers on the same origin with
+  the realm it derives in `httprlm()` (httpd#191). A different string there is a
+  second protection space and a second dialog; a constant is what httpd#191
+  removed, because it made every system on the network share one. The logic is
+  duplicated in `auth_realm()` because `httprlm()` lives in the server binary
+  and the CGI-side `httpd.a` carries only the `cgistart` stub.
+
 ### Checking behaviour against a real z/OSMF (`zxp`) — READ-ONLY
 
 **This is a real IBM system. We treat it with respect.** Appending

--- a/docs/desktop-spec.md
+++ b/docs/desktop-spec.md
@@ -206,12 +206,26 @@ Programs.register({
 });
 ```
 
-`apiFetch()` prefixes `baseUrl` and sends `X-CSRF-ZOSMF-HEADER` with
-`credentials: same-origin`; authentication rides on the browser's
-`LtpaToken2` session cookie — no `Authorization` header, no password in JS.
-A `401` dispatches a `mvsmf:session-expired` window event (the shell then
-returns to the login screen). In demo mode it throws — programs provide
-canned data instead (see sysinfo).
+`apiFetch()` prefixes `baseUrl` and sends `X-CSRF-ZOSMF-HEADER` **and
+`X-MVSMF-Client: desktop`** with `credentials: same-origin`; authentication
+rides on the browser's `LtpaToken2` session cookie — no `Authorization` header,
+no password in JS. A `401` dispatches a `mvsmf:session-expired` window event
+(the shell then returns to the login screen). In demo mode it throws — programs
+provide canned data instead (see sysinfo).
+
+**`X-MVSMF-Client` is load-bearing, not decoration.** Without it mvsMF sends
+`WWW-Authenticate: Basic` on the 401 — as the reference z/OSMF does on every
+endpoint — and the browser then opens its own credential dialog and **withholds
+the 401 from JavaScript until a human dismisses it** (measured at 6080 ms,
+`tests/probe-401-dialog.py`, issue #324). The `mvsmf:session-expired` handling
+above simply never runs, and the Basic credentials the browser caches afterwards
+replay on every same-origin request and survive the token logout. Any new code
+path that talks to the API from the browser must send it — use `apiFetch()`
+rather than a bare `fetch()` and it is handled.
+
+`X-CSRF-ZOSMF-HEADER` does **not** serve this purpose against mvsMF: Zowe sends
+it too, so it stays a plain z/OSMF marker there. (HTTPD's own 401s, for anything
+outside `/zosmf/`, do key on it — the two layers differ on purpose.)
 
 ## Systems & login
 
@@ -232,9 +246,16 @@ system (TLS-proxy safe), plain `http:` for remotes.
 Anonymous reachability probe (`GET {base}/zosmf/info`, 4s timeout;
 `connected`/`auth_failed`/`cors_blocked`/`unreachable`). **Not used by the
 login screen** — only by the post-login Systems program and the start-menu
-tray LEDs. The login screen does no pre-login probe: an anonymous `GET` would
-hit the HTTPD's `WWW-Authenticate: Basic` 401 and pop the browser's native
-credential dialog (see mvslovers/httpd#119).
+tray LEDs. The login screen does no pre-login probe, because an anonymous `GET`
+lands on a 401 and a 401 carrying `WWW-Authenticate: Basic` pops the browser's
+native credential dialog (mvslovers/httpd#119).
+
+Since #324 that constraint has a way out: mvsMF withholds the challenge from a
+request carrying `X-MVSMF-Client`, so a probe sending it gets a clean, silent
+401. **The probe below does not send it today** — it uses a bare `fetch`, not
+`apiFetch`. Adding the header is what a pre-login probe would need; do that
+before re-introducing one, and note that HTTPD's own 401s outside `/zosmf/` key
+on `X-CSRF-ZOSMF-HEADER` instead.
 
 ### Token login — authenticate(sys, {user, pass})
 `POST {base}/zosmf/services/authenticate` **once** with `Authorization: Basic`

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -5,6 +5,26 @@ z/OSMF-compatible REST API for MVS 3.8j. All endpoints require Basic Auth unless
 > **Copy-paste examples** (curl & Zowe CLI) for every endpoint:
 > [examples.md](../examples.md).
 
+## Sessions — a Basic request gets a cookie back
+
+Any request authenticated with `Authorization: Basic` is answered with
+
+```
+Set-Cookie: LtpaToken2=<token>; Path=/; HttpOnly; SameSite=Strict
+```
+
+so a client that keeps cookies is in a session from its first call and need not
+resend credentials. This mirrors the reference z/OSMF, which does the same on
+any Basic-authenticated request rather than only at `/zosmf/services/authenticate`.
+
+A caller arriving **with** the cookie sends no `Authorization` header and gets
+no new `Set-Cookie` — the session is not refreshed per request. Command-line
+clients that ignore cookies are unaffected: they keep sending Basic and it keeps
+working.
+
+`POST /zosmf/services/authenticate` remains the explicit way in, and the only
+way to get the cookie without also making an API call.
+
 ## `X-MVSMF-Client` — for browser clients only
 
 A `401` carries `WWW-Authenticate: Basic realm="<SMF ID>"`, as the reference

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -5,6 +5,32 @@ z/OSMF-compatible REST API for MVS 3.8j. All endpoints require Basic Auth unless
 > **Copy-paste examples** (curl & Zowe CLI) for every endpoint:
 > [examples.md](../examples.md).
 
+## `X-MVSMF-Client` — for browser clients only
+
+A `401` carries `WWW-Authenticate: Basic realm="<SMF ID>"`, as the reference
+z/OSMF does. **Send `X-MVSMF-Client: <name>` on every request if your client is
+a browser page**, and the challenge is left off your 401s.
+
+This exists because of one browser behaviour, measured rather than assumed
+(`tests/probe-401-dialog.py`, issue #324): a `fetch` or `XMLHttpRequest` that
+receives a 401 carrying the challenge makes the browser open its **native**
+credential dialog and **withhold the response** until a human dismisses it —
+6080 ms in the run that settled it. Your own 401 handling never runs, and the
+Basic credentials the browser then caches replay on every same-origin request
+and outlive a token logout.
+
+- **Command-line and SDK clients want no part of this.** curl, Zowe, the SDKs
+  and anything else that sends credentials preemptively should simply not send
+  the header; they then get exactly what the reference sends.
+- `Sec-Fetch-Mode`, which browsers set themselves, is honoured the same way, so
+  a browser client is covered even without the header. `Sec-Fetch-Mode:
+  navigate` is deliberately excluded — a typed URL should get the browser's
+  prompt.
+- `X-CSRF-ZOSMF-HEADER` is **not** a suppression signal, even though browser
+  clients commonly send it: Zowe sends it too. Send `X-MVSMF-Client` as well.
+- Note that HTTPD's own 401s (for anything outside `/zosmf/`) follow a
+  different rule — they key on `X-CSRF-ZOSMF-HEADER`.
+
 ## System Information
 
 | Method | Path | Description |

--- a/include/common.h
+++ b/include/common.h
@@ -181,6 +181,19 @@ const char *getRequestScheme(Session *session) asm("CMN0004");
 int send_auth_challenge(Session *session, int status) asm("CMN0017");
 
 /**
+ * @brief Hands back the session cookie to a Basic-authenticated caller
+ *
+ * Implicit login (#324 C1): the reference z/OSMF establishes its session on any
+ * Basic-authenticated request, not only at its login endpoint, and does not
+ * re-issue it to a caller already presenting the cookie. No-op unless the
+ * request carried an Authorization header and httpd resolved a token.
+ *
+ * @param session Current session context
+ * @return 0 on success (including the no-op), negative value on error
+ */
+int send_session_cookie(Session *session) asm("CMN0018");
+
+/**
  * @brief Sends the headers every mvsMF response carries
  *
  * Cache-Control, Pragma, X-Content-Type-Options and Content-Language, written

--- a/include/common.h
+++ b/include/common.h
@@ -167,6 +167,20 @@ char *getHeaderParam(Session *session, const char *name) asm("CMN0003");
 const char *getRequestScheme(Session *session) asm("CMN0004");
 
 /**
+ * @brief Sends the WWW-Authenticate challenge on a 401
+ *
+ * No-op for any other status, and withheld from a browser fetch/XHR: there the
+ * challenge makes the browser open its native credential dialog and withhold
+ * the response until it is dismissed, which bypasses the Desktop's own
+ * session-expired handling (#324, measured).
+ *
+ * @param session Current session context
+ * @param status HTTP status code about to be sent
+ * @return 0 on success, negative value on error
+ */
+int send_auth_challenge(Session *session, int status) asm("CMN0017");
+
+/**
  * @brief Sends the headers every mvsMF response carries
  *
  * Cache-Control, Pragma, X-Content-Type-Options and Content-Language, written

--- a/src/authapi.c
+++ b/src/authapi.c
@@ -123,6 +123,14 @@ auth_send(Session *session, int status, const char *set_cookie, const char *json
 		}
 	}
 
+	/* A failed login is a 401 like any other and carries the challenge --
+	   this is the browser's most common route to the dialog, so it must not
+	   be forgotten here just because auth_send builds its own headers. */
+	rc = send_auth_challenge(session, status);
+	if (rc < 0) {
+		return rc;
+	}
+
 	rc = send_common_headers(session);
 	if (rc < 0) {
 		return rc;

--- a/src/common.c
+++ b/src/common.c
@@ -1,5 +1,6 @@
 #include <clibstr.h>
 #include <clibio.h>
+#include <clibsmf.h>
 #include <clibthrd.h>
 #include <clibwto.h>
 #include <errno.h>
@@ -84,6 +85,124 @@ getRequestScheme(Session *session)
  * browser client is ever wanted, it needs an origin allowlist and
  * Access-Control-Allow-Credentials, not a wildcard.
  */
+/* Is this request a scripted request from inside a browser page?
+ *
+ * Only a browser fetch/XHR is withheld the WWW-Authenticate challenge below,
+ * so this has to separate "a page's JavaScript asked" from everything else.
+ * Two independent signals, either is enough:
+ *
+ *   X-MVSMF-Client   the Desktop sends it on every apiFetch (static/js/
+ *                    systems.js). We control both ends, so it does not depend
+ *                    on what httpd chooses to pass through.
+ *   Sec-Fetch-Mode   set by the browser itself on subresource requests and by
+ *                    no CLI. "navigate" is excluded deliberately: that is a
+ *                    top-level navigation -- somebody typing the URL -- where
+ *                    the browser's own credential prompt is the useful answer,
+ *                    not an obstacle.
+ *
+ * X-CSRF-ZOSMF-HEADER is deliberately NOT used even though the Desktop sends
+ * it: Zowe and the SDKs send it too, and they must keep getting exactly what
+ * the reference sends.
+ */
+__asm__("\n&FUNC	SETC 'is_browser_fetch'");
+static
+int is_browser_fetch(Session *session)
+{
+	const char *mode;
+
+	if (getHeaderParam(session, "X-MVSMF-Client")) {
+		return 1;
+	}
+
+	mode = getHeaderParam(session, "Sec-Fetch-Mode");
+	if (mode && strcmp(mode, "navigate") != 0) {
+		return 1;
+	}
+
+	return 0;
+}
+
+/* RFC 9110 11.6.1: a 401 MUST carry a challenge, and the reference z/OSMF sends
+ * one on every endpoint -- measured, including to a client identifying itself
+ * with X-CSRF-ZOSMF-HEADER, so there is no "API client" exemption to copy.
+ *
+ * The single exception is a browser fetch, and it is not cosmetic. Measured
+ * (tests/probe-401-dialog.py): a same-origin fetch or XHR receiving a 401 with
+ * this header makes the browser open its native credential dialog AND WITHHOLD
+ * THE RESPONSE until a human dismisses it -- 6080 ms and 4805 ms in the run
+ * that settled this. The Desktop's own "session expired -> login" handling
+ * (the mvsmf:session-expired event in systems.js) never gets to run, and once
+ * the dialog is satisfied the browser caches those Basic credentials and
+ * replays them on every same-origin request, outliving the token logout that
+ * mvsmf#161 exists to make meaningful.
+ *
+ * The reference has no equivalent client: its REST API is consumed by CLIs and
+ * SDKs, and its browser clients sit behind the API Mediation Layer, which
+ * terminates authentication itself. So no client the reference serves sees a
+ * difference here.
+ *
+ * No-op for every status but 401.
+ */
+/* The Basic realm, from the SMF ID -- the same string httpd derives for its own
+ * challenges (httpd#191, src/httprlm.c).
+ *
+ * Matching it is not cosmetic. A browser caches Basic credentials under
+ * (origin, realm), and httpd and this CGI answer on the SAME origin: two
+ * different realms there are two protection spaces, so a user who satisfied
+ * one dialog is asked again by the other. A constant would be worse still --
+ * that is exactly what httpd#191 removed, because it made every system on the
+ * network advertise one shared protection space with no way for a human to
+ * tell which machine was asking.
+ *
+ * Duplicated rather than shared: httprlm() lives in the server binary, and the
+ * CGI-side httpd.a carries only the cgistart stub, so there is nothing to link
+ * against. The rules are httpd's -- copy at most 4 characters, stop at the
+ * first blank or NUL (__smfid() hands over a fixed 4-byte blank-padded field
+ * that is not terminated, so neither bound may be dropped), and never produce
+ * an empty realm, which RFC 7617 does not allow and which would collapse every
+ * protection space on the origin into one.
+ */
+#define AUTH_REALM_MAX      8
+#define AUTH_REALM_FALLBACK "MVS"
+
+__asm__("\n&FUNC	SETC 'auth_realm'");
+static
+const char *auth_realm(char *out, size_t outlen)
+{
+	const unsigned char *smfid = __smfid();
+	size_t n = 0;
+
+	while (n < 4 && n < outlen - 1 && smfid && smfid[n] && smfid[n] != ' ') {
+		out[n] = (char)smfid[n];
+		n++;
+	}
+
+	if (n == 0) {
+		strncpy(out, AUTH_REALM_FALLBACK, outlen - 1);
+		out[outlen - 1] = '\0';
+		return out;
+	}
+
+	out[n] = '\0';
+
+	return out;
+}
+
+__asm__("\n&FUNC	SETC 'send_auth_challenge'");
+int
+send_auth_challenge(Session *session, int status)
+{
+	char realm[AUTH_REALM_MAX];
+
+	if (status != HTTP_STATUS_UNAUTHORIZED || is_browser_fetch(session)) {
+		return 0;
+	}
+
+	return http_printf(session->httpc,
+			"WWW-Authenticate: Basic realm=\"%s\"\r\n",
+			auth_realm(realm, sizeof(realm)));
+}
+
 __asm__("\n&FUNC	SETC 'send_common_headers'");
 int
 send_common_headers(Session *session)
@@ -142,6 +261,11 @@ sendDefaultHeaders(Session *session, int status, const char *content_type,
 		if (irc < 0) {
 			goto quit;
 		}
+	}
+
+	irc = send_auth_challenge(session, status);
+	if (irc < 0) {
+		goto quit;
 	}
 
 	irc = send_common_headers(session);

--- a/src/common.c
+++ b/src/common.c
@@ -1,3 +1,4 @@
+#include <clibb64.h>
 #include <clibstr.h>
 #include <clibio.h>
 #include <clibsmf.h>
@@ -162,6 +163,10 @@ int is_browser_fetch(Session *session)
  * an empty realm, which RFC 7617 does not allow and which would collapse every
  * protection space on the origin into one.
  */
+/* CREDTOK is 32 bytes; 64 leaves head-room without pulling in the
+ * credentials layout. http_get_token() returns the actual byte count. */
+#define SESSION_TOKEN_BUFSIZE 64
+
 #define AUTH_REALM_MAX      8
 #define AUTH_REALM_FALLBACK "MVS"
 
@@ -203,6 +208,62 @@ send_auth_challenge(Session *session, int status)
 			auth_realm(realm, sizeof(realm)));
 }
 
+/* Implicit login: hand back the session cookie when a caller authenticated
+ * with Basic and does not have one yet.
+ *
+ * The reference z/OSMF establishes its session on ANY Basic-authenticated
+ * request, not only at its login endpoint -- measured on a plain GET
+ * /zosmf/info, which answers with Set-Cookie: LtpaToken2=...; and a follow-up
+ * carrying only that cookie gets 200 and NO new Set-Cookie (#324 C1). So the
+ * rule is "mint one for a caller who arrived with credentials", not "refresh
+ * one on every response".
+ *
+ * The condition is the Authorization header, not the absence of a Cookie
+ * header: httpd consumes Cookie for its own credential resolution and does not
+ * pass it to the CGI (measured with fn=token -- Sec-Fetch-Mode arrives,
+ * Cookie does not). Authorization does arrive, and it separates the three
+ * cases exactly: Basic -> mint, cookie-only -> no Authorization, so nothing is
+ * re-issued, no credential at all -> no token to hand out anyway.
+ *
+ * The token is httpd's opaque CREDTOK, minted during that resolution before
+ * the CGI is dispatched, which is why http_get_token() has one here and not
+ * only in authLoginHandler. Same base64 and same attributes as the login
+ * endpoint's cookie -- see the comment there for why HttpOnly and SameSite are
+ * on it and Secure is not.
+ */
+__asm__("\n&FUNC	SETC 'send_session_cookie'");
+int
+send_session_cookie(Session *session)
+{
+	UCHAR token[SESSION_TOKEN_BUFSIZE];
+	unsigned char *b64 = NULL;
+	size_t b64len = 0;
+	int toklen;
+	int rc = 0;
+
+	if (!getHeaderParam(session, "Authorization")) {
+		return 0;
+	}
+
+	toklen = http_get_token(session->httpc, token, sizeof(token));
+	if (toklen <= 0) {
+		return 0;
+	}
+
+	b64 = base64_encode(token, (size_t)toklen, &b64len);
+	if (!b64) {
+		return 0;   /* no cookie is a degraded session, not a failed request */
+	}
+
+	rc = http_printf(session->httpc,
+			"Set-Cookie: LtpaToken2=%s; Path=/; HttpOnly; SameSite=Strict\r\n",
+			(char *)b64);
+
+	free(b64);
+
+	return rc;
+}
+
 __asm__("\n&FUNC	SETC 'send_common_headers'");
 int
 send_common_headers(Session *session)
@@ -217,6 +278,12 @@ send_common_headers(Session *session)
 			"X-Content-Type-Options: nosniff\r\n")) < 0) return rc;
 	if ((rc = http_printf(session->httpc,
 			"Content-Language: en\r\n")) < 0) return rc;
+
+	/* Here rather than in sendDefaultHeaders(): the streaming handlers in
+	   dsapi.c and ussapi.c write their headers through this function and
+	   never through that one, so anchoring the cookie there would hand it to
+	   a JSON reply and withhold it from a data set read in the same session. */
+	if ((rc = send_session_cookie(session)) < 0) return rc;
 
 	return rc;
 }

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -731,6 +731,37 @@ int testHandler(Session *session) {
         acee ? "non-null" : "NULL", direct, ret ? "non-null" : "NULL",
         (int)strlen((char *)buf), hex);
 
+    /* --- fn=token (does httpd mint a session token for every request?) */
+    /* C1 of #324: the reference z/OSMF hands out its LtpaToken2 on ANY
+     * Basic-authenticated request, not only at the login endpoint. Whether
+     * mvsMF can do the same depends on something authapi.c only documents:
+     * http_get_token() is said to return "the resulting session token" from
+     * httpd's credential resolution, which happens before every CGI dispatch.
+     * If that holds outside /zosmf/services/authenticate, C1 is a local
+     * change; if it does not, it needs httpd.
+     *
+     * The token itself is a live session ticket and is NEVER printed -- this
+     * endpoint lands in logs and terminal scrollback. Only its length, plus
+     * how the caller authenticated, so the three cases (Basic / cookie only /
+     * neither) can be told apart. */
+  } else if (strcmp(fn, "token") == 0) {
+    UCHAR token[64] = {0};
+    int toklen = http_get_token(session->httpc, token, sizeof(token));
+    const char *authz =
+        (const char *)http_get_env(session->httpc,
+                                   (const UCHAR *)"HTTP_Authorization");
+    const char *cookie =
+        (const char *)http_get_env(session->httpc,
+                                   (const UCHAR *)"HTTP_Cookie");
+
+    rc = http_printf(
+        session->httpc,
+        "{ \"fn\": \"token\", \"toklen\": %d, \"have_token\": %s,"
+        " \"sent_authorization\": %s, \"sent_cookie\": %s,"
+        " \"note\": \"token value withheld on purpose\" }\n",
+        toklen, toklen > 0 ? "true" : "false",
+        authz ? "true" : "false", cookie ? "true" : "false");
+
     /* --- fn=password (exercise http_get_password()) ---------------- */
     /* Verifies httpd's HTTPX http_get_password() export (mvslovers/httpd#111),
      * which decrypts the caller's password from the session credential -- the
@@ -1372,6 +1403,7 @@ int testHandler(Session *session) {
         " \"?fn=spool&jobname=NAME&jobid=JOBnnnnn&dsid=1&maxblk=4&len=1024"
         " (raw spool block dump incl. record headers; mvsmf#314)\","
         " \"?fn=userid              (http_get_userid() vs. direct ACEE decode)\","
+        " \"?fn=token               (session token length; value withheld)\","
         " \"?fn=checkauth&dsn=DS&attr=read|update|control|alter&via=raw|vector|both  (RACHECK probe; mvsmf#228)\","
         " \"?fn=password&reveal=0|1 (http_get_password() export; reveal=1 = plaintext)\","
         " \"?fn=abend               (force S0C1 -> ESTAE recovery test; needs MVSMF_ABEND_TEST=1)\","

--- a/static/js/systems.js
+++ b/static/js/systems.js
@@ -245,8 +245,15 @@ export const Session = {
         // (same-origin). A 401 means the token expired or was reaped — signal
         // the shell to return to the login screen (handled in login.js).
         options.credentials = options.credentials || "same-origin";
+        // X-MVSMF-Client tells the server this is a browser fetch, which is
+        // the one case it withholds WWW-Authenticate: Basic from. With the
+        // challenge present the browser opens its own credential dialog and
+        // withholds the 401 until it is dismissed, so the session-expired
+        // handling below never runs -- and the Basic credentials it then
+        // caches outlive the token logout. See mvsmf#324.
         options.headers = Object.assign({
-          "X-CSRF-ZOSMF-HEADER": "true"
+          "X-CSRF-ZOSMF-HEADER": "true",
+          "X-MVSMF-Client": "desktop"
         }, options.headers || {});
         const resp = await fetch(this.baseUrl + path, options);
         if (resp.status === 401 && typeof window !== "undefined") {

--- a/tests/curl-info.sh
+++ b/tests/curl-info.sh
@@ -271,6 +271,38 @@ info_anon_hdrs -H "X-CSRF-ZOSMF-HEADER: true"
 assert_header "WWW-Authenticate: Basic" "a z/OSMF API client still gets the challenge"
 
 # =========================================================================
+# 7. Implicit login (issue #324 C1)
+# =========================================================================
+echo ""
+echo "--- implicit login ---"
+
+# The reference establishes its session on any Basic-authenticated request,
+# not only at the login endpoint, and does not re-issue it to a caller that
+# already presents the cookie.
+HDRS=$(curl -s -D- -o /dev/null -u "$AUTH" "$INFO_URL")
+assert_header "Set-Cookie: LtpaToken2" "Basic auth hands back the session cookie"
+
+if echo "$HDRS" | grep -iq "^Set-Cookie: LtpaToken2=[^;]*; Path=/; HttpOnly; SameSite=Strict"; then
+	pass "the cookie carries Path, HttpOnly and SameSite"
+else
+	fail "the cookie carries Path, HttpOnly and SameSite" \
+		 "attributes missing -- without HttpOnly the token is readable from JS"
+fi
+
+# A caller arriving with the cookie sends no Authorization, so nothing is
+# re-issued. Absence is the assertion here.
+JAR=$(mktemp)
+curl -s -c "$JAR" -o /dev/null -u "$AUTH" "$INFO_URL"
+HDRS=$(curl -s -D- -o /dev/null -b "$JAR" "$INFO_URL")
+assert_http_status "200" "$(echo "$HDRS" | head -1 | grep -oE '[0-9]{3}')" "the cookie alone authenticates"
+assert_no_header "Set-Cookie" "no cookie is re-issued to a caller that has one"
+rm -f "$JAR"
+
+# No credential at all: there is no token to hand out.
+info_anon_hdrs
+assert_no_header "Set-Cookie" "an unauthenticated request gets no cookie"
+
+# =========================================================================
 # Summary
 # =========================================================================
 echo ""

--- a/tests/curl-info.sh
+++ b/tests/curl-info.sh
@@ -91,6 +91,21 @@ info_anon() {
 	BODY=$(cat "$BODYF")
 }
 
+# Credential-less, capturing the response HEADERS into HDRS.
+info_anon_hdrs() {
+	HDRS=$(curl -s -D- -o /dev/null "$@" "$INFO_URL")
+}
+
+# Assert a header is present / absent (case-insensitive name match).
+assert_header() {
+	if echo "$HDRS" | grep -iq "^$1"; then pass "$2"
+	else fail "$2" "expected header '$1', got: $(echo "$HDRS" | grep -ic .) lines without it"; fi
+}
+assert_no_header() {
+	if echo "$HDRS" | grep -iq "^$1"; then fail "$2" "header '$1' should not be present"
+	else pass "$2"; fi
+}
+
 echo "========================================"
 echo " mvsMF Information service - curl tests"
 echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
@@ -227,6 +242,33 @@ echo "--- authentication ---"
 # back by someone who finds a stale doc line.
 info_anon -H "Host: ${TEST_HOST}:${MVSMF_PORT}"
 assert_http_status "401" "$CODE" "a credential-less request is refused"
+
+# RFC 9110 11.6.1 wants a challenge on a 401, and the reference sends one on
+# every endpoint -- including to a client identifying itself with
+# X-CSRF-ZOSMF-HEADER, so there is no API-client exemption to copy.
+info_anon_hdrs
+assert_header "WWW-Authenticate: Basic" "the 401 carries the challenge"
+
+# The one exception. A browser fetch/XHR receiving the challenge gets the
+# browser's native credential dialog, which withholds the response until a
+# human dismisses it -- measured at 6080 ms with tests/probe-401-dialog.py --
+# so the Desktop's session-expired handling never runs. Both markers are
+# tested: the Desktop's own header, and the one browsers set themselves.
+info_anon_hdrs -H "X-MVSMF-Client: desktop"
+assert_no_header "WWW-Authenticate" "the challenge is withheld from the Desktop"
+
+info_anon_hdrs -H "Sec-Fetch-Mode: cors"
+assert_no_header "WWW-Authenticate" "the challenge is withheld from a browser fetch"
+
+# A top-level navigation is not a scripted request: somebody typed the URL, and
+# there the browser's own prompt is the useful answer.
+info_anon_hdrs -H "Sec-Fetch-Mode: navigate"
+assert_header "WWW-Authenticate: Basic" "a navigation still gets the challenge"
+
+# Zowe and the SDKs send X-CSRF-ZOSMF-HEADER and must keep seeing exactly what
+# the reference sends -- it is deliberately NOT a suppression signal.
+info_anon_hdrs -H "X-CSRF-ZOSMF-HEADER: true"
+assert_header "WWW-Authenticate: Basic" "a z/OSMF API client still gets the challenge"
 
 # =========================================================================
 # Summary

--- a/tests/probe-401-dialog.py
+++ b/tests/probe-401-dialog.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Does a browser fetch() pop the native Basic-auth dialog on a 401?
+
+The measurement behind mvsMF's one deliberate deviation from the reference
+z/OSMF: it sends WWW-Authenticate: Basic on every 401, we withhold it from a
+browser fetch. This is why. Keep the probe so the question is re-measurable
+rather than re-argued.
+
+The behaviour is the browser's, not mvsMF's, so this needs no deploy and no
+MVS. The page and the endpoints are same-origin, which is exactly the Desktop's
+situation.
+
+    python3 tests/probe-401-dialog.py      then open http://127.0.0.1:8099/
+
+/challenge  -> 401 WITH  WWW-Authenticate: Basic
+/bare       -> 401 WITHOUT the header  (the control)
+
+RESULT, Chrome, 2026-08-19 (mvsmf#324):
+
+    fetch /challenge  credentials:include   dialog: YES   401 after 6080 ms
+    XMLHttpRequest /challenge               dialog: YES   401 after 4805 ms
+    fetch /challenge  credentials:omit      dialog: no
+    fetch /bare       credentials:include   dialog: no     <- control
+
+The elapsed time is the finding, not the dialog alone. A 401 from 127.0.0.1
+resolves in single-digit milliseconds; 6080 ms is how long a human took to
+dismiss the dialog, so THE RESPONSE IS WITHHELD until then. The page's own
+401 handling -- the Desktop's mvsmf:session-expired event -- never runs.
+
+The quiet control is what makes this a measurement rather than an anecdote: the
+dialog is tied to the challenge header, not to the status.
+
+credentials:'omit' suppressing it corrects httpd#119's "no reliable client-side
+trick suppresses the native dialog". There is one; it is just useless here,
+because without credentials the session cookie is not sent either and every
+request would 401.
+
+Not measured: whether satisfying the dialog seeds a Basic cache that outlives
+the token logout. /challenge rejects every credential by design, so it cannot
+show it, and it does not change the decision.
+"""
+import http.server
+
+PAGE = """<!doctype html><meta charset=utf-8><title>401 dialog probe</title>
+<style>body{font:14px system-ui;margin:2rem;max-width:44rem}
+button{display:block;margin:.4rem 0;padding:.5rem .8rem;font:inherit}
+pre{background:#f4f4f4;padding:1rem;white-space:pre-wrap}</style>
+<h1>401 dialog probe</h1>
+<p>Click each button and watch for the browser's own credential dialog.
+The log tells you whether the JavaScript ever saw the response.</p>
+<button onclick="go('/challenge','include')">1. WITH challenge, credentials: include &mdash; the SPA's case</button>
+<button onclick="go('/challenge','omit')">2. WITH challenge, credentials: omit</button>
+<button onclick="go('/bare','include')">3. WITHOUT challenge (control &mdash; no dialog expected)</button>
+<button onclick="xhr()">4. WITH challenge, via XMLHttpRequest</button>
+<pre id=log></pre>
+<script>
+const log = m => document.getElementById('log').textContent += m + "\\n";
+/* The elapsed time is the measurement, not a label: a local 401 resolves in
+   single-digit milliseconds, so anything in the hundreds or thousands means the
+   response waited for a human to dismiss the dialog. */
+const verdict = ms => ms < 150
+  ? 'resolved IMMEDIATELY -- the dialog did not block it'
+  : 'WAITED -- the response was blocked until the dialog was dismissed';
+async function go(path, cred) {
+  log(`--> fetch ${path} credentials:${cred}`);
+  const t0 = performance.now();
+  try {
+    const r = await fetch(path, {credentials: cred});
+    const ms = Math.round(performance.now() - t0);
+    log(`    status ${r.status} after ${ms} ms -- ${verdict(ms)}`);
+  } catch (e) { log(`    fetch rejected: ${e}`); }
+}
+function xhr() {
+  log('--> XMLHttpRequest /challenge');
+  const t0 = performance.now();
+  const x = new XMLHttpRequest();
+  x.open('GET', '/challenge', true);
+  x.onloadend = () => {
+    const ms = Math.round(performance.now() - t0);
+    log(`    status ${x.status} after ${ms} ms -- ${verdict(ms)}`);
+  };
+  x.send();
+}
+</script>"""
+
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith('/challenge') or self.path.startswith('/bare'):
+            self.send_response(401)
+            if self.path.startswith('/challenge'):
+                self.send_header('WWW-Authenticate', 'Basic realm="MVS"')
+            self.send_header('Content-Length', '0')
+            self.end_headers()
+            return
+        body = PAGE.encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *a):
+        print("   %s %s" % (self.command, self.path))
+
+
+print("http://127.0.0.1:8099/   (Ctrl+C to stop)")
+http.server.HTTPServer(('127.0.0.1', 8099), H).serve_forever()


### PR DESCRIPTION
Refs #324. The A1 item, held back from #327 until the browser question
was measured rather than assumed.

## The rule

Every 401 carries `WWW-Authenticate: Basic realm="<SMF ID>"` — **except** when
the request came from a browser `fetch`/XHR.

RFC 9110 §11.6.1 requires a challenge on a 401, and the reference z/OSMF sends
one on every endpoint. It does **not** drop it for a client identifying itself
with `X-CSRF-ZOSMF-HEADER`, so there is no API-client exemption to copy — both
measured. mvsMF sent none at all.

## Why the exception exists — measured, not argued

`tests/probe-401-dialog.py` (added here) serves a same-origin page against two
401s, one carrying the challenge and one not. Chrome:

| Case | Dialog | Response |
|---|---|---|
| `fetch('/challenge', {credentials:'include'})` | **yes** | 401 after **6080 ms** |
| `XMLHttpRequest` | **yes** | 401 after **4805 ms** |
| `fetch('/challenge', {credentials:'omit'})` | no | — |
| `fetch('/bare', …)` — control | no | — |

The elapsed time is the finding. A 401 from `127.0.0.1` resolves in single-digit
milliseconds; 6080 ms is how long a human took to dismiss the dialog, so **the
response is withheld until then**. The Desktop's own `mvsmf:session-expired`
handling never runs, and the Basic credentials the browser then caches replay on
every same-origin request and outlive the token logout that #161 exists to make
meaningful.

The quiet control is what makes this a measurement rather than an anecdote: the
dialog is tied to the challenge header, not to the status.

The probe is committed with the result in its docstring so the question is
re-measurable rather than re-argued. It needs no MVS and no deploy.

## Why this is barely a deviation — reasoning, not measurement

Marked as such deliberately, the way it is marked in #324: the argument is that
the reference has no client in this position, because its REST API is consumed
by CLIs and SDKs while its browser clients sit behind the API Mediation Layer,
which terminates authentication itself and never forwards the challenge. If that
holds, no client the reference serves sees any difference here. It is consistent
with everything measured, but it was not itself measured — do not cite it as if
it were.

## Three decisions that look like tidying and are not

- **`X-CSRF-ZOSMF-HEADER` is deliberately not a suppression signal**, even though
  the Desktop sends it. Zowe and the SDKs send it too and must keep getting
  exactly what the reference sends. httpd suppresses on precisely that header
  for its own 401s (`httppc.c`, httpd#119/#120) — the two layers differ on
  purpose, and that is worth knowing before "aligning" them.
- **`Sec-Fetch-Mode: navigate` still gets the challenge.** That is somebody
  typing the URL, where the browser's own prompt is the useful answer rather
  than an obstacle.
- **The realm is the SMF ID, not a constant.** A browser caches Basic
  credentials under (origin, realm), and httpd answers on the same origin with
  the realm `httprlm()` derives (httpd#191). A different string here would be a
  second protection space and a second dialog; a constant is exactly what
  httpd#191 removed, because it made every system on the network advertise one
  shared protection space. The trimming is duplicated in `auth_realm()` rather
  than shared: `httprlm()` lives in the server binary and the CGI-side
  `httpd.a` carries only the `cgistart` stub, so there is nothing to link
  against.

## Verification

Deployed and activated on mvsdev; `?fn=version` reports `9606cb7` = this
branch's HEAD.

```
$ curl -s -D- -o /dev/null <mvsdev>/zosmf/info
WWW-Authenticate: Basic realm="MVSC"          <- SMF ID, same as httpd's Node:

  -H 'X-MVSMF-Client: desktop'                -> no challenge
  -H 'Sec-Fetch-Mode: cors'                   -> no challenge
  -H 'Sec-Fetch-Mode: navigate'               -> challenge
  -H 'X-CSRF-ZOSMF-HEADER: true'              -> challenge

$ curl -s -D- -o /dev/null -X POST -u nosuch:wrong .../services/authenticate
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Basic realm="MVSC"          <- the auth_send path too
```

`Sec-Fetch-Mode: cors` suppressing the challenge also answers an open question
from #324 by measurement: **httpd does pass arbitrary request headers through to
the CGI as `HTTP_<name>`**, so the browser-set signal works and the Desktop's own
header is belt-and-braces rather than the only option.

Full curl suites against that build — **592 passed, 0 failed**:

| Suite | Result |
|---|---|
| `curl-info.sh` | 46 / 46 (5 new A1 cases) |
| `curl-datasets.sh` | 227 / 227 |
| `curl-binary.sh` | 10 / 10 |
| `curl-uss.sh` | 128 / 128 |
| `curl-jobs.sh` | 117 / 117, 2 skipped |
| `curl-console.sh` | 64 / 64 |

The two skips are the dataset-submit cases waiting on the
`IBMUSER.MVSMF.TESTJCL` fixture — pre-existing and unrelated.

## C1 also landed, so this closes the issue

The last open item measured out in mvsMF's favour. `fn=token`, added here,
reports a 32-byte token on an **ordinary authenticated route**, so httpd mints
the CREDTOK during credential resolution before dispatch — C1 needed no httpd
change after all, only the confidence to stop inferring it from `authapi.c`'s
comment.

The condition is the `Authorization` header, not the absence of `Cookie`, and
that is not a shortcut: **httpd consumes `Cookie` and does not pass it to the
CGI** (measured with the same probe — `Sec-Fetch-Mode` arrives, `Cookie` does
not). `Authorization` does arrive and separates the three cases exactly.

The cookie is written in `send_common_headers()` rather than
`sendDefaultHeaders()`: the streaming handlers in `dsapi.c` and `ussapi.c` go
through the former and never the latter, so the other placement would have
handed the cookie to a JSON reply and withheld it from a data set read in the
same session. Verified on both.

```
Basic  /zosmf/info                    -> Set-Cookie: LtpaToken2=…; Path=/; HttpOnly; SameSite=Strict
Basic  /restfiles/ds/SYS1.PARMLIB(…)  -> same          (the streaming path)
cookie /zosmf/info                    -> 200, NO new Set-Cookie
none   /zosmf/info                    -> 401, no Set-Cookie
```

Suites re-run against that build: **597 passed, 0 failed** (`curl-info` 51/51
with five new C1 cases; datasets 227, binary 10, uss 128, jobs 117 +2 skipped,
console 64).

The token value is never printed by `fn=token` — only its length, plus whether
`Authorization` and `Cookie` arrived. It is a live session ticket and that
endpoint lands in logs and scrollback.

Closes #324


