### PR TITLE
Fold data set names to upper case

### DIFF
--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -93,6 +93,21 @@ Volume-specific variants: `/zosmf/restfiles/ds/-({volser})/{name}` for GET and P
 | GET | [`/zosmf/restfiles/ds/{name}({member})`](datasets/members-get.md) | Read PDS member |
 | PUT | [`/zosmf/restfiles/ds/{name}({member})`](datasets/members-put.md) | Write PDS member |
 
+## Data set names are folded to upper case
+
+Every data set, member and `dslevel` name on the `/zosmf/restfiles/ds` endpoints
+is upper-cased before it is used, so `ibmuser.cntl`, `IBMUSER.CNTL` and
+`IBMUSER.cntl` all address the same data set. Trailing blanks are trimmed.
+
+This matches z/OSMF, which folds both the path variable and the `dslevel` query
+value. It applies to the names in a `rename` control body as well.
+
+A name longer than its limit is **refused with 400**, not truncated — 44
+characters for a data set or `dslevel`, 8 for a member.
+
+**USS paths are not folded.** `/zosmf/restfiles/fs` addresses a case-sensitive
+file system, where `/tmp/Foo` and `/tmp/foo` are different files.
+
 ## USS Files (`/zosmf/restfiles/fs`)
 
 | Method | Path | Description |

--- a/docs/endpoints/datasets/list.md
+++ b/docs/endpoints/datasets/list.md
@@ -9,7 +9,7 @@ GET
 `/zosmf/restfiles/ds`
 
 ## Query Parameters
-- `dslevel` (required): Dataset name filter pattern. Supports exact names (`USER.TEST.DATA`), hierarchical prefixes (`USER.TEST`), and wildcard patterns (`USER.*`, `USER.**`, `USER.C*`). Internally, the longest concrete prefix is used for the catalog lookup and any wildcard or extra-qualifier filtering is applied afterwards.
+- `dslevel` (required): Dataset name filter pattern. Upper-cased before use, so `mike.test` and `MIKE.TEST` are equivalent; a value longer than 44 characters is refused with `400`. Supports exact names (`USER.TEST.DATA`), hierarchical prefixes (`USER.TEST`), and wildcard patterns (`USER.*`, `USER.**`, `USER.C*`). Internally, the longest concrete prefix is used for the catalog lookup and any wildcard or extra-qualifier filtering is applied afterwards.
 - `volser` (optional): Filter by volume serial
 - `start` (optional): Starting dataset name for pagination. The listing begins
   at this name — **inclusive**, as in z/OSMF — and runs to the end of the list.

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -55,6 +55,61 @@ static int dataset_etag(Session *session, const char *dataset,
 static int check_if_match(Session *session, const char *dataset,
                           long max_records);
 static int require_access(Session *session, const char *dsname, int attr);
+static int normalize_dsn(const char *value, char *out, size_t outlen);
+
+/* Fold a data set, member or qualifier name from the request into the form MVS
+   actually stores: copy it out of httpd's environment storage, drop trailing
+   blanks, and upper-case it.
+
+   Catalog entries, VTOC entries and PDS directory names are all upper case, so
+   a name that reaches __locate() or fopen() as the client typed it matches
+   nothing -- which is what made every lower-case request a 404 or an empty
+   listing (#334). Real z/OSMF folds both the {dataset-name} path variable and
+   the dslevel query value; measured, so this is what makes mvsMF agree with it.
+
+   Two properties are load-bearing and both fail silently if dropped.
+
+   It COPIES rather than folding in place: the value is httpd's environment
+   storage, not ours, and other readers of the same request see it afterwards.
+
+   And it is the length check as well as the fold, so the two cannot disagree.
+   That is not tidiness -- extract_level_prefix() used to strcpy() an unbounded
+   dslevel into a 45-byte stack buffer (#337), and the only reason that is now
+   unreachable is that an over-long value is refused here, before the split.
+
+   Callers must fold BEFORE require_access(). http_check_auth() normalizes SAF
+   rc 4 ("no profile covers the resource") to 0 = permitted, so authorizing the
+   name as typed and then operating on the folded one lets a lower-case name be
+   permitted by no-match and go on to touch the real data set.
+
+   Returns 1 when the value fit, 0 when it was absent, empty, or too long for
+   out. Shaped deliberately like make_query_key() below, which does the same job
+   for start= and pattern=. */
+__asm__("\n&FUNC    SETC 'normalize_dsn'");
+static int
+normalize_dsn(const char *value, char *out, size_t outlen)
+{
+	size_t	n;
+	size_t	i;
+
+	if (!value || outlen == 0) {
+		return 0;
+	}
+
+	n = strlen(value);
+	while (n > 0 && value[n - 1] == ' ') n--;
+
+	if (n == 0 || n > outlen - 1) {
+		return 0;
+	}
+
+	for (i = 0; i < n; i++) {
+		out[i] = (char) toupper((unsigned char) value[i]);
+	}
+	out[n] = '\0';
+
+	return 1;
+}
 
 /* Authorization gate for a data set operation (issue #228).
  *
@@ -825,11 +880,20 @@ static int write_record_open(Session *session, FILE **fp, const char *target,
 ** extract_level_prefix - split a dslevel pattern into a catalog LEVEL
 ** prefix and an optional wildcard filter for __listds().
 **
-** level_out must be at least 45 bytes. *filter_out is set to the
-** original dslevel when post-filtering is needed, NULL otherwise.
+** level_size bounds every write to level_out. It is a parameter rather than
+** the comment it used to be ("must be at least 45 bytes") because all three
+** copies below are input-derived: with a 45-byte caller buffer and a query
+** value httpd allows to reach 4000, this smashed the caller's stack (#337).
+** normalize_dsn() refuses an over-long dslevel before it ever gets here, so
+** truncation is unreachable today -- the bound exists so that a future caller
+** cannot reintroduce the overflow by getting that wrong.
+**
+** *filter_out is set to the original dslevel when post-filtering is needed,
+** NULL otherwise.
 */
 static void
-extract_level_prefix(const char *dslevel, char *level_out, char **filter_out)
+extract_level_prefix(const char *dslevel, char *level_out, size_t level_size,
+		     char **filter_out)
 {
 	const char	*p;
 	const char	*last_dot = NULL;
@@ -854,7 +918,8 @@ extract_level_prefix(const char *dslevel, char *level_out, char **filter_out)
 		/* No wildcards: pass through as catalog LEVEL, no filter.
 		** Caller handles z/OSMF prefix semantics (the exact name
 		** plus anything below it) separately. */
-		strcpy(level_out, dslevel);
+		strncpy(level_out, dslevel, level_size - 1);
+		level_out[level_size - 1] = '\0';
 		return;
 	}
 
@@ -883,11 +948,14 @@ extract_level_prefix(const char *dslevel, char *level_out, char **filter_out)
 		}
 
 		if (prefix_end && prefix_end > dslevel) {
-			memcpy(level_out, dslevel, prefix_end - dslevel);
-			level_out[prefix_end - dslevel] = '\0';
+			size_t plen = (size_t)(prefix_end - dslevel);
+			if (plen > level_size - 1) plen = level_size - 1;
+			memcpy(level_out, dslevel, plen);
+			level_out[plen] = '\0';
 		} else {
 			/* wildcard in first qualifier — use full dslevel */
-			strcpy(level_out, dslevel);
+			strncpy(level_out, dslevel, level_size - 1);
+			level_out[level_size - 1] = '\0';
 		}
 
 		/* HLQ.** is equivalent to bare HLQ, no filter needed */
@@ -1082,6 +1150,7 @@ int datasetListHandler(Session *session)
 	char		*start		= NULL;
 	char		*filter		= NULL;
 	char		level_buf[45]	= {0};
+	char		dslevel_buf[MAX_DATASET_NAME + 1] = {0};
 	char		start_key[MAX_DATASET_NAME + 1] = {0};
 	int		have_start	= 0;
 	int		start_after	= 0;
@@ -1095,7 +1164,25 @@ int datasetListHandler(Session *session)
 	volser	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_VOLSER");
 	start 	= (char *) http_get_env(session->httpc, (const UCHAR *) "QUERY_START");
 
-	extract_level_prefix(dslevel, level_buf, &filter);
+	/* Fold before anything reads the catalog (#334). Everything downstream then
+	   works on the folded name -- including `filter`, which extract_level_prefix()
+	   aliases to this pointer, and the exact-name lookup below, which uses it
+	   directly in __locate()/__dscbdv(). dslevel_buf is function-scoped for that
+	   reason: its lifetime has to cover the whole listing loop.
+
+	   An empty dslevel is not an error -- it means "list everything", which is
+	   what extract_level_prefix() already does with it. An over-long one is
+	   refused rather than truncated: silently listing a different level is worse
+	   than saying no, and this refusal is what keeps #337 unreachable. */
+	if (dslevel && *dslevel) {
+		if (!normalize_dsn(dslevel, dslevel_buf, sizeof(dslevel_buf))) {
+			return handle_error(session, ERR_INVALID_PARAM,
+				"Dataset level is too long");
+		}
+		dslevel = dslevel_buf;
+	}
+
+	extract_level_prefix(dslevel, level_buf, sizeof(level_buf), &filter);
 	dslist = __listds(level_buf, "NONVSAM VOLUME", filter);
 
 	/* z/OSMF prefix semantics: a bare multi-qualifier dslevel like
@@ -1348,10 +1435,21 @@ int datasetGetHandler(Session *session)
     FILE *fp = NULL;
 
     // Validate parameters
+    char dsn_buf[MAX_DATASET_NAME + 1];
     dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
     if (!dsname) {
         return handle_error(session, ERR_INVALID_PARAM, "Dataset name is required");
     }
+
+    /* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+       ("no profile covers the resource") as permitted, so authorizing the name
+       as typed and then operating on the folded one would let a lower-case name
+       pass by no-match. */
+    if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
+        return handle_error(session, ERR_INVALID_PARAM,
+            "Dataset name is too long");
+    }
+    dsname = dsn_buf;
 
     /* Authorize before anything looks at the data set (issue #228).
        Ahead of is_pds(), not after it: is_pds() reads the catalog and the VTOC
@@ -1450,11 +1548,22 @@ int datasetPutHandler(Session *session)
     int blksize = 0;
 
     // Validate parameters
+    char dsn_buf[MAX_DATASET_NAME + 1];
     dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
 
     if (!dsname) {
         return handle_error(session, ERR_INVALID_PARAM, "Dataset name is required");
     }
+
+    /* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+       ("no profile covers the resource") as permitted, so authorizing the name
+       as typed and then operating on the folded one would let a lower-case name
+       pass by no-match. */
+    if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
+        return handle_error(session, ERR_INVALID_PARAM,
+            "Dataset name is too long");
+    }
+    dsname = dsn_buf;
 
     // z/OSMF control request (rename): Content-Type: application/json.
     // Must be handled before the existence/PDS checks because the target
@@ -2088,11 +2197,29 @@ int memberListHandler(Session *session)
 	int		have_pattern	= 0;
 
 
+	char		dsn_buf[MAX_DATASET_NAME + 1];
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
 	if (!dsname){
 		rc = http_resp_internal_error(session->httpc);
 		goto quit;
 	}
+
+	/* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+	   ("no profile covers the resource") as permitted, so authorizing the name
+	   as typed and then operating on the folded one would let a lower-case name
+	   pass by no-match.
+
+	   goto quit, not return: this handler owns an fp by the time it reaches the
+	   end, and every other early exit here goes through the label. fp is still
+	   NULL at this point, so the two are equivalent today -- which is exactly
+	   why the wrong one would survive review and then break when something is
+	   allocated above it. */
+	if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
+		rc = (unsigned) handle_error(session, ERR_INVALID_PARAM,
+				"Dataset name is too long");
+		goto quit;
+	}
+	dsname = dsn_buf;
 
 	/* Authorize before the directory is read (issue #228). This listing is
 	   unlike the dslevel one in #229: it opens the PDS with BPAM, so it has
@@ -2233,6 +2360,8 @@ int memberGetHandler(Session *session)
     FILE *fp = NULL;
 
     // Validate parameters
+    char dsn_buf[MAX_DATASET_NAME + 1];
+    char mbr_buf[MAX_MEMBER_NAME + 1];
     dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
     member = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_member-name");
 
@@ -2240,10 +2369,21 @@ int memberGetHandler(Session *session)
         return handle_error(session, ERR_INVALID_PARAM, "Dataset and member names are required");
     }
 
-    // Validate dsname and member individually (not combined — qualified form fits MAX_QUALIFIED_DSN)
-    if (strlen(dsname) > MAX_DATASET_NAME || strlen(member) > MAX_MEMBER_NAME) {
-        return handle_error(session, ERR_INVALID_PARAM, "Dataset or member name too long");
+    /* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+       ("no profile covers the resource") as permitted, so authorizing the name
+       as typed and then operating on the folded one would let a lower-case name
+       pass by no-match. */
+    if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
+        return handle_error(session, ERR_INVALID_PARAM,
+            "Dataset name is too long");
     }
+    dsname = dsn_buf;
+
+    if (!normalize_dsn(member, mbr_buf, sizeof(mbr_buf))) {
+        return handle_error(session, ERR_INVALID_PARAM,
+            "Member name is too long");
+    }
+    member = mbr_buf;
 
     // Create dataset path
     snprintf(dataset, sizeof(dataset), "%s(%s)", dsname, member);
@@ -2331,6 +2471,8 @@ int memberPutHandler(Session *session)
     int blksize = 0;
 
     // Validate parameters
+    char dsn_buf[MAX_DATASET_NAME + 1];
+    char mbr_buf[MAX_MEMBER_NAME + 1];
     dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
     member = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_member-name");
 
@@ -2338,6 +2480,22 @@ int memberPutHandler(Session *session)
 
         return handle_error(session, ERR_INVALID_PARAM, "Dataset and member names are required");
     }
+
+    /* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+       ("no profile covers the resource") as permitted, so authorizing the name
+       as typed and then operating on the folded one would let a lower-case name
+       pass by no-match. */
+    if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
+        return handle_error(session, ERR_INVALID_PARAM,
+            "Dataset name is too long");
+    }
+    dsname = dsn_buf;
+
+    if (!normalize_dsn(member, mbr_buf, sizeof(mbr_buf))) {
+        return handle_error(session, ERR_INVALID_PARAM,
+            "Member name is too long");
+    }
+    member = mbr_buf;
 
     // z/OSMF control request (rename): Content-Type: application/json.
     // Must be handled before opening the (new) member for writing.
@@ -2352,11 +2510,6 @@ int memberPutHandler(Session *session)
        is an update of the PDS; there is no member-level profile to ask about. */
     if (require_access(session, dsname, RACF_ATTR_UPDATE) != 0) {
         return 0;
-    }
-
-    // Validate dsname and member individually (not combined — qualified form fits MAX_QUALIFIED_DSN)
-    if (strlen(dsname) > MAX_DATASET_NAME || strlen(member) > MAX_MEMBER_NAME) {
-        return handle_error(session, ERR_INVALID_PARAM, "Dataset or member name too long");
     }
 
     // Get headers
@@ -2813,8 +2966,8 @@ process_rename(Session *session, const char *target_dsn,
 	char	*body		= NULL;
 	size_t	body_len	= 0;
 	char	request[16]	= {0};
-	char	from_dsn[MAX_DATASET_NAME] = {0};
-	char	from_member[12]	= {0};
+	char	from_dsn[MAX_DATASET_NAME + 1] = {0};
+	char	from_member[MAX_MEMBER_NAME + 1] = {0};
 	int	rc;
 
 	// Read and EBCDIC-translate the JSON control body
@@ -2845,6 +2998,16 @@ process_rename(Session *session, const char *target_dsn,
 				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
 		}
 		free(body);
+
+		/* The control body carries names too, and they reach __renmem() and
+		   require_access() exactly like the ones in the URL -- so they get the
+		   same fold (#334). In place is safe here: normalize_dsn() writes out[i]
+		   from value[i] at the same index and never past n. */
+		if (!normalize_dsn(from_member, from_member, sizeof(from_member))) {
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
+				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
+		}
 
 		/* UPDATE on the library (issue #228): both the old and the new member
 		   are in target_dsn, so one check covers the whole STOW. */
@@ -2884,6 +3047,14 @@ process_rename(Session *session, const char *target_dsn,
 				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
 		}
 		free(body);
+
+		/* Same fold as the member branch above, and for the same reason: this
+		   name is authorized and then renamed (#334). */
+		if (!normalize_dsn(from_dsn, from_dsn, sizeof(from_dsn))) {
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
+				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
+		}
 
 		/* ALTER on BOTH names (issue #228), before the locate so the 404 does
 		   not become an existence oracle for a caller who may not rename.
@@ -2941,12 +3112,23 @@ int datasetCreateHandler(Session *session)
 	char ddname[9] = {0};
 	char opts[512];
 
+	char		dsn_buf[MAX_DATASET_NAME + 1];
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
 	if (!dsname) {
 		return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
 			CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_ALLOC_PARAMS,
 			ERR_MSG_INVALID_ALLOC_PARAMS, NULL, 0);
 	}
+
+	/* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+	   ("no profile covers the resource") as permitted, so authorizing the name
+	   as typed and then operating on the folded one would let a lower-case name
+	   pass by no-match. */
+	if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
+		return handle_error(session, ERR_INVALID_PARAM,
+			"Dataset name is too long");
+	}
+	dsname = dsn_buf;
 
 	/*
 	 * Try POST_STRING first — HTTPD sets this when the request
@@ -3102,12 +3284,23 @@ int datasetDeleteHandler(Session *session)
 	LOCWORK locwork;
 	char dsn44[44];
 
+	char		dsn_buf[MAX_DATASET_NAME + 1];
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
 	if (!dsname) {
 		return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
 			CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_ALLOC_PARAMS,
 			ERR_MSG_INVALID_ALLOC_PARAMS, NULL, 0);
 	}
+
+	/* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+	   ("no profile covers the resource") as permitted, so authorizing the name
+	   as typed and then operating on the folded one would let a lower-case name
+	   pass by no-match. */
+	if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
+		return handle_error(session, ERR_INVALID_PARAM,
+			"Dataset name is too long");
+	}
+	dsname = dsn_buf;
 
 	/* ALTER before the catalog is even consulted (issue #228). The order is
 	   deliberate: authorizing after the locate would make the 404 an existence
@@ -3154,6 +3347,8 @@ int memberDeleteHandler(Session *session)
 	char dataset[MAX_QUALIFIED_DSN] = {0};
 	FILE *fp = NULL;
 
+	char		dsn_buf[MAX_DATASET_NAME + 1];
+	char		mbr_buf[MAX_MEMBER_NAME + 1];
 	dsname = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_dataset-name");
 	member = (char *) http_get_env(session->httpc, (const UCHAR *) "HTTP_member-name");
 
@@ -3162,11 +3357,21 @@ int memberDeleteHandler(Session *session)
 			"Dataset and member names are required");
 	}
 
-	// Validate dsname and member individually (not combined — qualified form fits MAX_QUALIFIED_DSN)
-	if (strlen(dsname) > MAX_DATASET_NAME || strlen(member) > MAX_MEMBER_NAME) {
+	/* Fold before require_access() (#334): http_check_auth() reads SAF rc 4
+	   ("no profile covers the resource") as permitted, so authorizing the name
+	   as typed and then operating on the folded one would let a lower-case name
+	   pass by no-match. */
+	if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
 		return handle_error(session, ERR_INVALID_PARAM,
-			"Dataset or member name too long");
+			"Dataset name is too long");
 	}
+	dsname = dsn_buf;
+
+	if (!normalize_dsn(member, mbr_buf, sizeof(mbr_buf))) {
+		return handle_error(session, ERR_INVALID_PARAM,
+			"Member name is too long");
+	}
+	member = mbr_buf;
 
 	snprintf(dataset, sizeof(dataset), "%s(%s)", dsname, member);
 

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -2994,6 +2994,15 @@ process_rename(Session *session, const char *target_dsn,
 	char	request[16]	= {0};
 	char	from_dsn[MAX_DATASET_NAME + 1] = {0};
 	char	from_member[MAX_MEMBER_NAME + 1] = {0};
+	/* Extraction scratch, deliberately wider than either target.
+	   extract_json_string() TRUNCATES a value that does not fit and still
+	   returns 0, so extracting straight into a target sized to the limit turns
+	   an over-long name into a valid one: {"member":"ABCDEFGHIJ"} would arrive
+	   as ABCDEFGH and __renmem() would rename a different, existing member and
+	   answer 204. Extract wide, then let normalize_dsn() refuse the length.
+	   Anything longer than this is truncated to 63, which no target accepts
+	   either -- so no over-long name can ever alias a real one. */
+	char	json_val[64] = {0};
 	int	rc;
 
 	// Read and EBCDIC-translate the JSON control body
@@ -3016,8 +3025,8 @@ process_rename(Session *session, const char *target_dsn,
 	if (target_member) {
 		// Member rename: from-dataset.member is the OLD member name,
 		// the URL member is the NEW name, within the same PDS (target_dsn).
-		if (extract_json_string(body, "member", from_member,
-				sizeof(from_member)) < 0) {
+		if (extract_json_string(body, "member", json_val,
+				sizeof(json_val)) < 0) {
 			free(body);
 			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
 				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
@@ -3027,9 +3036,8 @@ process_rename(Session *session, const char *target_dsn,
 
 		/* The control body carries names too, and they reach __renmem() and
 		   require_access() exactly like the ones in the URL -- so they get the
-		   same fold (#334). In place is safe here: normalize_dsn() writes out[i]
-		   from value[i] at the same index and never past n. */
-		if (!normalize_dsn(from_member, from_member, sizeof(from_member))) {
+		   same fold (#334), and the same length refusal. */
+		if (!normalize_dsn(json_val, from_member, sizeof(from_member))) {
 			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
 				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
 				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);
@@ -3065,8 +3073,8 @@ process_rename(Session *session, const char *target_dsn,
 		LOCWORK	locwork;
 		char	dsn44[44];
 
-		if (extract_json_string(body, "dsn", from_dsn,
-				sizeof(from_dsn)) < 0) {
+		if (extract_json_string(body, "dsn", json_val,
+				sizeof(json_val)) < 0) {
 			free(body);
 			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
 				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
@@ -3076,7 +3084,7 @@ process_rename(Session *session, const char *target_dsn,
 
 		/* Same fold as the member branch above, and for the same reason: this
 		   name is authorized and then renamed (#334). */
-		if (!normalize_dsn(from_dsn, from_dsn, sizeof(from_dsn))) {
+		if (!normalize_dsn(json_val, from_dsn, sizeof(from_dsn))) {
 			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
 				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_RENAME_REQUEST,
 				ERR_MSG_INVALID_RENAME_REQUEST, NULL, 0);

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -56,6 +56,7 @@ static int check_if_match(Session *session, const char *dataset,
                           long max_records);
 static int require_access(Session *session, const char *dsname, int attr);
 static int normalize_dsn(const char *value, char *out, size_t outlen);
+static size_t dsn44_len(const char *dsname);
 
 /* Fold a data set, member or qualifier name from the request into the form MVS
    actually stores: copy it out of httpd's environment storage, drop trailing
@@ -109,6 +110,27 @@ normalize_dsn(const char *value, char *out, size_t outlen)
 	out[n] = '\0';
 
 	return 1;
+}
+
+/* Length of dsname to copy into a 44-byte, blank-padded dsn44 for __locate()
+   and __dscbdv().
+
+   Every caller now folds through normalize_dsn() first, which refuses anything
+   longer than 44, so this never actually clamps. It exists because the four
+   copies it guards used to be a bare memcpy(dsn44, dsname, strlen(dsname)) into
+   a 44-byte stack buffer, and three of their callers had no length check on
+   dsname at all -- GET /zosmf/restfiles/ds/<200 characters> was the same remote
+   stack smash as #337, through the path variable instead of dslevel. The fold
+   is what closes that; this makes sure a future caller cannot reopen it by
+   forgetting to fold. dataset_cataloged() has always clamped here -- it was the
+   only one that did. */
+__asm__("\n&FUNC    SETC 'dsn44_len'");
+static size_t
+dsn44_len(const char *dsname)
+{
+	size_t	len = dsname ? strlen(dsname) : 0;
+
+	return len > MAX_DATASET_NAME ? (size_t) MAX_DATASET_NAME : len;
 }
 
 /* Authorization gate for a data set operation (issue #228).
@@ -211,7 +233,7 @@ get_fb_record_count(const char *dsname)
 	int rc;
 
 	memset(dsn44, ' ', sizeof(dsn44));
-	memcpy(dsn44, dsname, strlen(dsname));
+	memcpy(dsn44, dsname, dsn44_len(dsname));
 
 	/* Locate dataset to get volser */
 	memset(&locwork, 0, sizeof(locwork));
@@ -499,7 +521,7 @@ is_pds(const char *dsname)
 
 	// Pad dataset name to 44 bytes (required by __locate/__dscbdv)
 	memset(dsn44, ' ', sizeof(dsn44));
-	memcpy(dsn44, dsname, strlen(dsname));
+	memcpy(dsn44, dsname, dsn44_len(dsname));
 
 	// Locate dataset in catalog to get volume serial
 	memset(&locwork, 0, sizeof(locwork));
@@ -1176,8 +1198,12 @@ int datasetListHandler(Session *session)
 	   than saying no, and this refusal is what keeps #337 unreachable. */
 	if (dslevel && *dslevel) {
 		if (!normalize_dsn(dslevel, dslevel_buf, sizeof(dslevel_buf))) {
-			return handle_error(session, ERR_INVALID_PARAM,
-				"Dataset level is too long");
+			/* goto quit like every other exit here: dslist is still NULL at
+			   this point, so a bare return would be correct today and wrong
+			   the moment anything is allocated above it. */
+			rc = (unsigned) handle_error(session, ERR_INVALID_PARAM,
+					"Dataset level is too long");
+			goto quit;
 		}
 		dslevel = dslevel_buf;
 	}
@@ -3071,7 +3097,7 @@ process_rename(Session *session, const char *target_dsn,
 
 		// Verify the source data set exists
 		memset(dsn44, ' ', sizeof(dsn44));
-		memcpy(dsn44, from_dsn, strlen(from_dsn));
+		memcpy(dsn44, from_dsn, dsn44_len(from_dsn));
 		memset(&locwork, 0, sizeof(locwork));
 		if (__locate(dsn44, &locwork) != 0) {
 			return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
@@ -3313,7 +3339,7 @@ int datasetDeleteHandler(Session *session)
 
 	/* Check if dataset exists via catalog locate */
 	memset(dsn44, ' ', sizeof(dsn44));
-	memcpy(dsn44, dsname, strlen(dsname));
+	memcpy(dsn44, dsname, dsn44_len(dsname));
 	memset(&locwork, 0, sizeof(locwork));
 
 	rc = __locate(dsn44, &locwork);

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2729,6 +2729,41 @@ fi
 curl -s -o /dev/null -X DELETE -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD4)"
 
+# An over-long member name in the control body must not rename a DIFFERENT
+# member. extract_json_string() truncates a value that does not fit and still
+# returns 0, so a target buffer sized to the 8-character limit would turn
+# "ABCDEFGHIJ" into "ABCDEFGH" -- an existing member -- and __renmem() would
+# rename that one and answer 204. The extraction buffer is deliberately wider
+# than the limit so the length refusal happens on the real value.
+curl -s -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary "DO NOT RENAME ME" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ABCDEFGH)"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${TEST_PDS}\",\"member\":\"ABCDEFGHIJ\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(WRONGTGT)")
+if [ "$HTTP_CODE" = "204" ]; then
+	fail "an over-long source member is not truncated into a real one" \
+		"got HTTP 204 -- the rename hit a different member"
+else
+	pass "an over-long source member is refused (HTTP $HTTP_CODE)"
+fi
+
+CONTENT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ABCDEFGH)")
+if echo "$CONTENT" | grep -q "DO NOT RENAME ME"; then
+	pass "the truncation target was left alone"
+else
+	fail "the truncation target was left alone" \
+		"ABCDEFGH no longer holds its content -- it was renamed by a truncated name"
+fi
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(ABCDEFGH)"
+curl -s -o /dev/null -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(WRONGTGT)" || true
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2525,6 +2525,113 @@ else
 		"${BASE_URL}/zosmf/restfiles/ds/${VICTIM}" || true
 fi
 
+# --- Lower-case names are folded to upper case (issue #334) ---
+#
+# Every files endpoint used to take the name exactly as typed, so a lower-case
+# request found nothing: the catalog, the VTOC and a PDS directory are all upper
+# case. Real z/OSMF folds both the {dataset-name} path variable and the dslevel
+# query value -- measured against z/OSMF 29 -- so mvsMF has to as well.
+#
+# This is the class of bug the Zowe suite structurally CANNOT catch: the CLI
+# folds the name client-side before it reaches the wire, so zowe-datasets.sh
+# sends upper case no matter what is typed. Only curl can see it, which is why
+# these cases live here.
+echo ""
+echo "--- Lower-case names are folded (issue #334) ---"
+
+PDS_LOWER=$(echo "$TEST_PDS" | tr '[:upper:]' '[:lower:]')
+
+# a member to look for, written under the upper-case name
+curl -s -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary "FOLDED" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD1)"
+
+# 1. dslevel= -- the reported symptom: an empty listing, not an error
+COUNT=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${PDS_LOWER}" |
+	jq -r '.items | length' 2>/dev/null)
+if [ "${COUNT:-0}" -ge 1 ]; then
+	pass "lower-case dslevel finds the data set"
+else
+	fail "lower-case dslevel finds the data set" \
+		"expected at least one item, got '${COUNT:-<none>}'"
+fi
+
+# 2. member list under a lower-case data set name
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${PDS_LOWER}/member")
+assert_http_status "200" "$HTTP_CODE" "lower-case dsname: member list"
+
+# 3. read a member, both names lower case
+CONTENT=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${PDS_LOWER}(fold1)")
+if echo "$CONTENT" | grep -q "FOLDED"; then
+	pass "lower-case dsname and member: read"
+else
+	fail "lower-case dsname and member: read" \
+		"expected the member content, got '${CONTENT}'"
+fi
+
+# 4. a write through the lower-case name must land on the UPPER-case member --
+#    proving the name was folded, not that a second lower-case name was created
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary "WRITTEN VIA LOWER CASE" \
+	"${BASE_URL}/zosmf/restfiles/ds/${PDS_LOWER}(fold2)")
+assert_http_status "204" "$HTTP_CODE" "lower-case dsname and member: write"
+
+CONTENT=$(curl -s -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD2)")
+if echo "$CONTENT" | grep -q "WRITTEN VIA LOWER CASE"; then
+	pass "the lower-case write landed on the upper-case member"
+else
+	fail "the lower-case write landed on the upper-case member" \
+		"reading ${TEST_PDS}(FOLD2) gave '${CONTENT}'"
+fi
+
+# 5. delete through the lower-case name
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${PDS_LOWER}(fold2)")
+assert_http_status "204" "$HTTP_CODE" "lower-case dsname and member: delete"
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD1)"
+
+# --- An over-long dslevel is refused, not copied (issue #337) ---
+#
+# extract_level_prefix() used to strcpy() the raw query value into a 45-byte
+# stack buffer, and httpd lets a query value reach CBUFSIZE = 4000. The lengths
+# below are deliberately just over the limit rather than 4000: against a build
+# without the fix these still exercise the overflow, and the point is to detect
+# it, not to maximise the damage to the stand while doing so.
+#
+# The liveness check at the end is the actual assertion. A stack smash in the
+# CGI is never cleaned up (mvslovers/httpd#154), so "the server still answers"
+# is what separates a fixed build from one that happened not to crash yet.
+echo ""
+echo "--- Over-long dslevel is refused (issue #337) ---"
+
+LEVEL44=$(printf 'A%.0s' $(seq 1 44))
+LEVEL45=$(printf 'A%.0s' $(seq 1 45))
+LEVEL200=$(printf 'A%.0s' $(seq 1 200))
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${LEVEL44}")
+assert_http_status "200" "$HTTP_CODE" "dslevel at the 44-character limit is accepted"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${LEVEL45}")
+assert_http_status "400" "$HTTP_CODE" "dslevel one character over the limit is refused"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${LEVEL200}")
+assert_http_status "400" "$HTTP_CODE" "a 200-character dslevel is refused"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member")
+assert_http_status "200" "$HTTP_CODE" "the server still answers after the over-long dslevels"
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2632,6 +2632,103 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member")
 assert_http_status "200" "$HTTP_CODE" "the server still answers after the over-long dslevels"
 
+# --- An over-long name in the PATH is refused too (issue #337) ---
+#
+# dslevel was not the only door. get_fb_record_count() and is_pds() copied
+# dsname into a 44-byte dsn44 with a bare memcpy(..., strlen(dsname)), and the
+# sequential GET/DELETE/POST handlers had no length check on dsname at all --
+# only the two member handlers did. So an over-long name in the path was the
+# same stack smash. The fold refuses it; dsn44_len() clamps behind that.
+echo ""
+echo "--- Over-long name in the path is refused (issue #337) ---"
+
+NAME45=$(printf 'A%.0s' $(seq 1 45))
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${NAME45}")
+assert_http_status "400" "$HTTP_CODE" "over-long dsname in the path is refused"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(${NAME45})")
+assert_http_status "400" "$HTTP_CODE" "over-long member name in the path is refused"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}/member")
+assert_http_status "200" "$HTTP_CODE" "the server still answers after the over-long path names"
+
+# --- Create and rename accept lower case too (issue #334) ---
+#
+# Both are changed code and neither was covered. The rename cases matter most:
+# process_rename() takes its source name from the JSON control body, not the
+# URL, and that is the one fold done in place (value == out).
+echo ""
+echo "--- Create and rename fold lower case (issue #334) ---"
+
+FOLD_NEW="${MVSMF_USER}.CURL.FOLDNEW"
+FOLD_SRC="${MVSMF_USER}.CURL.FOLDSRC"
+FOLD_DST="${MVSMF_USER}.CURL.FOLDDST"
+FOLD_NEW_LOWER=$(echo "$FOLD_NEW" | tr '[:upper:]' '[:lower:]')
+FOLD_SRC_LOWER=$(echo "$FOLD_SRC" | tr '[:upper:]' '[:lower:]')
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${FOLD_NEW}" || true
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${FOLD_SRC}" || true
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${FOLD_DST}" || true
+
+ALLOC='{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":3120,"alcunit":"TRK","primary":1,"secondary":1}'
+
+# create through a lower-case name ...
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" -d "$ALLOC" \
+	"${BASE_URL}/zosmf/restfiles/ds/${FOLD_NEW_LOWER}")
+assert_http_status "201" "$HTTP_CODE" "create through a lower-case name"
+
+# ... and the data set exists under the upper-case name
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${FOLD_NEW}")
+assert_http_status "200" "$HTTP_CODE" "the lower-case create landed on the upper-case name"
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${FOLD_NEW}"
+
+# data set rename with a lower-case source in the control body
+curl -s -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" -d "$ALLOC" \
+	"${BASE_URL}/zosmf/restfiles/ds/${FOLD_SRC}"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${FOLD_SRC_LOWER}\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${FOLD_DST}")
+assert_http_status "204" "$HTTP_CODE" "rename with a lower-case source data set"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${FOLD_DST}")
+assert_http_status "200" "$HTTP_CODE" "the renamed data set is there"
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${FOLD_DST}"
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${FOLD_SRC}"
+
+# member rename with a lower-case source member in the control body
+curl -s -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary "RENAME ME" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD3)"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	--data-binary "{\"request\":\"rename\",\"from-dataset\":{\"dsn\":\"${TEST_PDS}\",\"member\":\"fold3\"}}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD4)")
+assert_http_status "204" "$HTTP_CODE" "rename with a lower-case source member"
+
+CONTENT=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD4)")
+if echo "$CONTENT" | grep -q "RENAME ME"; then
+	pass "the renamed member kept its content"
+else
+	fail "the renamed member kept its content" "got '${CONTENT}'"
+fi
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(FOLD4)"
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"


### PR DESCRIPTION
Fixes #334
Fixes #337

## What was wrong

A data set name typed in lower case found nothing. `dsname` came straight out of
`HTTP_dataset-name` and `dslevel` out of `QUERY_DSLEVEL`, and both went into
`__locate()`/`fopen()` as typed — while the catalog, the VTOC and a PDS
directory are all upper case. The listing came back empty, every other endpoint
404'd, and `zowe files cp ds` aborted on its own existence check.

Measured on mvsdev before the fix:

| Request | lower case | UPPER CASE |
|---|---|---|
| `?dslevel=ibmuser.cntl` | `200`, 0 rows | `200`, found |
| `/ds/ibmuser.cntl/member` | `404` | `200` |
| `/ds/ibmuser.cntl(iefbr14)` | `404` | — |

Real z/OSMF folds both the path variable and the `dslevel` query value —
measured against z/OSMF 29 with `--zosmf-p zxp` — so this was a conformance gap.

## The fix

`normalize_dsn()` copies the value out of httpd's environment storage, trims
trailing blanks, folds, and validates the length in one place. It is shaped like
`make_query_key()`, which has been doing exactly this for `start=` and `pattern=`
all along; the data set name itself was simply never given the same treatment.

Applied at all eleven request-name sites plus `dslevel`, and to the names
`process_rename()` reads out of the JSON control body.

**Every call site folds before `require_access()`, and that ordering is
load-bearing.** `http_check_auth()` normalizes SAF rc 4 ("no profile covers the
resource") to `0 = permitted`, so authorizing the name as typed and then
operating on the folded one would let a lower-case name pass by no-match and go
on to touch the real data set.

USS is deliberately untouched — `/zosmf/restfiles/fs` addresses a case-sensitive
file system.

## The overflow that came with it (#337)

`extract_level_prefix()` copied `dslevel` into its caller's 45-byte stack buffer
with an unbounded `strcpy()`, and httpd lets a query value reach
`CBUFSIZE = 4000`. `GET /zosmf/restfiles/ds?dslevel=<4000 bytes>` was an
authenticated remote stack smash.

It had a second door: `get_fb_record_count()` and `is_pds()` copied `dsname`
into a 44-byte `dsn44` with a bare `memcpy(..., strlen(dsname))`, and the
sequential GET/DELETE/POST handlers had no length check on `dsname` at all —
only the two member handlers did. `dataset_cataloged()` was the one site that
already clamped.

Making `normalize_dsn()` the length check as well closes both: an over-long name
is refused with `400` before any handler touches it. `extract_level_prefix()` now
takes the destination size as a parameter instead of a comment promising "at
least 45 bytes", and `dsn44_len()` puts the bound at the copy — so a future
caller that forgets to fold cannot reopen either door.

Identified statically and deliberately **not** provoked against a live stand: a
CGI abend is never cleaned up (mvslovers/httpd#154), so triggering it would take
the whole HTTPD address space down until the STC is restarted.

## Why no test caught the original bug

The Zowe suites structurally cannot: the CLI folds the name client-side before it
reaches the wire, so `zowe-datasets.sh` sends upper case no matter what is typed.
Only `tests/curl-datasets.sh` can see this class of bug, and it had no lower-case
case among its 215 requests. The new cases live there.

## A regression this PR introduced, and caught

Narrowing `from_member` to the 8-character limit turned a harmless failure into
a **wrong-target write**. `extract_json_string()` truncates a value that does not
fit and still returns `0`, so
`{"request":"rename","from-dataset":{"member":"ABCDEFGHIJ"}}` arrived as
`ABCDEFGH` — eight characters, which `normalize_dsn()` accepts — and
`__renmem()` renamed *that existing member* instead, answering `204`. With the
original 12-byte buffer the same body left eleven characters, matched no member,
and got a `404`.

Both control-body names are now extracted into a scratch buffer wider than
either target, so the length refusal happens on the real value. Anything longer
than the scratch truncates to 63, which neither target accepts — so no over-long
name can alias a real one at any length. The test asserts the negative directly:
a member named exactly the truncation target is planted first, and the rename
must neither answer `204` nor disturb it.

## Verification

Deployed to mvsdev (build `87a5f2e` == HEAD) and activated into the running
httpd STEPLIB. `tests/curl-datasets.sh`: **248 passed, 0 failed, 0 skipped**,
including the new coverage — lower-case list/read/write/delete/create/rename,
the write landing on the upper-case member, over-long `dslevel` and over-long
path names refused with `400`, each followed by a liveness check. Adjacent suites for regressions:
`curl-binary.sh` 10/0, `curl-jobs.sh` 119/0 (2 pre-existing skips).

Three of the four originally reported commands now work:

```
zowe files ls ds "ibmuser.cntl"                        ->  IBMUSER.CNTL
zowe files ls am "ibmuser.cntl"                        ->  IEFBR14, UFSDCLNP
zowe files ul ftds x.jcl "ibmuser.cntl(iefbr14)"       ->  IBMUSER.CNTL(IEFBR14)
```

The upload is the interesting one, because it looked like a separate client-side
bug and was not. Zowe's `Upload.pathToDataSet` splits `name(member)` and then
asks the server which kind of data set it is —
`GET /zosmf/restfiles/ds?dslevel=<name>` — and on `returnedRows === 0` it gives
up on the member and uploads to the bare name anyway, by design:

```js
// If dsnameIndex === -1, it means we could not find the given data set.
// We will attempt the upload anyways so that we can forward/throw the proper error from z/OS MF
```

That listing was the one returning zero rows, so the client sent
`PUT /zosmf/restfiles/ds/IBMUSER.CNTL` — a sequential write to a PDS — and got a
400. The empty listing was the cause; the mangled request was the symptom. See
#335 for the full trace.

## Not fixed here

- **#338** — `zowe files cp ds` still fails. The fold got the source lookup
  working, and the next error surfaced: Zowe sends
  `POST {"like":"IBMUSER.CNTL","blksize":19040}` and the create handler does not
  implement `like`. Independent of this PR — it reproduces with upper-case names.
- **#335** — re-scoped. The *upload* is fixed here (above). What remains is
  narrower and no longer user-visible: the same `PUT /ds/IBMUSER.CNTL` answered a
  clean 400 on mvsdev — 64 KB body, with and without `Expect: 100-continue` — but
  closed the connection on the stand behind `gw.neunetz.it:8080`. That would
  apply to any early 4xx on a PUT whose body is still in flight, not just this
  one.
- **#336** — the `{volume-serial}` path variable is captured and never used.
- **#340** — found while checking this PR's own bounds: `extract_path_vars()`
  copies a path variable into a 1024-byte stack buffer with a length taken from
  the path, which httpd allows to reach 4000. That sits in the router, before any
  handler, so it affects every route and is **not** closed by this PR. Left out
  deliberately — CLAUDE.md restricts router-core changes.
