### PR TITLE
Drop the MVSMF_ABEND_TEST gate and hold=; gate the test endpoint at the route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,6 +559,22 @@ the next request S80As before mvsMF's ESTAE exists. `&total=1` briefly holds
 *all* free storage, so it must be sampled between load runs, never during one.
 See [docs/storage-probe.md](docs/storage-probe.md).
 
+**The endpoint has no per-function gate any more, and must not grow one back
+(#343).** `fn=abend`, `fn=jesabend` and `fn=denyopen` were gated on
+`MVSMF_ABEND_TEST` in the server environment from the days when a CGI abend
+cost the address space its storage permanently (httpd#154). That is measured
+gone — httpd#175 plus mvslovers/libc370#126 — and the gate was guarding the
+weakest function here while `fn=cmd`, which issues operator commands through
+SVC 34 in supervisor state, never had one. `&hold=` went with it: it was the
+only knob that degraded *other* requests, and #287, which it was built for, is
+closed. The boundary that means something is the route: building with
+`-DMVSMF_NO_TEST_ENDPOINT` leaves `/zosmf/test` unregistered, which covers
+`fn=cmd` too. Default is ON — `fn=version` is how a deploy is verified.
+
+`tests/curl-diag.sh` now asserts what the gate used to promise: an abend is
+caught, the server keeps serving, and it costs no storage. It deliberately
+faults the worker several times.
+
 ### Known Platform Bugs
 
 The MVS 3.8j TCP/IP stack has a ring buffer bug that corrupts data when a multi-byte `recv()` call spans the internal buffer wrap-around point. Corrupted reads return replayed data from earlier in the stream. Single-byte `recv()` calls are not affected because they never cross the boundary.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -88,7 +88,7 @@ member not found, record too long) produce **no** console message.
 | `MVSMF903W` | `SESSION FILE TABLE FULL, FILE NOT TRACKED` | More data sets are open in one request than `MAX_SESSION_FILES`. The untracked file is not closed if the handler abends. |
 | `MVSMF904I` | `RECOVERY CLOSING dsn (DD:ddname)` | Recovery is closing a data set the abending handler left open. Informational; it accompanies a `MVSMF901E`. |
 | `MVSMF905W` | `RECOVERY FCLOSE ABENDED FOR SLOT n` | The recovery close abended in turn. The DD stays allocated and its storage stays held for the life of the address space. |
-| `MVSMF906W` | `FORCING S0C1 TO EXERCISE THE ESTAE RECOVERY` | `/zosmf/test?fn=abend` is about to abend the worker **on purpose**. Only reachable with `MVSMF_ABEND_TEST=1` in the server environment. Not a fault. |
+| `MVSMF906W` | `FORCING S0C1 TO EXERCISE THE ESTAE RECOVERY` | `/zosmf/test?fn=abend` is about to abend the worker **on purpose**. Not a fault. A build that does not want the diagnostic endpoint at all leaves it out with `-DMVSMF_NO_TEST_ENDPOINT` (#343). |
 | `MVSMF907I` | `ENV[n] "name"="value"` | CGI environment dump, one line per variable. Only written when `logging_middleware` is registered — it is not by default. A developer aid, not an operator message. |
 | `MVSMF908I` | `RECOVERY CLOSING THE JES SPOOL HANDLE` | Recovery is closing the JES2 spool handle an abending handler left open. Informational; it accompanies a `MVSMF901E`. Its absence after a jobs-API abend is the leak of issue #286. |
 | `MVSMF909W` | `RECOVERY JESCLOSE ABENDED, SPOOL DATA SETS STAY OPEN` | The recovery `jesclose()` abended in turn. The JES2 spool data sets stay allocated and their storage stays held for the life of the address space. |

--- a/docs/storage-probe.md
+++ b/docs/storage-probe.md
@@ -10,22 +10,22 @@ them pushes its own evidence out of the buffer.
 GET /zosmf/test?fn=storage
 GET /zosmf/test?fn=storage&total=1
 GET /zosmf/test?fn=storage&sp=1
-GET /zosmf/test?fn=storage&hold=8      (fault injection -- gated, see below)
 ```
 
 Read-only, Basic-Auth like the rest of `/zosmf/test`, and it changes nothing
 in the request paths.
 
-`&hold=<seconds>` (cap 10) keeps the largest block allocated for that long
-before freeing it, so concurrent requests must start their 262328-byte C
-stack in whatever else is free. This is how the fragmentation claim was
-proven live instead of by arithmetic: with only the two fenced-off holes
-(measured 262144 and 258048) available, **8 of 8 concurrent requests failed
-to start** — `HTTPD908E EXTERNAL PROGRAM MVSMF failed with U0801 ABEND` /
-`@@CRT1 - No storage for C stack` on the console, `503` at the client. It is
-deliberate fault injection against a live server, so it is gated exactly like
-`fn=abend`: without `MVSMF_ABEND_TEST=1` in the server environment the
-parameter is ignored and the reply carries `hold_denied: true`.
+**`&hold=<seconds>` is gone (#343).** It kept the largest block allocated for
+up to ten seconds so concurrent requests had to build their C stack in
+whatever else was free, and that is how the fragmentation claim was proven
+live instead of by arithmetic: with only the two fenced-off holes (measured
+262144 and 258048) available, **8 of 8 concurrent requests failed to start** —
+`HTTPD908E EXTERNAL PROGRAM MVSMF failed with U0801 ABEND` / `@@CRT1 - No
+storage for C stack` on the console, `503` at the client. It was the only
+function on this endpoint that degraded *other* requests, and what it was
+built to establish is established: #287 is closed and its cause fixed
+(mvslovers/libc370#115 and `__stklen`). Reinstate it from the history if a
+future investigation needs it.
 
 ## What it reports
 
@@ -89,9 +89,9 @@ This matters most for mvsMF because httpd re-LINKs it on *every request*. The
 point is not the 4× smaller demand but that it changes the failure mode:
 concurrency fences off free holes of roughly one stack each
 (mvslovers/httpd#195), and a 65584-byte request fits in holes that a
-262328-byte one cannot use at all. Measured both ways with `&hold=` against
-the same fragmented space — **8 of 8 requests failed before the change, 8 of
-8 succeeded after it.**
+262328-byte one cannot use at all. Measured both ways with the `&hold=`
+injection of the day against the same fragmented space — **8 of 8 requests
+failed before the change, 8 of 8 succeeded after it.**
 
 `link_stack` is read from `PPASTKLN`, the length `@@crt0`/`@@crt1` actually
 GETMAINed (`ST R8,PPASTKLN`), so it follows `__stklen` and cannot drift from

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -127,8 +127,22 @@ int main(int argc, char **argv)
 
 	/* add the URL mappings */
 	add_route(&router, GET, "/zosmf/info", infoHandler);
+
+	/* /zosmf/test is the diagnostic endpoint, and the boundary that decides
+	   whether a deployment has one is HERE, not inside its functions (#343).
+	   It carries fn=cmd (operator commands via SVC 34 in supervisor state),
+	   fn=abend and fn=denyopen; a runtime flag on some of those guarded the
+	   weakest of them while the strongest never had one. Building with
+	   -DMVSMF_NO_TEST_ENDPOINT leaves the routes unregistered, so the whole
+	   surface answers 404 and the code behind it is unreachable.
+
+	   The default is ON deliberately: fn=version is the documented way to
+	   confirm which build a deploy actually activated, and fn=storage is the
+	   storage instrument -- a hardened build gives both up knowingly. */
+#ifndef MVSMF_NO_TEST_ENDPOINT
 	add_route(&router, GET, "/zosmf/test", testHandler);
 	add_route(&router, GET, "/zosmf/test/wildcard/{*filepath}", testWildcardHandler);
+#endif
 
 	add_route(&router, POST, "/zosmf/services/authenticate", authLoginHandler);
 	add_route(&router, DELETE, "/zosmf/services/authenticate", authLogoutHandler);

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -78,20 +78,18 @@ static const char *jespr_reason_name(int reason) {
  * (e.g. the 2026-07-22 console crash) -- distinct from httpd's worker-level
  * recovery() path, which /abend in httpd already covers.
  *
- * HARD-GUARDED so it can never fire in a production deployment: it only
- * triggers when the server operator has explicitly set MVSMF_ABEND_TEST in
- * the server environment (a `//SYSENV DD` line `MVSMF_ABEND_TEST=1` in the
- * HTTPD started task; read here via getenv() from the CGI's runtime env,
- * which shares httpd's GRT). Unset -- the production default -- returns 400
- * and never faults. The value is server-side and operator-controlled; a
- * client cannot enable it by any request input.
+ * It used to be gated on MVSMF_ABEND_TEST in the server environment, back
+ * when a CGI abend cost the address space its storage permanently
+ * (mvslovers/httpd#154): one deliberate abend could wedge every endpoint
+ * with S80A until the STC was restarted.  That is measured gone -- httpd#175
+ * made CGI storage request-lifetime (ten fn=abend cost 4096 bytes between
+ * them, #287) and mvslovers/libc370#126 closed the last path where a handler
+ * abend leaked what it had built.  The gate also guarded the weakest
+ * function here: fn=cmd issues operator commands through SVC 34 in
+ * supervisor state and never had one, and every caller is authenticated
+ * anyway.  The boundary that means something is the route -- see
+ * MVSMF_NO_TEST_ENDPOINT in mvsmf.c (issue #343).
  */
-__asm__("\n&FUNC	SETC 'abend_test_enabled'");
-static int abend_test_enabled(void) {
-  const char *v = getenv("MVSMF_ABEND_TEST");
-  return v && (v[0] == '1' || v[0] == 'Y' || v[0] == 'y');
-}
-
 /* --- fn=denyopen (issue #315) -------------------------------------------
  * Take a real S913 through the real ESTAE, to check that the router answers a
  * denial OPEN caught with the reference's authorization report rather than the
@@ -107,8 +105,6 @@ static int abend_test_enabled(void) {
  * pre-checks do not cover -- a pre-check and OPEN disagreeing, and the handlers
  * outside dsapi.c -- and a net nobody can reach is a net nobody can test.
  *
- * Gated exactly like fn=abend: an abend costs the CGI its storage subpool
- * (mvslovers/httpd#154), so this must never be reachable in production.
  * Handled before any response byte is written, so headers_sent is still 0 and
  * the router can send its recovery response.
  */
@@ -116,15 +112,6 @@ __asm__("\n&FUNC	SETC 'testDenyOpen'");
 static int testDenyOpen(Session *session) {
   char *dsn = (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_DSN");
   FILE *fp;
-
-  if (!abend_test_enabled()) {
-    return sendErrorResponse(
-        session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE, RC_ERROR,
-        REASON_SERVER_ERROR,
-        "fn=denyopen is disabled. Set MVSMF_ABEND_TEST=1 in the server "
-        "environment to enable the denial-recovery test hook.",
-        NULL, 0);
-  }
 
   if (!dsn)
     dsn = "SYS1.SECURE.CNTL(PROFILES)";
@@ -154,15 +141,6 @@ static int testDenyOpen(Session *session) {
 
 __asm__("\n&FUNC	SETC 'testAbend'");
 static int testAbend(Session *session) {
-  if (!abend_test_enabled()) {
-    return sendErrorResponse(
-        session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE, RC_ERROR,
-        REASON_SERVER_ERROR,
-        "fn=abend is disabled. Set MVSMF_ABEND_TEST=1 in the server "
-        "environment to enable the ESTAE recovery test hook.",
-        NULL, 0);
-  }
-
   wtof(MSG_ABEND_TEST);
 
   /* Deliberate operation exception (S0C1): execute an invalid opcode
@@ -186,15 +164,6 @@ static int testAbend(Session *session) {
 __asm__("\n&FUNC	SETC 'testJesAbend'");
 static int testJesAbend(Session *session) {
   JES *jes = NULL;
-
-  if (!abend_test_enabled()) {
-    return sendErrorResponse(
-        session, HTTP_STATUS_BAD_REQUEST, CATEGORY_SERVICE, RC_ERROR,
-        REASON_SERVER_ERROR,
-        "fn=jesabend is disabled. Set MVSMF_ABEND_TEST=1 in the server "
-        "environment to enable the ESTAE recovery test hook.",
-        NULL, 0);
-  }
 
   jes = jesopen();
   if (!jes) {
@@ -848,18 +817,22 @@ int testHandler(Session *session) {
         ret ? "non-null" : "NULL", len,
         (reveal && strcmp(reveal, "1") == 0) ? (char *)buf : masked);
 
-    /* --- fn=env (does the CGI see httpd's //SYSENV?) --------------- */
-    /* The abend test hook is gated on getenv("MVSMF_ABEND_TEST"), which only
-     * works because httpd and the CGI share one CLIBGRT -- the CGI reads the
-     * environment httpd's @@START loaded from //SYSENV. When that gate does
-     * not open there are two indistinguishable causes: the DD/member was not
-     * in place at server start, or the CGI is not seeing httpd's environment
-     * at all. Listing what this CGI actually has separates them: names but no
-     * MVSMF_* means the member was empty at start; an empty list means the
-     * environment is not shared.
+    /* --- fn=env (what environment did this CGI load?) -------------- */
+    /* httpd and the CGI do NOT share an environment, despite what this
+     * comment claimed until #343.  Every LINK builds its own CLIBGRT with
+     * its own empty env array (it has to: grtapp2 holds the per-request
+     * HTTPC), and cgistart.c then runs loadenv("dd:SYSENV") into it -- so
+     * what the CGI sees comes from re-reading the DD on this very request,
+     * not from httpd's copy.  What the two share is the address space's DD,
+     * which is why the member must stay allocated for the life of the STC
+     * and why FREE=CLOSE on it leaves every CGI with an empty environment.
      *
-     * Names are always safe to show; values are not (httpd's environment is
-     * the server operator's, not the caller's), so only MVSMF_* values are
+     * That makes this function the direct read-out of that per-request load:
+     * an empty list means the DD or member was not there when this request
+     * ran; names present means loadenv() found and parsed it.
+     *
+     * Names are always safe to show; values are not (the environment is the
+     * server operator's, not the caller's), so only MVSMF_* values are
      * printed -- those are our own test flags and carry no secrets.
      *
      * Read grt->grtenv, which is where the environment actually lives. The
@@ -911,34 +884,18 @@ int testHandler(Session *session) {
     char *spv = (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_SP");
     char *totalv =
         (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_TOTAL");
-    char *holdv =
-        (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_HOLD");
     int spn = spv ? atoi(spv) : 0;
     unsigned sp = (unsigned)spn;
     int want_total = totalv && (totalv[0] == '1' || totalv[0] == 'y' ||
                                 totalv[0] == 'Y');
-    /* &hold=<seconds> (cap 10): after measuring, KEEP the largest block
-     * allocated for that long before freeing it.  Concurrent requests must
-     * then start their 262328-byte C stack in what remains -- which is how
-     * both halves of the #287 fragmentation claim get proven live: a request
-     * that fails U0801 while the holes are the only space left proves the
-     * failure signature AND that a fenced-off hole cannot hold a stack.
-     *
-     * This is deliberate fault injection against a live server, so it is
-     * gated exactly like fn=abend: without MVSMF_ABEND_TEST in the server
-     * environment the parameter is ignored and reported as such. */
-    int hold = holdv ? atoi(holdv) : 0;
-    int hold_denied = 0;
-
-    if (hold < 0)
-      hold = 0;
-    if (hold > 10)
-      hold = 10;
-    if (hold && !abend_test_enabled()) {
-      hold = 0;
-      hold_denied = 1;
-    }
-
+    /* There used to be an &hold=<seconds> here: it kept the largest block
+     * allocated for up to ten seconds so a concurrent request had to build
+     * its C stack in what remained, which is how both halves of the #287
+     * fragmentation claim were proven live.  It is gone with #343.  Unlike
+     * every other function on this endpoint it degraded OTHER requests, and
+     * what it was built to establish is established -- #287 is closed and
+     * its cause fixed (mvslovers/libc370#115 and __stklen).  Reinstate it
+     * from the history if an investigation ever needs it again. */
     if (spn < 0 || spn > 127) {
       rc = http_printf(session->httpc,
                        "{ \"fn\": \"storage\", \"error\": \"sp must be 0..127;"
@@ -963,14 +920,6 @@ int testHandler(Session *session) {
         p = stg_getmain(largest, sp);
         if (p) {
           sprintf(largest_at, "0x%06X", (unsigned)(unsigned long)p);
-          if (hold) {
-            ECB ecb = 0;
-            /* BINTVL is in hundredths of a second.  A failed timer (negative
-             * rc) means no wait happened -- fine here, the block is simply
-             * given back at once and `held` reports what really occurred. */
-            if (ecb_timed_wait(&ecb, (unsigned)hold * 100u, 1) < 0)
-              hold = 0;
-          }
           if (stg_freemain(p, largest, sp) != 0)
             free_errors++;
         }
@@ -1005,13 +954,6 @@ int testHandler(Session *session) {
         }
 
         rc = http_printf(session->httpc, "]");
-        if (rc < 0)
-          goto quit;
-      }
-
-      if (hold || hold_denied) {
-        rc = http_printf(session->httpc, ", \"held\": %d, \"hold_denied\": %s",
-                         hold, hold_denied ? "true" : "false");
         if (rc < 0)
           goto quit;
       }
@@ -1455,8 +1397,7 @@ int testHandler(Session *session) {
         " \"?fn=syslog&step=0..5  (JES2 spool SYSLOG probe)\","
         " \"?fn=mtt&step=1..3     (Master Trace Table dump)\","
         " \"?fn=cmd&cmd=D+T       (issue MVS command via SVC34, find in MTT)\","
-        " \"?fn=storage&sp=0&total=0|1&hold=N (free storage sample; total=1 briefly holds all"
-        " of it; hold=N keeps the largest block N seconds -- needs MVSMF_ABEND_TEST=1)\","
+        " \"?fn=storage&sp=0&total=0|1 (free storage sample; total=1 briefly holds all of it)\","
         " \"?fn=intrdr&n=1..25      (internal-reader open/close cycles, no records; libc370#115 bisect)\","
         " \"?fn=job&jobname=NAME    (raw JCT completion + JCTJTFLG bits per job; mvsmf#305)\","
         " \"?fn=spool&jobname=NAME&jobid=JOBnnnnn&dsid=1&maxblk=4&len=1024"
@@ -1465,8 +1406,8 @@ int testHandler(Session *session) {
         " \"?fn=token               (session token length; value withheld)\","
         " \"?fn=checkauth&dsn=DS&attr=read|update|control|alter&via=raw|vector|both  (RACHECK probe; mvsmf#228)\","
         " \"?fn=password&reveal=0|1 (http_get_password() export; reveal=1 = plaintext)\","
-        " \"?fn=abend               (force S0C1 -> ESTAE recovery test; needs MVSMF_ABEND_TEST=1)\","
-        " \"?fn=denyopen&dsn=DS      (open without authorizing -> S913 -> denial recovery; needs MVSMF_ABEND_TEST=1)\""
+        " \"?fn=abend               (force S0C1 -> ESTAE recovery test)\","
+        " \"?fn=denyopen&dsn=DS      (open without authorizing -> S913 -> denial recovery)\""
         " ] }\n");
   }
 

--- a/tests/curl-diag.sh
+++ b/tests/curl-diag.sh
@@ -2,25 +2,30 @@
 # =========================================================================
 # mvsMF diagnostics endpoint (/zosmf/test) - curl test suite
 #
-# Focus: the fn=abend ESTAE recovery test hook (src/testapi.c).
+# Focus: the CGI-level ESTAE recovery hooks (src/testapi.c).
 #
-#   GET /zosmf/test?fn=abend
+#   GET /zosmf/test?fn=abend      deliberate S0C1
+#   GET /zosmf/test?fn=jesabend   the same, with a JES spool handle open
 #
-# This suite verifies the PRODUCTION-SAFETY guard, i.e. the DISABLED path:
-# when the server environment does NOT set MVSMF_ABEND_TEST, fn=abend must
-# return HTTP 400 and must NOT fault -- the server keeps serving. That is
-# the "cannot fire in a production deployment" guarantee.
+# Until #343 these were gated on MVSMF_ABEND_TEST in the server environment
+# and this suite asserted the DISABLED path -- 400, no fault. That gate
+# existed because a CGI abend used to cost the address space its storage
+# permanently (mvslovers/httpd#154), and it is gone because that is no longer
+# true. So the suite now asserts the property that REPLACED it:
 #
-# The ENABLED path (MVSMF_ABEND_TEST=1 -> deliberate S0C1 -> router ESTAE
-# failed() -> MVSMF97W + MVSMF99E + HTTP 500) is the CGI-level recovery path
-# exercised by the httpd#123 shutdown acceptance test, not here. Running this
-# suite against a server that HAS MVSMF_ABEND_TEST set will (correctly) report
-# the abend test as enabled and skip the disabled-path assertions.
+#   1. an abend is caught -- 500 with the abend code in the body, not a
+#      dropped connection;
+#   2. the server keeps serving afterwards;
+#   3. it costs no storage. This is the regression guard for httpd#175
+#      (request-lifetime CGI storage) and mvslovers/libc370#126 (recovery
+#      frees what a handler was building). A leak here is what used to end in
+#      every endpoint answering S80A until the STC was restarted.
 #
 # Prerequisites:
 #   - Copy .env.example to .env at the repo root and fill in
 #   - curl and jq must be installed
-#   - the server must NOT have MVSMF_ABEND_TEST set (production-like)
+#   - a server that may be abended on purpose: this suite DOES fault the
+#     worker, several times, by design
 #
 # Usage:
 #   ./tests/curl-diag.sh
@@ -74,57 +79,92 @@ echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
 echo " User: ${MVSMF_USER}"
 echo "========================================"
 
+# storage sample: echo the largest free block, or empty on failure
+storage_largest() {
+	curl -s -u "$AUTH" "${TEST_URL}?fn=storage&total=1" |
+		sed -n 's/.*"total": \([0-9]*\).*/\1/p'
+}
+
 # =========================================================================
-# 1. fn=abend is guarded: DISABLED by default -> 400, no fault
+# 1. fn=abend faults and the router's ESTAE catches it
 # =========================================================================
 echo ""
-echo "--- fn=abend guard (expect DISABLED in production) ---"
+echo "--- fn=abend: deliberate S0C1, caught by the router ESTAE ---"
+BEFORE=$(storage_largest)
+if [ -z "$BEFORE" ]; then
+	fail "baseline storage sample" "fn=storage&total=1 returned nothing"
+	BEFORE=0
+else
+	pass "baseline storage sample (${BEFORE} bytes free)"
+fi
+
 RESP=$(get_fn abend)
 CODE=$(echo "$RESP" | tail -1); BODY=$(echo "$RESP" | sed '$d')
 
-if [ "$CODE" = "400" ]; then
-	pass "fn=abend disabled -> HTTP 400"
+# A caught abend is a formatted 500. A dropped connection (curl code 000) means
+# nothing caught it, which is the failure this hook exists to detect.
+assert_http_status "500" "$CODE" "fn=abend -> caught, formatted error"
 
-	# =====================================================================
-	# 2. server survived the guarded call (did not abend/crash)
-	# =====================================================================
-	echo ""
-	echo "--- server still serving after guarded fn=abend ---"
-	RESP2=$(get_fn version)
-	CODE2=$(echo "$RESP2" | tail -1)
-	assert_http_status "200" "$CODE2" "server alive after fn=abend (fn=version)"
+if echo "$BODY" | grep -qi "abend"; then
+	pass "fn=abend body names the abend"
 else
-	# 500 (or a dropped connection) means the guard did not hold and the
-	# handler actually faulted -- fail loudly, this is the safety property.
-	fail "fn=abend disabled -> HTTP 400" \
-		"got HTTP '${CODE}'. If 500, MVSMF_ABEND_TEST is set on the server: \
-this suite must run against a production-like server with it UNSET."
+	fail "fn=abend body names the abend" "got: ${BODY}"
 fi
 
+echo ""
+echo "--- server still serving after the abend ---"
+CODE2=$(get_fn version | tail -1)
+assert_http_status "200" "$CODE2" "server alive after fn=abend (fn=version)"
+
 # =========================================================================
-# 3. fn=jesabend is guarded the same way
+# 2. fn=jesabend: the same, with a JES handle open
 #
-# It abends with a JES handle open, so on the ENABLED path recovery has to
-# close it (MVSMF908I) instead of leaking the JES2 spool DCBs -- issue #286.
-# Here, as above, only the guard is asserted: the enabled path is exercised
-# by hand against a server that sets MVSMF_ABEND_TEST.
+# Recovery has to close the spool handle (MVSMF908I on the console) instead of
+# leaking the JES2 spool DCBs -- issue #286. What is checkable from here is
+# that the jobs API still works afterwards: a leaked handle takes the spool
+# DCBs with it.
 # =========================================================================
 echo ""
-echo "--- fn=jesabend guard (expect DISABLED in production) ---"
-RESP=$(get_fn jesabend)
-CODE=$(echo "$RESP" | tail -1)
+echo "--- fn=jesabend: abend with a spool handle open ---"
+CODE=$(get_fn jesabend | tail -1)
+assert_http_status "500" "$CODE" "fn=jesabend -> caught, formatted error"
 
-if [ "$CODE" = "400" ]; then
-	pass "fn=jesabend disabled -> HTTP 400"
+echo ""
+echo "--- jobs API still works after the abend ---"
+CODE2=$(curl -s -o /dev/null -w '%{http_code}' -u "$AUTH" \
+	"${BASE_URL}/zosmf/restjobs/jobs?owner=*&prefix=HTTPD*")
+assert_http_status "200" "$CODE2" "jobs list after fn=jesabend"
 
-	echo ""
-	echo "--- server still serving after guarded fn=jesabend ---"
-	CODE2=$(get_fn version | tail -1)
-	assert_http_status "200" "$CODE2" "server alive after fn=jesabend (fn=version)"
+# =========================================================================
+# 3. the abends cost no storage
+#
+# This is the assertion that replaced the production gate. Ten abends used to
+# be measured at 4096 bytes between them (#287); the tolerance below is far
+# wider than that and still far below one CGI stack, so a real leak fails it
+# while ordinary allocator noise does not.
+# =========================================================================
+echo ""
+echo "--- storage after the abends (the guard that replaced the gate) ---"
+for _ in 1 2 3 4 5; do
+	curl -s -o /dev/null -u "$AUTH" "${TEST_URL}?fn=abend"
+done
+CODE2=$(get_fn version | tail -1)
+assert_http_status "200" "$CODE2" "server alive after five more abends"
+
+AFTER=$(storage_largest)
+if [ -z "$AFTER" ]; then
+	fail "storage sample after the abends" "fn=storage&total=1 returned nothing"
+elif [ "$BEFORE" -eq 0 ]; then
+	fail "storage delta" "no usable baseline"
 else
-	fail "fn=jesabend disabled -> HTTP 400" \
-		"got HTTP '${CODE}'. If 500, MVSMF_ABEND_TEST is set on the server: \
-this suite must run against a production-like server with it UNSET."
+	LOST=$((BEFORE - AFTER))
+	if [ "$LOST" -lt 65536 ]; then
+		pass "seven abends cost ${LOST} bytes (< 64K)"
+	else
+		fail "seven abends cost ${LOST} bytes" \
+			"a CGI abend must not leak (httpd#175, mvslovers/libc370#126). \
+Before ${BEFORE}, after ${AFTER}."
+	fi
 fi
 
 # =========================================================================


### PR DESCRIPTION
Fixes #343.

`fn=abend`, `fn=jesabend` and `fn=denyopen` were gated on `MVSMF_ABEND_TEST` in the server environment, and `fn=storage&hold=` with them. The gate was right when it was written — a CGI abend was cleaned up by nobody (mvslovers/httpd#154), so one deliberate abend could later wedge every endpoint with S80A until the STC was restarted — and it is measured wrong now.

**What changed under it:** httpd#175 made CGI storage request-lifetime (ten `fn=abend` = 4096 bytes between them, #287), and mvslovers/libc370#126 closed the last path where a handler abend leaked what it was building. **What it was guarding:** the weakest function on the endpoint — `fn=cmd` issues operator commands through SVC 34 in supervisor state and never had a gate, `/zosmf/restconsoles` ships that capability as a feature, and every caller here is authenticated. **What it cost:** `getenv()` is fed by `loadenv("dd:SYSENV")`, which `cgistart` runs on **every CGI LINK** — a PDS member open and parse per request, against a data set that must stay allocated for the life of the STC. On mvsdev that data set was SYS2.PARMLIB, i.e. #342's arming condition.

`&hold=` is deleted rather than ungated: it is the one knob that degraded *other* requests (largest free block held for up to ten seconds), and #287, which it was built to prove, is closed with its cause fixed. The history has it.

The boundary moves to the route: `-DMVSMF_NO_TEST_ENDPOINT` leaves `/zosmf/test` unregistered, which covers `fn=cmd` too. Default ON, deliberately — `fn=version` is the documented deploy verification and `fn=storage` is the storage instrument, so a hardened build gives both up knowingly.

`tests/curl-diag.sh` asserted the disabled path, which no longer exists. It now asserts the property that replaced it, which is the useful regression guard for httpd#175 and libc370#126: the abend is caught, the server keeps serving, and the abends cost no storage.

Also corrects the `fn=env` comment, which claimed httpd and the CGI share one CLIBGRT. They do not — every LINK builds its own with an empty environment (it has to; `grtapp2` holds the per-request HTTPC) and `cgistart` reloads `//SYSENV` into it per request. That is why `FREE=CLOSE` on that DD leaves every CGI with nothing, which is what the maintainer measured when it was tried.

## Verified on mvsdev (build `37cc960`)

- `tests/curl-diag.sh` **8/8**, including the headline number: **seven deliberate abends cost 8192 bytes**.
- `fn=denyopen` now actually exercises #315's safety net, which the closed gate made unreachable in practice: as an admin it reports "the data set opened, so nothing was denied"; as an ordinary id it takes the real S913 and comes back with `Authorization failed - You may not use this protected data set. Open 913 abend.`
- `fn=storage&hold=8` is ignored, and the reply carries neither `held` nor `hold_denied`.
- `fn=env` confirms the end state: `MVSMF_ABEND_TEST=1` is still loaded from the DD and now has **no consumer anywhere**.
- Regression: `make test-mvs` 508/0, `curl-datasets.sh` 267/0, `curl-jobs.sh` 119/0 (2 skipped), `curl-console.sh` 64/0.

`SYSENV` itself stays a legitimate feature — `TZ` is a documented consumer in httpd's `docs/configuration.md` and reaches every task. What no longer forces it to point at SYS2.PARMLIB is mvslovers/httpd#238.
