### PR TITLE
Support like= on create, so zowe files cp ds works

### DIFF
--- a/docs/endpoints/datasets/create.md
+++ b/docs/endpoints/datasets/create.md
@@ -17,6 +17,10 @@ POST
 ## Request Body (JSON)
 
 ### Required Fields
+
+Required **unless `like` is given** — with a model, every one of them becomes an
+optional override:
+
 - `dsorg`: Dataset organization (`PS` for sequential, `PO` for partitioned)
 - `recfm`: Record format (e.g. `FB`, `VB`, `U`)
 - `lrecl`: Logical record length
@@ -24,16 +28,55 @@ POST
 - `primary`: Primary space allocation
 
 ### Optional Fields
+- `like`: Model the new data set on an existing one (see below)
 - `secondary`: Secondary space allocation (default: 0)
 - `dirblk`: Directory blocks for PDS (default: 0)
 - `alcunit`: Allocation unit — `TRK`, `CYL`, or `BLK` (default: `TRK`)
+
+## `like` — model on an existing data set
+
+```json
+{"like": "MY.MODEL.PDS"}
+{"like": "MY.MODEL.PDS", "blksize": 800}
+```
+
+This is what `zowe files cp ds` sends when it creates the copy target.
+
+**DSORG, RECFM, LRECL and BLKSIZE come from the model**, read off its DSCB by
+MVS itself through the SVC 99 `DALDCBDS` text unit — the same mechanism as JCL
+`DCB=(dsname)`. Any of those fields present in the body overrides the model.
+
+**Space does not come from the model in the same way.** `DCB=` never copied
+`SPACE`; the thing that does is DFSMS `LIKE=`, which MVS 3.8j has no equivalent
+for. mvsMF derives it instead:
+
+| | with `like`, field absent |
+|---|---|
+| `primary` | the model's total allocated tracks, in `TRK` |
+| `secondary` | the model's secondary quantity, converted to tracks |
+| `alcunit` | forced to `TRK`, because the two above are track counts |
+| `dirblk` | `20` when the model is partitioned — see below |
+
+Supplying `primary` yourself leaves your `alcunit` alone.
+
+`dirblk` is the one value with no source at all: a DSCB records no directory
+quantity, so there is nothing to model. 20 blocks is roughly 100 members once
+ISPF statistics are present, which covers the copy case and costs about 5 KB.
+Send `dirblk` explicitly when you know better.
+
+A `like` naming a data set that is not cataloged answers **404**, not the
+generic allocation 500 — otherwise nothing would say it was the *model* that
+was missing.
 
 ## Response
 On successful completion, this request returns HTTP status code 201 (Created).
 
 ## Error Responses
 - HTTP 400 (Bad Request)
-    - Missing or invalid allocation parameters
+    - Missing or invalid allocation parameters, or a `like` name longer than 44
+      characters
+- HTTP 404 (Not Found)
+    - The data set named by `like` is not cataloged
 - HTTP 500 (Internal Server Error)
     - `{"category":8,"rc":900,"reason":7,"message":"Dynamic allocation Error"}`
       — every allocation failure, whatever the cause: the name already exists,

--- a/docs/endpoints/datasets/create.md
+++ b/docs/endpoints/datasets/create.md
@@ -55,9 +55,15 @@ for. mvsMF derives it instead:
 | `primary` | the model's total allocated tracks, in `TRK` |
 | `secondary` | the model's secondary quantity, converted to tracks |
 | `alcunit` | forced to `TRK`, because the two above are track counts |
-| `dirblk` | `20` when the model is partitioned — see below |
+| `dirblk` | `20` when the **target** is partitioned — see below |
 
-Supplying `primary` yourself leaves your `alcunit` alone.
+Supplying `primary` yourself leaves your `alcunit` alone — and in that case the
+secondary is only derived when the unit in force is `TRK`. Under `CYL` or `BLK`
+there is no safe way to express a track count, so an omitted `secondary` stays
+`0` rather than being emitted in the wrong unit.
+
+`dirblk` follows the `dsorg` actually going out, not the model's: `{"like":
+"PS.MODEL", "dsorg": "PO"}` still gets directory blocks.
 
 `dirblk` is the one value with no source at all: a DSCB records no directory
 quantity, so there is nothing to model. 20 blocks is roughly 100 members once

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -3420,6 +3420,14 @@ int datasetCreateHandler(Session *session)
 			sizeof(alcunit)) == 0);
 	if (!have_alcunit) {
 		strcpy(alcunit, "TRK");
+	} else {
+		/* Folded here, not left to __dsalcf(): it upper-cases the whole opts
+		   string, but the unit is compared against "TRK" below that, before
+		   the string is built. A client sending "trk" would otherwise miss. */
+		int u;
+		for (u = 0; alcunit[u]; u++) {
+			alcunit[u] = (char) toupper((unsigned char) alcunit[u]);
+		}
 	}
 
 	/* Fill the space the model cannot supply. DALDCBDS carries the DCB
@@ -3438,7 +3446,15 @@ int datasetCreateHandler(Session *session)
 				   otherwise get its track count read as cylinders. */
 				strcpy(alcunit, "TRK");
 			}
-			if (!have_secondary) {
+			/* The same hazard applies to the secondary, and it is easy to
+			   miss because the guard above looks like it covers both: it
+			   does not. With an explicit primary the client's unit governs,
+			   and a derived track count emitted under CYL is a fifteen-fold
+			   over-allocation on every extent -- silent, since nothing in
+			   the listing reports the secondary. So the derived value is
+			   only used when the unit actually in force is TRK; under any
+			   other the secondary stays whatever the client asked for. */
+			if (!have_secondary && strcmp(alcunit, "TRK") == 0) {
 				secondary = (int) msec;
 			}
 		}
@@ -3457,8 +3473,19 @@ int datasetCreateHandler(Session *session)
 		   for the copy case this exists for, and 5 KB out of the primary
 		   allocation, which is a fraction of a single track. A client that
 		   knows better sends dirblk and this does not fire. */
-		if (!have_dirblk && is_pds(like)) {
-			dirblk = LIKE_DIRBLK;
+		/* Keyed off the dsorg actually going out, not the model's: with
+		   {"like":"PS.MODEL","dsorg":"PO"} the target is partitioned even
+		   though the model is not, and a PO with zero directory blocks is
+		   not a data set anyone can use. */
+		if (!have_dirblk) {
+			int target_is_pds = dsorg[0]
+				? (toupper((unsigned char) dsorg[0]) == 'P' &&
+				   toupper((unsigned char) dsorg[1]) == 'O')
+				: is_pds(like);
+
+			if (target_is_pds) {
+				dirblk = LIKE_DIRBLK;
+			}
 		}
 	}
 

--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -26,6 +26,11 @@
 #define UNDEFINED 0x0004
 
 // Constants for better readability and maintainability
+/* Directory blocks given to a PDS created with like= when the client does not
+   say. See datasetCreateHandler() for why this is a decision rather than a
+   measurement. */
+#define LIKE_DIRBLK 20
+
 #define MAX_DATASET_NAME 44
 #define MAX_MEMBER_NAME 8
 // Qualified form DSN(MEMBER): 44 + '(' + 8 + ')' + NUL
@@ -131,6 +136,97 @@ dsn44_len(const char *dsname)
 	size_t	len = dsname ? strlen(dsname) : 0;
 
 	return len > MAX_DATASET_NAME ? (size_t) MAX_DATASET_NAME : len;
+}
+
+/* Read a `like` model's space allocation off its DSCB, for a create that names
+   one (#338).
+
+   MVS supplies the DCB attributes itself through the DALDCBDS text unit
+   (`DCBDSN=`, the SVC 99 form of JCL DCB=(dsname)) -- DSORG, RECFM, LRECL and
+   BLKSIZE all come from the model without mvsMF decoding anything. What it does
+   NOT supply is SPACE: copying the allocation as well is DFSMS LIKE=, and 3.8j
+   has no equivalent. Measured -- LIKE= on a DD statement is a JCL ERROR here,
+   and key X'004B' is DALRSRVS ("secondary buffer reserve") in this era's
+   text-unit table rather than DALLIKE, so sending it would quietly set a TCAM
+   buffer size instead of modelling anything.
+
+   So the space has to be derived here, and this is that derivation: the total
+   allocated tracks of the model become the primary, and its secondary quantity
+   comes off scal3. Everything is expressed in TRACKS, including a model
+   allocated in cylinders -- one unit end to end is what keeps a CYL model from
+   silently producing a 15-times-too-small target.
+
+   Only the first three extents are visible in the DSCB1 (the rest live in
+   format-3 DSCBs), so a heavily fragmented model reports short. That
+   under-reports the primary rather than over-reporting it, and the secondary
+   still covers the rest, which is the safe direction for the failure.
+
+   Returns 0 on success. */
+__asm__("\n&FUNC    SETC 'model_alloc'");
+static int
+model_alloc(const char *dsname, unsigned *pri_trks, unsigned *sec_trks)
+{
+	LOCWORK		locwork = {0};
+	DSCB		dscb = {0};
+	DSCB1		*dscb1 = &dscb.dscb1;
+	DSCB		dscb4buf = {0};
+	char		vol[7] = {0};
+	char		dsn44[44];
+	unsigned short	tpc = 0;
+	unsigned	trks = 0;
+	unsigned	sec;
+	int		e;
+
+	*pri_trks = 0;
+	*sec_trks = 0;
+
+	memset(dsn44, ' ', sizeof(dsn44));
+	memcpy(dsn44, dsname, dsn44_len(dsname));
+
+	if (__locate(dsn44, &locwork) != 0) {
+		return -1;
+	}
+	memcpy(vol, locwork.volser, 6);
+	if (__dscbdv(dsn44, vol, &dscb) != 0) {
+		return -1;
+	}
+
+	/* tracks per cylinder, read the same way the listing reads it: __dscbv()
+	   returns data only, so dstrk sits at work[20] rather than at its struct
+	   offset. 30 is the 3350 fallback the listing uses when the volume DSCB
+	   cannot be read. */
+	if (__dscbv(vol, &dscb4buf) == 0) {
+		tpc = ((unsigned char)dscb4buf.work[20] << 8)
+		    |  (unsigned char)dscb4buf.work[21];
+	}
+	if (tpc == 0) tpc = 30;
+
+	for (e = 0; e < 3 && e < dscb1->noepv; e++) {
+		unsigned short lc, lh, hc, hh;
+		lc = ((unsigned)dscb1->extent[e].lower[0] << 8)
+		   |  (unsigned)dscb1->extent[e].lower[1];
+		lh = ((unsigned)dscb1->extent[e].lower[2] << 8)
+		   |  (unsigned)dscb1->extent[e].lower[3];
+		hc = ((unsigned)dscb1->extent[e].upper[0] << 8)
+		   |  (unsigned)dscb1->extent[e].upper[1];
+		hh = ((unsigned)dscb1->extent[e].upper[2] << 8)
+		   |  (unsigned)dscb1->extent[e].upper[3];
+		trks += (unsigned)((hc - lc) * tpc + (hh - lh) + 1);
+	}
+
+	sec = ((unsigned)dscb1->scal3[0] << 16)
+	    | ((unsigned)dscb1->scal3[1] << 8)
+	    |  (unsigned)dscb1->scal3[2];
+
+	/* scal1 says which unit scal3 counts in; normalise to tracks */
+	if ((dscb1->scal1 & 0xC0) == CYL) {
+		sec *= tpc;
+	}
+
+	*pri_trks = trks ? trks : 1;
+	*sec_trks = sec;
+
+	return 0;
 }
 
 /* Authorization gate for a data set operation (issue #228).
@@ -3143,6 +3239,14 @@ int datasetCreateHandler(Session *session)
 	int lrecl = 0;
 	int blksize = 0;
 
+	char like[MAX_DATASET_NAME + 1] = {0};
+	char json_val[64] = {0};	/* see the note at the like= extraction */
+	int have_like = 0;
+	int have_primary = 0;
+	int have_secondary = 0;
+	int have_dirblk = 0;
+	int have_alcunit = 0;
+
 	char ddname[9] = {0};
 	char opts[512];
 
@@ -3260,30 +3364,135 @@ int datasetCreateHandler(Session *session)
 		body_size = strlen(body);
 	}
 
-	/* Parse JSON fields */
-	if (extract_json_string(body, "dsorg", dsorg, sizeof(dsorg)) < 0 ||
-	    extract_json_string(body, "recfm", recfm, sizeof(recfm)) < 0 ||
-	    extract_json_int(body, "lrecl", &lrecl) < 0 ||
-	    extract_json_int(body, "blksize", &blksize) < 0 ||
-	    extract_json_int(body, "primary", &primary) < 0) {
-		return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
-			CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_ALLOC_PARAMS,
-			ERR_MSG_INVALID_ALLOC_PARAMS, NULL, 0);
+	/* like= -- allocate modelled on an existing data set (#338). This is what
+	   `zowe files cp ds` sends: {"like":"SRC","blksize":19040}, a body with
+	   none of the five fields below in it, which is why that command used to
+	   come back "Invalid or missing allocation parameters".
+
+	   Extracted through a scratch buffer wider than the target, for the same
+	   reason as the rename names: extract_json_string() truncates a value that
+	   does not fit and still returns 0, so extracting straight into a 45-byte
+	   buffer would turn an over-long name into a valid, different one. */
+	if (extract_json_string(body, "like", json_val, sizeof(json_val)) == 0) {
+		if (!normalize_dsn(json_val, like, sizeof(like))) {
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_ALLOC_PARAMS,
+				ERR_MSG_INVALID_ALLOC_PARAMS, NULL, 0);
+		}
+		/* A model that is not there is a 404. Without this it would reach
+		   __dsalcf(), fail there, and come back as the generic 500 dynalloc
+		   error -- which does not say that it was the *model* that was
+		   missing, and that is the whole diagnosis. */
+		if (!dataset_cataloged(like)) {
+			return sendErrorResponse(session, HTTP_STATUS_NOT_FOUND,
+				CATEGORY_SERVICE, RC_ERROR, REASON_DATASET_NOT_FOUND,
+				ERR_MSG_DATASET_NOT_FOUND, NULL, 0);
+		}
+		have_like = 1;
+	}
+
+	/* Parse JSON fields. With a model, every one of these is an override and
+	   none is required -- MVS fills the rest in from the model's DSCB. Without
+	   one they are all required, exactly as before. */
+	if (!have_like) {
+		if (extract_json_string(body, "dsorg", dsorg, sizeof(dsorg)) < 0 ||
+		    extract_json_string(body, "recfm", recfm, sizeof(recfm)) < 0 ||
+		    extract_json_int(body, "lrecl", &lrecl) < 0 ||
+		    extract_json_int(body, "blksize", &blksize) < 0 ||
+		    extract_json_int(body, "primary", &primary) < 0) {
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_ALLOC_PARAMS,
+				ERR_MSG_INVALID_ALLOC_PARAMS, NULL, 0);
+		}
+		have_primary = 1;
+	} else {
+		extract_json_string(body, "dsorg", dsorg, sizeof(dsorg));
+		extract_json_string(body, "recfm", recfm, sizeof(recfm));
+		extract_json_int(body, "lrecl", &lrecl);
+		extract_json_int(body, "blksize", &blksize);
+		have_primary = (extract_json_int(body, "primary", &primary) == 0);
 	}
 
 	/* Optional fields */
-	extract_json_int(body, "secondary", &secondary);
-	extract_json_int(body, "dirblk", &dirblk);
-	if (extract_json_string(body, "alcunit", alcunit, sizeof(alcunit)) < 0) {
+	have_secondary = (extract_json_int(body, "secondary", &secondary) == 0);
+	have_dirblk = (extract_json_int(body, "dirblk", &dirblk) == 0);
+	have_alcunit = (extract_json_string(body, "alcunit", alcunit,
+			sizeof(alcunit)) == 0);
+	if (!have_alcunit) {
 		strcpy(alcunit, "TRK");
 	}
 
-	/* Build allocation options string */
-	snprintf(opts, sizeof(opts),
-		"DSN=%s;DISP=(NEW,CATLG,DELETE);DSORG=%s;RECFM=%s;"
-		"LRECL=%d;BLKSIZE=%d;SPACE=%s(%d,%d,%d)",
-		dsname, dsorg, recfm, lrecl, blksize,
-		alcunit, primary, secondary, dirblk);
+	/* Fill the space the model cannot supply. DALDCBDS carries the DCB
+	   attributes and nothing else -- see model_alloc() for why SPACE is not
+	   part of that bargain on this platform. */
+	if (have_like) {
+		unsigned mpri = 0;
+		unsigned msec = 0;
+
+		if (model_alloc(like, &mpri, &msec) == 0) {
+			if (!have_primary && mpri > 0) {
+				primary = (int) mpri;
+				/* model_alloc() answers in tracks whatever unit the model
+				   was allocated in, so the unit has to follow. A client
+				   that asked for CYL and left primary to us would
+				   otherwise get its track count read as cylinders. */
+				strcpy(alcunit, "TRK");
+			}
+			if (!have_secondary) {
+				secondary = (int) msec;
+			}
+		}
+		if (primary <= 0) {
+			primary = 1;
+		}
+
+		/* Directory blocks are the one thing neither MVS nor the DSCB can
+		   answer: the DSCB records no directory quantity, so there is nothing
+		   to model. A PDS target needs some, and getting it wrong is a
+		   directory-full failure part way through a copy.
+
+		   LIKE_DIRBLK is therefore a deliberate default, not a measurement. A
+		   256-byte directory block holds roughly five entries once ISPF
+		   statistics are present, so 20 blocks is about 100 members -- enough
+		   for the copy case this exists for, and 5 KB out of the primary
+		   allocation, which is a fraction of a single track. A client that
+		   knows better sends dirblk and this does not fire. */
+		if (!have_dirblk && is_pds(like)) {
+			dirblk = LIKE_DIRBLK;
+		}
+	}
+
+	/* Build allocation options string. Assembled piecewise because with a
+	   model the DCB keywords are omitted rather than sent empty -- an empty
+	   DSORG= would override the model with nothing. */
+	{
+		int n = 0;
+
+		n += snprintf(opts + n, sizeof(opts) - n,
+			"DSN=%s;DISP=(NEW,CATLG,DELETE)", dsname);
+		if (have_like) {
+			n += snprintf(opts + n, sizeof(opts) - n, ";DCBDSN=%s", like);
+		}
+		if (dsorg[0]) {
+			n += snprintf(opts + n, sizeof(opts) - n, ";DSORG=%s", dsorg);
+		}
+		if (recfm[0]) {
+			n += snprintf(opts + n, sizeof(opts) - n, ";RECFM=%s", recfm);
+		}
+		if (lrecl > 0) {
+			n += snprintf(opts + n, sizeof(opts) - n, ";LRECL=%d", lrecl);
+		}
+		if (blksize > 0) {
+			n += snprintf(opts + n, sizeof(opts) - n, ";BLKSIZE=%d", blksize);
+		}
+		if (n < 0 || n >= (int) sizeof(opts)) {
+			return sendErrorResponse(session, HTTP_STATUS_BAD_REQUEST,
+				CATEGORY_SERVICE, RC_ERROR, REASON_INVALID_ALLOC_PARAMS,
+				ERR_MSG_INVALID_ALLOC_PARAMS, NULL, 0);
+		}
+		snprintf(opts + n, sizeof(opts) - n, ";SPACE=%s(%d,%d,%d)",
+			alcunit, primary, secondary, dirblk);
+	}
 
 	/* Allocate the dataset */
 	rc = __dsalcf(ddname, "%s", opts);

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -474,6 +474,62 @@ int testHandler(Session *session) {
                      " \"rc\": %d, \"volser\": \"%.6s\" }\n",
                      dsn, loc_rc, locwork.volser);
 
+    /* --- fn=dscb ---------------------------------------------------- */
+    /*
+     * Raw format-1 DSCB space fields for a data set.
+     *
+     * The listing endpoint reports the space UNIT (spacu) but never the
+     * secondary QUANTITY, and that gap is not academic: a create modelled with
+     * like= derives the secondary in tracks, and emitting that under a
+     * client-supplied CYL is a fifteen-fold over-allocation that nothing in the
+     * API can see (mvsmf#338). This exposes scal1/scal3 so a test can assert
+     * the number that actually reached the DSCB.
+     *
+     * Read-only: __locate() and __dscbdv() consult the catalog and the VTOC.
+     */
+  } else if (strcmp(fn, "dscb") == 0) {
+    char *dsn =
+        (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_DSN");
+    LOCWORK locwork = {0};
+    DSCB dscb = {0};
+    DSCB1 *d1 = &dscb.dscb1;
+    char vol[7] = {0};
+    char dsn44[44];
+    unsigned sec = 0;
+    int loc_rc, dscb_rc = -1;
+
+    if (!dsn)
+      dsn = "SYS1.MACLIB";
+
+    memset(dsn44, ' ', sizeof(dsn44));
+    {
+      size_t n = strlen(dsn);
+      if (n > sizeof(dsn44))
+        n = sizeof(dsn44);
+      memcpy(dsn44, dsn, n);
+    }
+
+    loc_rc = __locate(dsn44, &locwork);
+    if (loc_rc == 0) {
+      memcpy(vol, locwork.volser, 6);
+      dscb_rc = __dscbdv(dsn44, vol, &dscb);
+    }
+
+    if (dscb_rc == 0) {
+      sec = ((unsigned)d1->scal3[0] << 16) | ((unsigned)d1->scal3[1] << 8) |
+            (unsigned)d1->scal3[2];
+    }
+
+    rc = http_printf(
+        session->httpc,
+        "{ \"fn\": \"dscb\", \"dsn\": \"%s\", \"locate_rc\": %d,"
+        " \"dscb_rc\": %d, \"volser\": \"%.6s\","
+        " \"lrecl\": %d, \"blksize\": %d, \"extents\": %d,"
+        " \"spacu\": \"%s\", \"secondary\": %u }\n",
+        dsn, loc_rc, dscb_rc, vol, dscb_rc == 0 ? d1->lrecl : 0,
+        dscb_rc == 0 ? d1->blksz : 0, dscb_rc == 0 ? d1->noepv : 0,
+        (dscb_rc == 0 && (d1->scal1 & 0xC0) == CYL) ? "CYL" : "TRK", sec);
+
     /* --- fn=syslog (stepped probe) -------------------------------- */
     /* Bisect via &step=N.  Each step that returns normally flushes its
      * output; the highest step still producing output is the last that
@@ -1395,6 +1451,7 @@ int testHandler(Session *session) {
         " \"?fn=version             (deployed version + git build id)\","
         " \"?fn=listds&level=HLQ&filter=HLQ.X*\","
         " \"?fn=locate&dsn=SYS1.MACLIB\","
+        " \"?fn=dscb&dsn=DS        (format-1 DSCB space fields incl. secondary)\","
         " \"?fn=syslog&step=0..5  (JES2 spool SYSLOG probe)\","
         " \"?fn=mtt&step=1..3     (Master Trace Table dump)\","
         " \"?fn=cmd&cmd=D+T       (issue MVS command via SVC34, find in MTT)\","

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2764,6 +2764,94 @@ curl -s -o /dev/null -X DELETE -u "$AUTH" \
 curl -s -o /dev/null -X DELETE -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(WRONGTGT)" || true
 
+# --- Create modelled on an existing data set: like= (issue #338) ---
+#
+# This is what `zowe files cp ds` sends -- {"like":"SRC","blksize":19040} -- and
+# a body with none of the five otherwise-required fields used to come back
+# "Invalid or missing allocation parameters".
+#
+# The 201 proves nothing on its own: the point is whether the attributes were
+# actually taken from the model, so every case reads them back off the listing.
+echo ""
+echo "--- Create with like= (issue #338) ---"
+
+LIKE_NEW="${MVSMF_USER}.CURL.LIKENEW"
+LIKE_OVR="${MVSMF_USER}.CURL.LIKEOVR"
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_NEW}" || true
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_OVR}" || true
+
+# the model's own attributes, straight from the listing
+MODEL=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds?dslevel=${TEST_PDS}")
+M_DSORG=$(echo "$MODEL" | jq -r '.items[0].dsorg')
+M_RECFM=$(echo "$MODEL" | jq -r '.items[0].recfm')
+M_LRECL=$(echo "$MODEL" | jq -r '.items[0].lrecl')
+M_BLKSZ=$(echo "$MODEL" | jq -r '.items[0].blksz')
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	-d "{\"like\":\"${TEST_PDS}\"}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${LIKE_NEW}")
+assert_http_status "201" "$HTTP_CODE" "create with like= only"
+
+NEWDS=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds?dslevel=${LIKE_NEW}")
+assert_json_field "$NEWDS" '.items[0].dsorg' "$M_DSORG" "like: dsorg copied from the model"
+assert_json_field "$NEWDS" '.items[0].recfm' "$M_RECFM" "like: recfm copied from the model"
+assert_json_field "$NEWDS" '.items[0].lrecl' "$M_LRECL" "like: lrecl copied from the model"
+assert_json_field "$NEWDS" '.items[0].blksz' "$M_BLKSZ" "like: blksize copied from the model"
+
+# the new PDS must actually be usable as one -- a directory with no blocks is
+# the failure mode LIKE_DIRBLK exists to avoid, and it only shows on a write
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" \
+	-H "Content-Type: application/octet-stream" \
+	--data-binary "MEMBER IN A MODELLED PDS" \
+	"${BASE_URL}/zosmf/restfiles/ds/${LIKE_NEW}(LIKEMBR)")
+assert_http_status "204" "$HTTP_CODE" "like: the modelled PDS takes a member"
+
+# an explicit field overrides the model
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	-d "{\"like\":\"${TEST_PDS}\",\"blksize\":800}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${LIKE_OVR}")
+assert_http_status "201" "$HTTP_CODE" "create with like= plus an override"
+
+OVRDS=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds?dslevel=${LIKE_OVR}")
+assert_json_field "$OVRDS" '.items[0].blksz' "800" "like: an explicit blksize wins over the model"
+assert_json_field "$OVRDS" '.items[0].lrecl' "$M_LRECL" "like: the unspecified lrecl still comes from the model"
+
+# a model that does not exist is a 404, not the generic dynalloc 500
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	-d "{\"like\":\"${MVSMF_USER}.NO.SUCH.MODEL\"}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.LIKEBAD")
+assert_http_status "404" "$HTTP_CODE" "like: a missing model is a 404"
+
+# ... and it created nothing
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.LIKEBAD")
+assert_http_status "404" "$HTTP_CODE" "like: the refused create created nothing"
+
+# an over-long model name must be refused, not truncated into a real one
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" \
+	-d "{\"like\":\"$(printf 'A%.0s' $(seq 1 60))\"}" \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.LIKEBAD")
+if [ "$HTTP_CODE" = "201" ]; then
+	fail "like: an over-long model name is refused" \
+		"got HTTP 201 -- a truncated name was accepted as a model"
+else
+	pass "like: an over-long model name is refused (HTTP $HTTP_CODE)"
+fi
+
+# a body with neither like= nor the five required fields is still a 400
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
+	-H "Content-Type: application/json" -d '{"recfm":"FB"}' \
+	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.LIKEBAD")
+assert_http_status "400" "$HTTP_CODE" "no like= and incomplete parameters is still a 400"
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_NEW}"
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_OVR}"
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -2849,6 +2849,71 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${MVSMF_USER}.CURL.LIKEBAD")
 assert_http_status "400" "$HTTP_CODE" "no like= and incomplete parameters is still a 400"
 
+# --- like= and the allocation unit -----------------------------------------
+#
+# model_alloc() answers in TRACKS whatever unit the model was allocated in. The
+# derived primary is guarded by forcing TRK, and it is easy to believe that
+# covers the secondary too. It does not: with an explicit primary the client's
+# unit governs, and a derived track count emitted under CYL over-allocates every
+# extent about fifteenfold.
+#
+# Nothing in the listing reports the secondary quantity, which is why this needs
+# ?fn=dscb -- asserting only on what the listing shows would pass either way,
+# and that is how this got shipped in the first place.
+
+DSCB_SEC() { curl -s -u "$AUTH" "${BASE_URL}/zosmf/test?fn=dscb&dsn=$1" | jq -r '.secondary'; }
+DSCB_UNIT() { curl -s -u "$AUTH" "${BASE_URL}/zosmf/test?fn=dscb&dsn=$1" | jq -r '.spacu'; }
+
+assert_json_field "$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/test?fn=dscb&dsn=${LIKE_NEW}")" 	'.spacu' "TRK" "like: a fully derived allocation is stated in tracks"
+
+LIKE_CYL="${MVSMF_USER}.CURL.LIKECYL"
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_CYL}" || true
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" 	-H "Content-Type: application/json" 	-d "{\"like\":\"${TEST_PDS}\",\"primary\":1,\"alcunit\":\"CYL\"}" 	"${BASE_URL}/zosmf/restfiles/ds/${LIKE_CYL}")
+assert_http_status "201" "$HTTP_CODE" "like: create with an explicit primary in cylinders"
+
+CYL_UNIT=$(DSCB_UNIT "${LIKE_CYL}")
+CYL_SEC=$(DSCB_SEC "${LIKE_CYL}")
+MODEL_SEC=$(DSCB_SEC "${TEST_PDS}")
+
+if [ "$CYL_UNIT" = "CYL" ]; then
+	pass "like: an explicit alcunit is honoured (CYL)"
+else
+	fail "like: an explicit alcunit is honoured (CYL)" "got spacu=${CYL_UNIT}"
+fi
+
+# the derived, track-denominated secondary must not have been emitted as cylinders
+if [ "${CYL_SEC:-0}" = "0" ]; then
+	pass "like: no track-denominated secondary is emitted under CYL"
+else
+	fail "like: no track-denominated secondary is emitted under CYL" 		"secondary=${CYL_SEC} under spacu=${CYL_UNIT} (model's own secondary is ${MODEL_SEC} tracks) -- a track count written as cylinders over-allocates every extent"
+fi
+
+curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_CYL}"
+
+# --- like= a sequential model, but asking for a PDS -------------------------
+#
+# dirblk keys off the dsorg actually going out, not the model's: a PS model with
+# an explicit dsorg=PO would otherwise be allocated with zero directory blocks.
+LIKE_PS="${MVSMF_USER}.CURL.LIKEPS"
+LIKE_PO="${MVSMF_USER}.CURL.LIKEPO"
+for D in "$LIKE_PS" "$LIKE_PO"; do
+	curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${D}" || true
+done
+
+curl -s -o /dev/null -X POST -u "$AUTH" -H "Content-Type: application/json" 	-d '{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":3120,"alcunit":"TRK","primary":1,"secondary":1}' 	"${BASE_URL}/zosmf/restfiles/ds/${LIKE_PS}"
+
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X POST -u "$AUTH" 	-H "Content-Type: application/json" 	-d "{\"like\":\"${LIKE_PS}\",\"dsorg\":\"PO\"}" 	"${BASE_URL}/zosmf/restfiles/ds/${LIKE_PO}")
+assert_http_status "201" "$HTTP_CODE" "like: a PS model with an explicit dsorg=PO"
+
+# the proof is that it works as a PDS -- zero directory blocks only shows here
+HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -X PUT -u "$AUTH" 	-H "Content-Type: application/octet-stream" --data-binary "MEMBER" 	"${BASE_URL}/zosmf/restfiles/ds/${LIKE_PO}(DIRMBR)")
+assert_http_status "204" "$HTTP_CODE" "like: that PDS got directory blocks and takes a member"
+
+for D in "$LIKE_PS" "$LIKE_PO"; do
+	curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${D}"
+done
+
 curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_NEW}"
 curl -s -o /dev/null -X DELETE -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${LIKE_OVR}"
 

--- a/tests/zowe-datasets.sh
+++ b/tests/zowe-datasets.sh
@@ -621,6 +621,62 @@ skip "etag: X-IBM-Return-Etag / If-Match (no Zowe CLI flag — see curl-datasets
 # option at all, so a 304 cannot be provoked through the CLI even indirectly.
 skip "etag: If-None-Match / 304 (no Zowe CLI or SDK option — see curl-datasets.sh)"
 
+# --- Copy a data set: files cp ds (issue #338) ---
+#
+# The reported symptom, and the one case only the CLI can produce: `cp ds`
+# creates the target with {"like":"<source>","blksize":N} and then copies the
+# members. Before like= was supported that create came back 400 "Invalid or
+# missing allocation parameters" and the copy aborted.
+#
+# The success message is not the assertion -- the members and the attributes
+# are, since a target created with the wrong DCB accepts the copy and corrupts
+# it.
+echo ""
+echo "--- Copy data set (issue #338) ---"
+
+COPY_DST="${MVS_USER}.ZOWE.COPYDST"
+
+run_zowe files delete ds "$COPY_DST" -f >/dev/null 2>&1 || true
+
+# The earlier member tests delete what they create, so TEST_PDS is empty by the
+# time this runs. Put a member back: comparing two empty directories would pass
+# whatever the copy did, which is the assertion that is really a skip.
+printf 'COPY SOURCE MEMBER\n' > /tmp/zowe_copy_src.txt
+run_zowe files ul ftds /tmp/zowe_copy_src.txt "${TEST_PDS}(COPYMBR)" >/dev/null 2>&1 || true
+
+RC=0
+OUTPUT=$(run_zowe files cp ds "$TEST_PDS" "$COPY_DST") || RC=$?
+assert_rc 0 "$RC" "copy PDS to a new data set"
+
+RC=0
+SRC=$(run_zowe_json files ls am "$TEST_PDS") || RC=$?
+DST=$(run_zowe_json files ls am "$COPY_DST") || RC=$?
+SRC_M=$(echo "$SRC" | jq -r '.data.apiResponse.items[].member' 2>/dev/null | sort | tr '\n' ' ')
+DST_M=$(echo "$DST" | jq -r '.data.apiResponse.items[].member' 2>/dev/null | sort | tr '\n' ' ')
+if [ -n "$SRC_M" ] && [ "$SRC_M" = "$DST_M" ]; then
+	pass "the copy has the same members as the source"
+else
+	fail "the copy has the same members as the source" \
+		"source: [${SRC_M}] copy: [${DST_M}]"
+fi
+
+RC=0
+SRCA=$(run_zowe_json files ls ds "$TEST_PDS" -a) || RC=$?
+DSTA=$(run_zowe_json files ls ds "$COPY_DST" -a) || RC=$?
+for F in dsorg recfm lrecl; do
+	SV=$(echo "$SRCA" | jq -r ".data.apiResponse.items[0].${F}" 2>/dev/null)
+	DV=$(echo "$DSTA" | jq -r ".data.apiResponse.items[0].${F}" 2>/dev/null)
+	if [ -n "$SV" ] && [ "$SV" = "$DV" ]; then
+		pass "the copy kept the source ${F} (${DV})"
+	else
+		fail "the copy kept the source ${F}" "source: ${SV}, copy: ${DV}"
+	fi
+done
+
+run_zowe files delete ds "$COPY_DST" -f >/dev/null 2>&1 || true
+run_zowe files delete ds "${TEST_PDS}(COPYMBR)" -f >/dev/null 2>&1 || true
+rm -f /tmp/zowe_copy_src.txt
+
 # --- Cleanup: delete PDS ---
 echo ""
 echo "--- Cleanup ---"


### PR DESCRIPTION
Fixes #338

> **Depends on mvslovers/libc370#124.** CI clones libc370 from its default
> branch, so this cannot go green until that is on `main`.

## What was wrong

z/OSMF's create takes a `like` parameter that models the new data set on an
existing one, and that is what `zowe files cp ds` sends:

```
POST /zosmf/restfiles/ds/IBMUSER.TEST.CNTL
{"like":"IBMUSER.CNTL","blksize":19040}
```

A body like that carries none of the five fields the handler required, so the
copy failed against mvsMF and worked against z/OS:

```
Invalid or missing allocation parameters
rc: 8  category: 6  reason: 3
```

## The DCB attributes come from MVS

libc370#124 adds a `DCBDSN=` keyword for the SVC 99 `DALDCBDS` text unit — the
form of JCL `DCB=(dsname)`. DSORG, RECFM, LRECL and BLKSIZE are copied off the
model's DSCB by the system, so mvsMF decodes nothing and cannot get the encoding
wrong.

Explicit body fields are emitted *after* the model reference and still override
it. The keyword string is now assembled piecewise rather than with one
`snprintf`, because an absent field has to be **omitted** — sending `DSORG=`
empty would override the model with nothing.

## Space is derived, and here is why it has to be

`DCB=` never copied `SPACE`. The thing that does is DFSMS `LIKE=`, which 3.8j has
no equivalent for — measured: `LIKE=` on a DD statement is a JCL ERROR here, and
key X'004B' is `DALRSRVS` ("secondary buffer reserve") in this era's text-unit
table rather than `DALLIKE`. Sending it expecting LIKE semantics would quietly
set a TCAM buffer size.

So `model_alloc()` reads the model's DSCB: allocated tracks become the primary,
`scal3` the secondary, **both normalised to tracks** — a model allocated in
cylinders would otherwise produce a fifteen-times-too-small target. Only the
first three extents are visible in a DSCB1, so a fragmented model under-reports;
that is the safe direction, and the secondary covers the rest.

`dirblk` has no source at all — a DSCB records no directory quantity, so there is
nothing to model. `LIKE_DIRBLK` (20) is a documented decision, not a
measurement: about 100 members once ISPF statistics are present, roughly 5 KB.
A client that knows better sends `dirblk`.

A `like` naming an uncataloged data set answers **404** rather than falling
through to the generic dynalloc 500, which would not say that it was the *model*
that was missing. An over-long `like` is extracted through a scratch buffer wider
than the target, for the same reason as the rename names in #334:
`extract_json_string()` truncates and still returns 0, so a 45-byte target would
turn an over-long name into a valid, different model.

## Two defects found in review, and the observability gap behind them

Both were in the space derivation and neither was visible to the suite.

`model_alloc()` answers in tracks whatever unit the model was allocated in. The
derived **primary** was guarded by forcing `TRK`, and that guard looks like it
covers the secondary too. It does not: with an explicit primary the client's unit
governs, so `{"like":"X","primary":5,"alcunit":"CYL"}` emitted the derived track
count as cylinders — roughly a fifteen-fold over-allocation on every extent. The
derived secondary is now used only when the unit in force is `TRK`.

`dirblk` keyed off the **model's** organisation rather than the one going out, so
`{"like":"PS.MODEL","dsorg":"PO"}` allocated a partitioned data set with no
directory blocks.

The reason the suite could not see the first one is worth keeping: the listing
reports the space *unit* but never the secondary *quantity*, so any assertion
built on it passes either way. `testapi` therefore grows `fn=dscb`, which reports
the format-1 DSCB space fields, and the test asserts on the number that actually
reached the DSCB. The `dirblk` case is asserted by writing a member — zero
directory blocks shows nowhere else.

## Verification

Deployed to mvsdev (build `6bf3227` == HEAD) and activated.

- `tests/curl-datasets.sh`: **267 passed, 0 failed, 0 skipped** — including the
  new `like=` block, which reads every attribute back off the catalog rather
  than trusting the 201, writes a member to prove the modelled PDS actually has
  a directory, and checks the override, the 404, the over-long name and that a
  body with neither `like` nor complete parameters is still a 400.
- `tests/zowe-datasets.sh`: **55 passed, 0 failed, 2 skipped** (the two
  pre-existing ETag CLI-limitation skips), with a new `files cp ds` case.

The reported command, end to end:

```
$ zowe files cp ds "IBMUSER.CNTL" "IBMUSER.TEST.CNTL"
Source contents were successfully copied into a new data set - IBMUSER.TEST.CNTL
```

and the copy is faithful — same DSORG/RECFM/LRECL/BLKSZ, same members, member
content byte-identical to the source. The lower-case form works too, via #334.

## One note on the new Zowe test

It plants a member before copying, deliberately. The earlier member tests delete
what they create, so `TEST_PDS` is empty by the time the copy runs — comparing
two empty directories would pass whatever the copy did. That is the
assertion-that-is-really-a-skip the note at the top of `curl-datasets.sh` warns
about, and it caught itself here on the first run.
