### PR TITLE
docs+tests: complete #346, and stop advertising record mode on dataset PUT

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,8 @@ than code, and the per-issue hazard that makes an obvious-looking fix not one.
 the issue thread, the PR, `docs/uss-spec.md` — this file points at it and stops.
 
 *Last reconciled against the tracker: 2026-08-23, 21 issues open — twenty
-entries below, because one of them pairs two issues.*
+entries below, because one of them pairs two issues. The doc halves of #346 and
+#245 landed the same day; both issues stay open on their remaining half.*
 
 ---
 
@@ -18,13 +19,13 @@ entries below, because one of them pairs two issues.*
 | | Issue | Kind | Waiting on |
 |---|---|---|---|
 | 1 | #214 | serialization landed; residuals open | a repro for the collect half |
-| 2 | #346 | decided: docs, not a timer | #214 part 3, for the collect half |
+| 2 | #346 | docs landed; test half open | a stand with `RUN_FTPD_TESTS=1` |
 | 3 | #267 | latent; one word, activates ten paths | a read of `quit:` |
 | 4 | #336 | accepts the syntax, discards the operand | wire it or reject it |
 | 5 | #210 | client-visible, fix identified, local | nothing |
 | 6 | #251 | Optimistic Path stop pattern | nothing |
 | 7 | #209 | client-visible, cheap on 3.8j | nothing |
-| 8 | #245 | the docs are wrong *today* | doc fix now, decision after |
+| 8 | #245 | docs corrected; decision open | reader-vs-400 decision |
 | 9 | #326 | its trigger has fired | nothing |
 | 10 | #76 | the one externally reported defect | nothing |
 | 11 | #244 | the ordering constraint is the content | nothing |
@@ -145,17 +146,25 @@ triples every console call — and it still would not fix this report, because
 `P FTPD` pauses 2 s mid-reply. It also feeds straight into #214, whose lock
 spans convergence.
 
-So: no timer, no marker field, no protocol change. `issue-command.md` must say
-that `cmd-response` is what arrived before the reply went quiet and that
-`cmd-response-key` is the way to the rest; `docs/examples.md` needs
-`--wait-to-collect`, which is the answer to the reported symptom and is
-currently nowhere. **The collect half depends on #214 part 3** — documenting
-collect as the completion path is only honest once it stops re-anchoring on the
-newest `strstr` match.
+So: no timer, no marker field, no protocol change. **The documentation half
+landed** — `issue-command.md` now states the convergence rule rather than its
+bound and says a reply with a mid-stream pause is cut at the pause,
+`collect.md` gained the completion-path section, and `docs/examples.md` gained
+`--wait-to-collect`.
 
-The regression test now needs no timing constant: assert the **difference** on
-the opt-in `P FTPD`/`S FTPD` block — more lines with the flag than without. It
-asserts only detection status today.
+**The "#214 part 3" dependency is discharged as a wording constraint, not as a
+fix.** It is dead as written — part 3 never landed and cannot, because it needs
+an MTT position that does not exist. But "collect is the completion path" and
+"collect is deterministic" are different claims and #346 only ever needed the
+first, so `collect.md` documents the completion path *and* names the
+re-anchoring caveat next to it. That is what makes the wording honest without
+waiting.
+
+**What is left is the regression test**, and it needs no timing constant:
+assert the **difference** on the opt-in `P FTPD`/`S FTPD` block — more lines
+with the flag than without. It asserts only detection status today. It is
+`RUN_FTPD_TESTS=1`, so it stops and starts FTPD on a live stand and cannot be
+written blind.
 
 ### 3 · #267 — `unsigned rc` makes every send-error check dead code
 
@@ -209,10 +218,14 @@ the code.
 The read path length-prefixes each record; the write path sends `record` down the
 *text* loop, so the four bytes read back as a length are a length only by accident.
 
-**Correct `put.md` and `members-put.md` immediately, ahead of any other decision.**
-Both advertise the mode without qualification today; that is what misleads right
-now and it costs nothing to stop. Then choose: a length-prefixed reader (mind a
-prefix split across a chunk boundary, and `record_content_max()`), or a 400.
+**The docs are corrected — that half is done.** It was three places, not the
+two the issue names: the opening sentence of `put.md` and `members-put.md`,
+their `X-IBM-Data-Type` bullets, and the common-header table in
+`docs/endpoints/README.md`. Grep before trusting an issue's list of sites.
+
+What is left is the choice: a length-prefixed reader (mind a prefix split
+across a chunk boundary, and `record_content_max()`), or a 400. Nothing
+misleads a client in the meantime.
 
 ### 9 · #326 — five sources missing from the CLAUDE.md list
 
@@ -490,9 +503,10 @@ Pointers only — the reasoning lives in the closing comments.
   of the block are guessed", and they fail in opposite directions from opposite
   preconditions. #251 is independent of all three.
 - **The endpoint advertises what it does not do** — #245 and #336, with #248 as
-  the worked example of how it ends. The doc half of #245 and the reject half of
-  #336 are both nearly free and both stop the lying today, ahead of whichever
-  implementation decision follows.
+  the worked example of how it ends. **#245's doc half is done**, which is the
+  campaign's proof that the cheap half is worth taking alone: the mode is still
+  unimplemented and nothing lies about it any more. #336's reject half is the
+  same move and is still open.
 - **Checked, then swallowed** — #267, #251, #215. The same `CLAUDE.md` stop pattern
   in three subsystems: the return code is inspected and the failure goes nowhere.
   One convention, not three decisions.

--- a/TODO.md
+++ b/TODO.md
@@ -9,8 +9,9 @@ than code, and the per-issue hazard that makes an obvious-looking fix not one.
 the issue thread, the PR, `docs/uss-spec.md` — this file points at it and stops.
 
 *Last reconciled against the tracker: 2026-08-23, 21 issues open — twenty
-entries below, because one of them pairs two issues. The doc halves of #346 and
-#245 landed the same day; both issues stay open on their remaining half.*
+entries below, because one of them pairs two issues. #346 is complete on PR
+#349 (docs + regression test, measured) and closes with it; #245's doc half
+landed there too and it stays open on its implement-vs-reject decision.*
 
 ---
 
@@ -19,7 +20,7 @@ entries below, because one of them pairs two issues. The doc halves of #346 and
 | | Issue | Kind | Waiting on |
 |---|---|---|---|
 | 1 | #214 | serialization landed; residuals open | a repro for the collect half |
-| 2 | #346 | docs landed; test half open | a stand with `RUN_FTPD_TESTS=1` |
+| 2 | #346 | **done** — docs + test, measured | nothing; closes on PR #349 |
 | 3 | #267 | latent; one word, activates ten paths | a read of `quit:` |
 | 4 | #336 | accepts the syntax, discards the operand | wire it or reject it |
 | 5 | #210 | client-visible, fix identified, local | nothing |
@@ -160,11 +161,19 @@ first, so `collect.md` documents the completion path *and* names the
 re-anchoring caveat next to it. That is what makes the wording honest without
 waiting.
 
-**What is left is the regression test**, and it needs no timing constant:
-assert the **difference** on the opt-in `P FTPD`/`S FTPD` block — more lines
-with the flag than without. It asserts only detection status today. It is
-`RUN_FTPD_TESTS=1`, so it stops and starts FTPD on a live stand and cannot be
-written blind.
+**The regression test landed too, in a shape the entry above asked for and one
+it did not.** "More lines with the flag than without" is not assertable on its
+own: it goes green on a stand fast enough to catch the whole block in one
+window, so a passing run would say nothing. What the curl suite asserts instead
+is the union — issue + collect carry the terminal `$HASP395` — and the strict
+difference only on a run that actually truncated, where a silent collect fails.
+Both halves come from **one** `P FTPD` call, so the service stops once.
+
+Measured on mvsdev 2026-08-23 with `RUN_FTPD_TESTS=1`: the capture returned
+**1 line, collect the remaining 3**, so the difference branch fired rather than
+the skip. curl 71/71, Zowe 13/13, FTPD back up afterwards. The Zowe half
+asserts `--wait-to-collect` reaches `$HASP395`, which is the same property
+through the client that meets it.
 
 ### 3 · #267 — `unsigned rc` makes every send-error check dead code
 
@@ -495,13 +504,15 @@ Pointers only — the reasoning lives in the closing comments.
 
 ## Campaigns, not twenty tickets
 
-- **Console correctness** — #214, #346, #251, and #195 behind them. One
-  subsystem and one reading of `consapi.c`, but **four separate bugs**: #214 and
-  #195 were ranked together on the guess that #195 might not survive the first
-  measurement of #214, and that premise is dead — see #195's entry. #214 and
-  #346 are the two halves of "MVS gives no end-of-response signal, so both ends
-  of the block are guessed", and they fail in opposite directions from opposite
-  preconditions. #251 is independent of all three.
+- **Console correctness** — #214, #251 and #195, with #346 now closed out of
+  it. One subsystem and one reading of `consapi.c`, but **four separate bugs**.
+  #214 and #195 were ranked together on the guess that #195 might not survive
+  the first measurement of #214, and that premise is dead — see #195's entry.
+  #214 and #346 were the two halves of "MVS gives no end-of-response signal, so
+  both ends of the block are guessed", failing in opposite directions from
+  opposite preconditions; #346's half proved to be by design and closed as
+  documentation plus a test, which leaves #214 holding that pair alone. #251 is
+  independent of all three.
 - **The endpoint advertises what it does not do** — #245 and #336, with #248 as
   the worked example of how it ends. **#245's doc half is done**, which is the
   campaign's proof that the cheap half is worth taking alone: the mode is still

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -131,7 +131,8 @@ file system, where `/tmp/Foo` and `/tmp/foo` are different files.
 
 | Header | Used By | Description |
 |--------|---------|-------------|
-| `X-IBM-Data-Type` | Dataset/member GET & PUT | `text` (default), `binary`; `record` on GET only (unimplemented on PUT, #245) |
+| `X-IBM-Data-Type` | Dataset/member GET | `text` (default), `binary`, `record` |
+| `X-IBM-Data-Type` | Dataset/member PUT | `text` (default), `binary`. `record` is accepted and **not implemented** — the write path frames no length prefix (#245) |
 | `X-IBM-Intrdr-Mode` | Job submit | Validated but fixed to `TEXT` |
 | `X-IBM-Intrdr-Lrecl` | Job submit | Validated but fixed to `80` |
 | `X-IBM-Intrdr-Recfm` | Job submit | Validated but fixed to `F` |

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -131,7 +131,7 @@ file system, where `/tmp/Foo` and `/tmp/foo` are different files.
 
 | Header | Used By | Description |
 |--------|---------|-------------|
-| `X-IBM-Data-Type` | Dataset/member GET & PUT | `text` (default), `binary`, `record` |
+| `X-IBM-Data-Type` | Dataset/member GET & PUT | `text` (default), `binary`; `record` on GET only (unimplemented on PUT, #245) |
 | `X-IBM-Intrdr-Mode` | Job submit | Validated but fixed to `TEXT` |
 | `X-IBM-Intrdr-Lrecl` | Job submit | Validated but fixed to `80` |
 | `X-IBM-Intrdr-Recfm` | Job submit | Validated but fixed to `F` |

--- a/docs/endpoints/console/collect.md
+++ b/docs/endpoints/console/collect.md
@@ -21,6 +21,26 @@ On successful completion, this request returns HTTP status code 200 (OK):
 
 Repeated polling drains the response: each call returns only what arrived since the previous call; once the command is done, collect returns `""`. An unknown key is **not** an error — it returns 200 with an empty `cmd-response`.
 
+### The completion path — and its one caveat
+
+This is how a truncated `cmd-response` is completed. The synchronous capture at
+issue time ends when the reply goes quiet, so a command that pauses mid-stream
+comes back short, with HTTP 200 and no indicator that anything is missing (see
+[Issue Command](issue-command.md#response)). The lines that arrive after that
+point are here and nowhere else. `P FTPD` is the worked example: one line from
+the issue call, four once collect is polled. Zowe CLI drives exactly this loop
+for `--wait-to-collect <seconds>`.
+
+**It re-correlates rather than resuming, and that part is not deterministic.**
+Every call finds the block again by searching the MTT for the *newest* entry
+matching the stored command text, so the same command text issued again between
+issue and collect — by another client, or by an operator at a console — moves
+the anchor to the newer echo, and the delta is then counted against a block the
+key was not handed out for. #214's serialization does not cover this: that lock
+is held by the issuing path only, and collect runs long afterwards and outside
+it. Closing it needs a stable position in the MTT and there is none across
+snapshots — tracked in #214.
+
 ## Error Responses
 Console error body (`return-code`/`reason-code`/`reason`). A bogus or evicted key yields HTTP 200 with an empty `cmd-response`, not an error.
 

--- a/docs/endpoints/console/issue-command.md
+++ b/docs/endpoints/console/issue-command.md
@@ -44,11 +44,14 @@ PUT
 ## Response
 
 ### Synchronous (`async` omitted or `N`) — HTTP 200
-After issuing, the MTT is polled for ~3 s for the correlated response.
+After issuing, the MTT is polled until the response block stops growing: the
+capture ends ~0.3 s after the line count last changed (three 0.10 s polls with
+no new line), and in any case after ~3 s. A lone `D T` takes about 0.39 s —
+four polls, which is the earliest the loop can return.
 
 ```json
 {
-    "cmd-response": "response lines joined by \\r, or \"\" if none in time",
+    "cmd-response": "lines captured before the reply went quiet, joined by \\r (\"\" if none in time)",
     "cmd-response-key": "opaque key",
     "cmd-response-url": "http://host:port/zosmf/restconsoles/consoles/{name}/solmsgs/{key}",
     "cmd-response-uri": "/zosmf/restconsoles/consoles/{name}/solmsgs/{key}",
@@ -56,7 +59,32 @@ After issuing, the MTT is polled for ~3 s for the correlated response.
 }
 ```
 
-`sol-key-detected` is present only when `sol-key` was supplied. A `cmd-response` of `""` means nothing was captured within the window — use the [Collect Command Response](collect.md) endpoint to retrieve the rest.
+`sol-key-detected` is present only when `sol-key` was supplied.
+
+**`cmd-response` holds what had arrived before the reply went quiet, and nothing
+in the response says whether that was all of it.** A command whose reply pauses
+mid-stream is cut at the pause. `P FTPD` returns `FTPD098I` alone; the
+`FTPD099I`, `IEF404I` and `$HASP395` lines that follow about 2 s later are not
+in it. HTTP 200, and nothing in the response marks it short. An empty
+`cmd-response` is the extreme case of the same thing, not a separate one.
+
+`cmd-response-key` / `-url` / `-uri` are the completion path: poll
+[Collect Command Response](collect.md) for whatever arrived after the capture
+converged. Real z/OSMF carries no "incomplete" flag either — the response key
+is the affordance both offer instead.
+
+Clients have to ask. Zowe CLI collects only when told to: `zowe zos-console
+issue command` prints exactly what the sync capture returned unless
+`--wait-to-collect <seconds>` is given, and with it `P FTPD` returns all four
+lines. Completeness costs wall clock — 12.3 s against 0.4 s for the plain call,
+measured — which is why it is opt-in on both sides.
+
+**The window is deliberate and does not change** (issue #346). About 0.3 s of a
+lone `D T`'s 0.39 s *is* the stability poll, so a 1 s quiet window would roughly
+triple every console call — and it still would not have caught `P FTPD`, whose
+reply pauses 2 s mid-stream. Nor is it free elsewhere: the #214 lock spans MGCR
+through convergence, so every millisecond added here comes off the ~2.2
+commands/s ceiling.
 
 `cmd-response-url` (and `detection-url`, where present) take their host from the request's
 `Host` header and their scheme from `X-Forwarded-Proto` — `https` when a reverse proxy

--- a/docs/endpoints/datasets/members-put.md
+++ b/docs/endpoints/datasets/members-put.md
@@ -1,6 +1,6 @@
 # Write PDS Member
 
-Writes content to a member in a partitioned dataset (PDS). Supports text, binary, and record modes. Handles both chunked transfer encoding and Content-Length based transfers.
+Writes content to a member in a partitioned dataset (PDS) in text or binary mode. Handles both chunked transfer encoding and Content-Length based transfers. `X-IBM-Data-Type: record` is accepted on read but **not implemented on write** — see below.
 
 ## HTTP Method
 PUT
@@ -22,7 +22,14 @@ or with explicit volume:
 - `X-IBM-Data-Type` (optional): Data transfer mode
     - `text` (default): ASCII-to-EBCDIC conversion, records split at newlines
     - `binary`: Raw bytes written without conversion, split at LRECL boundaries
-    - `record`: Each record preceded by 4-byte big-endian length prefix
+    - `record`: **accepted but not implemented on write — do not use.** The read
+      path emits a 4-byte big-endian length before every record; the write path
+      frames nothing. `record` is sent down the *text* loop, which cuts the body
+      at newlines, so the four bytes then taken as a length are one only by
+      accident: the request stores garbage or answers 500. **A body produced by
+      a `GET` with `X-IBM-Data-Type: record` cannot be written back** — use
+      `binary` for a byte-exact round trip. Whether this becomes a
+      length-prefixed reader or an outright 400 is issue #245.
 - `If-Match` (optional): An `ETag` from an earlier read. The write proceeds
   only if the member still matches it (see **Conditional writes** below).
 - `X-IBM-Return-Etag` (optional): `true` returns the `ETag` of the member as

--- a/docs/endpoints/datasets/put.md
+++ b/docs/endpoints/datasets/put.md
@@ -1,6 +1,6 @@
 # Write Dataset
 
-Writes content to a sequential dataset. Supports text, binary, and record modes. Handles both chunked transfer encoding and Content-Length based transfers.
+Writes content to a sequential dataset in text or binary mode. Handles both chunked transfer encoding and Content-Length based transfers. `X-IBM-Data-Type: record` is accepted on read but **not implemented on write** — see below.
 
 ## HTTP Method
 PUT
@@ -21,7 +21,14 @@ or with explicit volume:
 - `X-IBM-Data-Type` (optional): Data transfer mode
     - `text` (default): ASCII-to-EBCDIC conversion, records split at newlines
     - `binary`: Raw bytes written without conversion, split at LRECL boundaries
-    - `record`: Each record preceded by 4-byte big-endian length prefix
+    - `record`: **accepted but not implemented on write — do not use.** The read
+      path emits a 4-byte big-endian length before every record; the write path
+      frames nothing. `record` is sent down the *text* loop, which cuts the body
+      at newlines, so the four bytes then taken as a length are one only by
+      accident: the request stores garbage or answers 500. **A body produced by
+      a `GET` with `X-IBM-Data-Type: record` cannot be written back** — use
+      `binary` for a byte-exact round trip. Whether this becomes a
+      length-prefixed reader or an outright 400 is issue #245.
 - `If-Match` (optional): An `ETag` from an earlier read; the write proceeds only
   if the dataset still matches it.
 - `X-IBM-Return-Etag` (optional): `true` returns the `ETag` of the dataset as it

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -409,7 +409,15 @@ curl -s -u $USER:$PASS -X PUT -H 'Content-Type: application/json' \
 ```bash
 zowe zos-console issue command "D T"
 zowe zos-console issue command "D T" --solicited-keyword "DATE"
+zowe zos-console issue command "P FTPD" --wait-to-collect 5   # keep collecting
 ```
+
+> **The plain call can come back short.** `cmd-response` is what arrived before
+> the reply went quiet, so a command that pauses mid-stream is truncated — HTTP
+> 200, no indicator. `P FTPD` comes back as `FTPD098I` alone that way, and with
+> all four lines under `--wait-to-collect <seconds>`, which polls collect for
+> the rest. It costs wall clock (12.3 s against 0.4 s, measured), which is why
+> it is opt-in. With curl, poll `cmd-response-url` yourself.
 
 ### Collect a command response (deltas)
 `GET /zosmf/restconsoles/consoles/{console-name}/solmsgs/{cmd-response-key}`
@@ -421,6 +429,9 @@ curl -s -u $USER:$PASS \
 ```bash
 zowe zos-console collect sync-responses E2E82A699B2B2001
 ```
+
+Each call returns only what arrived since the previous one, so poll until it
+comes back empty. That is the completion path for a truncated `cmd-response`.
 
 ### Detect a keyword in unsolicited messages
 `GET /zosmf/restconsoles/consoles/{console-name}/detections/{detection-key}`

--- a/tests/curl-console.sh
+++ b/tests/curl-console.sh
@@ -355,11 +355,60 @@ if [ "${RUN_FTPD_TESTS:-0}" = "1" ]; then
 	RESP=$(issue '{"cmd":"P FTPD","unsol-key":"FTPD"}')
 	BODY=$(echo "$RESP" | sed '$d')
 	DKEY=$(echo "$BODY" | jq -r '.["detection-key"]' 2>/dev/null)
+	# The same issue call feeds the completion-path check below. Keep both
+	# values here: a second P FTPD is not available to that test -- FTPD is
+	# down by then -- and stopping the service twice to test it would be worse.
+	SYNC_RESP=$(echo "$BODY" | jq -r '.["cmd-response"] // ""' 2>/dev/null)
+	CKEY=$(echo "$BODY" | jq -r '.["cmd-response-key"]' 2>/dev/null)
 	if [ -n "$DKEY" ] && [ "$DKEY" != "null" ]; then
 		sleep 3
 		RESP=$(curl -s -u "$AUTH" "${CONSOLE}/detections/${DKEY}")
 		assert_json_field "$RESP" '.status' "detected" "P FTPD: ENDED detected (async)"
 		assert_contains   "$RESP" '.msg' "FTPD" "P FTPD: msg mentions FTPD"
+	fi
+
+	# ---- collect completes a truncated sync capture (issue #346) ----
+	#
+	# P FTPD is the reported case: its reply pauses ~2 s mid-stream, the sync
+	# capture converges after 0.3 s of quiet, and the issue call returns
+	# FTPD098I while FTPD099I, IEF404I and $HASP395 arrive later. collect is
+	# the documented way to the rest -- what Zowe's --wait-to-collect drives.
+	#
+	# The property under test is NOT a line count. "More lines with collect
+	# than without" goes green on a stand fast enough to catch the whole block
+	# in one window, which makes a passing run say nothing. So assert the
+	# union first -- issue + collect carry the terminal $HASP395 -- and only
+	# then the difference, and only when this run actually truncated.
+	if [ -n "$CKEY" ] && [ "$CKEY" != "null" ]; then
+		COLLECTED=""
+		for _ in 1 2 3; do
+			MORE=$(curl -s -u "$AUTH" "${CONSOLE}/solmsgs/${CKEY}" |
+				jq -r '.["cmd-response"] // ""' 2>/dev/null)
+			[ -n "$MORE" ] && COLLECTED="${COLLECTED}${MORE}"
+			sleep 1
+		done
+		SYNC_N=$(printf '%s' "$SYNC_RESP" | tr '\r' '\n' | grep -c .)
+		COLL_N=$(printf '%s' "$COLLECTED" | tr '\r' '\n' | grep -c .)
+
+		case "${SYNC_RESP}${COLLECTED}" in
+			*'$HASP395'*)
+				pass "P FTPD: issue+collect carry the whole block (${SYNC_N}+${COLL_N} lines)" ;;
+			*)
+				fail "P FTPD: issue+collect carry the whole block" \
+				     "no \$HASP395 in ${SYNC_N} captured + ${COLL_N} collected lines" ;;
+		esac
+
+		case "$SYNC_RESP" in
+			*'$HASP395'*)
+				skip "P FTPD: collect adds lines (this run captured the whole block)" ;;
+			*)
+				if [ "$COLL_N" -gt 0 ]; then
+					pass "P FTPD: collect supplied what the capture missed (${SYNC_N} -> $((SYNC_N + COLL_N)) lines)"
+				else
+					fail "P FTPD: collect supplied what the capture missed" \
+					     "the capture returned ${SYNC_N} line(s) without \$HASP395 and collect returned none"
+				fi ;;
+		esac
 	fi
 	# S FTPD -> sync detect "FTPD" -> startup message; also restarts FTPD.
 	# This is the "start and wait until ready" pattern in one call.

--- a/tests/zowe-console.sh
+++ b/tests/zowe-console.sh
@@ -155,9 +155,12 @@ fi
 # capture is over before $HASP395 arrives. This asserts the flag reaches the
 # terminal line, which is the whole point of the completion path.
 #
-# The curl suite carries the strict difference (captured vs collected) from a
-# single issue call; here the flag hides the two halves behind one command, so
-# testing the delta would mean stopping FTPD twice.
+# On its own this assertion does not discriminate: it would also pass on a stand
+# where the sync capture caught the whole block. The discriminator is the curl
+# suite's P FTPD block, which measures both halves from a single issue call and
+# fails if collect stays silent on a truncated run. Here the flag hides those
+# halves behind one command, so testing the delta would mean stopping FTPD
+# twice. Read the two blocks together.
 # =========================================================================
 if [ "${RUN_FTPD_TESTS:-0}" = "1" ]; then
 	echo ""

--- a/tests/zowe-console.sh
+++ b/tests/zowe-console.sh
@@ -58,6 +58,8 @@ fail() {
 	FAILED=$((FAILED + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"
 	[ -n "${2:-}" ] && echo "        $2"
 }
+# SKIPPED is counted in the summary but had no way to be incremented
+skip() { SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1)); echo "  SKIP: $1"; }
 
 # Run a zowe command with JSON output; sets OUTPUT and RC.
 run_zowe_json() {
@@ -139,6 +141,40 @@ if [ -n "$KEY" ] && [ "$KEY" != "null" ]; then
 	assert_json_field "$OUTPUT" '.success' "true" "collect: success"
 else
 	fail "issue returned no lastResponseKey"
+fi
+
+# =========================================================================
+# 5. --wait-to-collect completes a truncated response (issue #346)
+#
+# Opt-in: it STOPS then STARTS FTPD (the P/S pair leaves it running), so it
+# briefly disrupts the FTP service. Set RUN_FTPD_TESTS=1 to enable.
+#
+# Zowe does not collect unless asked -- Command.handler.js calls issue() and
+# only branches to issueAndCollect() when --wait-to-collect is given. P FTPD's
+# reply pauses ~2 s mid-stream, so the plain call returns FTPD098I and the sync
+# capture is over before $HASP395 arrives. This asserts the flag reaches the
+# terminal line, which is the whole point of the completion path.
+#
+# The curl suite carries the strict difference (captured vs collected) from a
+# single issue call; here the flag hides the two halves behind one command, so
+# testing the delta would mean stopping FTPD twice.
+# =========================================================================
+if [ "${RUN_FTPD_TESTS:-0}" = "1" ]; then
+	echo ""
+	echo "--- wait-to-collect: P/S FTPD (issue #346) ---"
+	run_zowe_json zos-console issue command "P FTPD" --wait-to-collect 5
+	assert_rc 0 "$RC" "issue P FTPD --wait-to-collect"
+	assert_contains "$OUTPUT" '.data.commandResponse' "FTPD098I" \
+		"P FTPD: shutdown line present"
+	assert_contains "$OUTPUT" '.data.commandResponse' "HASP395" \
+		"P FTPD: terminal line present (arrives after the sync capture)"
+
+	# Restart, so the suite leaves the service as it found it.
+	run_zowe_json zos-console issue command "S FTPD" --wait-to-collect 5
+	assert_rc 0 "$RC" "issue S FTPD --wait-to-collect (restores the service)"
+else
+	echo ""
+	skip "P/S FTPD wait-to-collect (set RUN_FTPD_TESTS=1 to enable)"
 fi
 
 # =========================================================================


### PR DESCRIPTION
**Closes #346.** #245 does **not** close — only its documentation half is here;
the implement-vs-reject decision is still open on that ticket.

No source change: `docs/`, `tests/` and `TODO.md` only. Nothing to deploy.

## #346 — a sync console capture can come back short (complete)

The doc tied incompleteness to an *empty* `cmd-response`, which is the case a
client is least likely to meet. The measured failure is a non-empty, plausible
response: `P FTPD` returns `FTPD098I` alone and the `FTPD099I`, `IEF404I` and
`$HASP395` lines that follow ~2 s later are not in it — HTTP 200, nothing
marking it short.

**Docs**

- `issue-command.md` — state the capture rule as it is (convergence ~0.3 s
  after the line count last changed, bounded at ~3 s) instead of as its bound;
  say plainly that a reply pausing mid-stream is cut at the pause; name
  `cmd-response-key` as the completion path. Record why the window does not
  change: ~0.3 s of a lone `D T`'s 0.39 s *is* the stability poll, a longer one
  would not have caught `P FTPD` anyway, and #214's lock spans convergence.
- `collect.md` — carried no caveat at all; "repeated polling drains the
  response" implicitly promised determinism. Now says both halves: it is the
  completion path, and it re-correlates on the newest matching MTT entry rather
  than resuming.
- `examples.md` — `--wait-to-collect`, the answer to the reported symptom,
  which was documented nowhere.

**Test — and one deliberate departure from the shape the issue asked for.**

The issue proposed asserting the *difference*: more lines with the flag than
without. That is not assertable on its own — it goes green on a stand fast
enough to catch the whole block in one window, so a passing run would say
nothing about the property. The curl suite therefore asserts the **union**
first (issue + collect carry the terminal `$HASP395`) and the strict difference
only on a run that actually truncated, where a silent collect is a failure.
Both halves come from **one** `P FTPD` call, so the service stops once rather
than twice. The Zowe half asserts `--wait-to-collect` reaches `$HASP395` — the
same property through the client that meets it, since Zowe collects only when
asked.

**Measured on mvsdev, `RUN_FTPD_TESTS=1`:** the capture returned **1 line and
collect the remaining 3**, so the strict-difference branch fired rather than
the skip. `curl-console.sh` 71/71, `zowe-console.sh` 13/13, FTPD active again
afterwards.

**On the "depends on #214 part 3" bullet:** discharged as a wording constraint,
not by a fix. Part 3 never landed and cannot — it needs a stable MTT position
that does not exist across snapshots. But "collect is the completion path" and
"collect is deterministic" are different claims and this issue only needs the
first, so the caveat now sits next to the promise in `collect.md`.

## #245 — `X-IBM-Data-Type: record` is not implemented on write (docs only)

Three sites advertised it, not the two the issue names:

- the opening sentence of `put.md` and `members-put.md`,
- their `X-IBM-Data-Type` bullets,
- the common-header table in `docs/endpoints/README.md`.

Verified against `main` before writing: everything that is not
`DATA_TYPE_BINARY` goes down the text loop, which cuts the body at newlines, so
the four bytes `write_record()` then reads as a length are one only by
accident. A body from a `GET` with `X-IBM-Data-Type: record` cannot be written
back. `ERR_IO` maps to 500, so a failed framing answers 500 like any other
write I/O error.

**Still open on #245:** the choice between a length-prefixed reader and an
outright 400. Nothing misleads a client while it is being made.

## Also

`TODO.md` updated on the branch — both entries described work that is now done,
both "Waiting on" cells were wrong, and #346 leaves the console-correctness
campaign.
