### PR TITLE
tests: a reproduction for #214's collect half

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ PR #349; it stays open on its implement-vs-reject decision.*
 
 | | Issue | Kind | Waiting on |
 |---|---|---|---|
-| 1 | #214 | serialization landed; residuals open | a repro for the collect half |
+| 1 | #214 | serialization landed; collect half **reproduced** | a design decision, not a measurement |
 | 2 | #267 | latent; one word, activates ten paths | a read of `quit:` |
 | 3 | #336 | accepts the syntax, discards the operand | wire it or reject it |
 | 4 | #210 | client-visible, fix identified, local | nothing |
@@ -84,10 +84,34 @@ recognising a later command echo has no field to do it with, and the obvious
 heuristic (an echo carries no message identifier) was tested against 407 real
 lines and fails — `IEFACTRT` and `SE '...'` carry none either.
 
-So what is left on this ticket is the **collect half**, and it wants a
-reproduction before another attempt: collect runs outside the lock, long after
-the fact, and still anchors on the newest match. Serialization does not reach
-it.
+So what is left on this ticket is the **collect half**, and it is no longer
+waiting on a reproduction — PR #350 carries one
+(`tests/repro-214-collect.sh`, standalone, exit 1 = reproduced, 2/2 on two
+runs). **It needs no concurrency**, which is the finding: one client issuing
+two commands is enough, because collect re-correlates on every poll instead of
+resuming. Two `D T` five seconds apart, and the first key comes back with the
+second command's reply — provable because `IEE136I` carries the time and the
+hardcopy log holds both blocks.
+
+**It is also wider than this entry said.** The anchor is `strstr()`, not an
+equality test, so any later command whose echo merely *contains* the stored
+text takes it: a cursor for `D A` returned ten lines of a subsequent `D A,L`.
+Narrowing that match is independent of the anchor question and looks like the
+cheapest piece here.
+
+And once mis-anchored the cursor writes the foreign block's count back
+(`cur.delivered = total`, watched 10 → 5), after which that key answers empty
+for good — so a polling client reads "complete" having received the wrong block
+or nothing.
+
+**One reading recorded above needs re-testing rather than inheriting.** Both
+refuted anchor attempts were on the *sync capture*, where the failure is that
+our own echo may not be in the table yet. At collect time it certainly is, and
+collect is not racing its arrival, so that verdict does not obviously transfer.
+`SOL_CURSOR.issue_tod` is stamped at issue (`consapi.c:823`) and never read by
+collect; `correlate_once()` already computes `echo_secs`. Hypothesis only — it
+resolves both experiments on paper, the residual (two matches inside one
+second, an echo aged out) is unmeasured, and that measurement is the next step.
 
 **Two of the issue's three directions are refuted by that data, including its
 preferred one.** MVS interleaves the MTT *line by line*, not block by block: a

--- a/tests/repro-214-collect.sh
+++ b/tests/repro-214-collect.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# =========================================================================
+# Reproduction for issue #214, collect half.
+#
+# consoleCollectHandler() re-correlates on every poll instead of resuming:
+# correlate_once() anchors on the NEWEST MTT entry whose text contains the
+# stored command, so a matching entry written after the key was handed out
+# takes the anchor away from the block the key belongs to. #214's
+# serialization does not reach this -- the lock is held by the issuing path
+# only, and collect runs long afterwards and outside it.
+#
+# This script does NOT need two clients. Both experiments are sequential.
+#
+#   1. Two "D T" commands, identical text, seconds apart. IEE136I carries the
+#      time, so the reply itself says which block was returned. async:"Y" is
+#      used so the cursor starts at delivered=0 and collect must return the
+#      whole block. The hardcopy log supplies the expected time independently.
+#
+#   2. A cursor for "D A" against a later "D A,L". The anchor is a strstr(),
+#      not an equality test, so any later command whose echo CONTAINS the
+#      stored text takes the anchor -- a wider surface than "the same command
+#      issued twice", and "D A" then "D A,L" is an ordinary operator sequence.
+#
+# Only display commands are issued; nothing on the system is changed.
+#
+# Exit status: 0 = the defect did NOT reproduce, 1 = it did (expected today).
+#
+# Usage:  ./tests/repro-214-collect.sh
+# =========================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+	echo "ERROR: ${ENV_FILE} not found. Copy .env.example and fill it in."
+	exit 2
+fi
+# shellcheck source=../.env
+. "$ENV_FILE"
+
+BASE_URL="http://${MVSMF_HOST}:${MVSMF_PORT}"
+AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+CONSOLE="${BASE_URL}/zosmf/restconsoles/consoles/defcn"
+LOG="${BASE_URL}/zosmf/restconsoles/v1/log"
+
+DEFECTS=0
+
+issue() {  # $1 = json body -> whole response body
+	curl -s -m 30 -u "$AUTH" -X PUT -H 'Content-Type: application/json' \
+		-d "$1" "$CONSOLE"
+}
+collect() {  # $1 = key -> cmd-response with \r turned into newlines
+	curl -s -m 30 -u "$AUTH" "${CONSOLE}/solmsgs/$1" |
+		jq -r '.["cmd-response"] // ""' | tr '\r' '\n'
+}
+newest_time() {  # newest IEE136I in the trace table -> its TIME=hh.mm.ss
+	curl -s -m 30 -u "$AUTH" "${LOG}?timeRange=5m" |
+		jq -r '[.items[] | select(.message | test("IEE136I"))] | last | .message' |
+		sed -n 's/.*LOCAL: TIME=\([0-9.]*\).*/\1/p'
+}
+
+echo ""
+echo "========================================"
+echo " #214 collect: does the anchor move?"
+echo " Host: ${MVSMF_HOST}:${MVSMF_PORT}"
+echo "========================================"
+
+# -------------------------------------------------------------------------
+# 1. Same command text, twice
+# -------------------------------------------------------------------------
+echo ""
+echo "--- 1. two async 'D T', collect the FIRST key ---"
+
+K1=$(issue '{"cmd":"D T","async":"Y"}' | jq -r '.["cmd-response-key"] // ""')
+T1=$(newest_time)
+echo "  command #1: key=${K1}  its reply says TIME=${T1}"
+
+sleep 5
+
+K2=$(issue '{"cmd":"D T","async":"Y"}' | jq -r '.["cmd-response-key"] // ""')
+T2=$(newest_time)
+echo "  command #2: key=${K2}  its reply says TIME=${T2}"
+
+if [ -z "$K1" ] || [ -z "$T1" ] || [ -z "$T2" ]; then
+	echo "  INCONCLUSIVE: could not read a key or a time from the system"
+	exit 2
+fi
+if [ "$T1" = "$T2" ]; then
+	echo "  INCONCLUSIVE: both commands report the same time -- rerun"
+	exit 2
+fi
+
+R1=$(collect "$K1")
+echo "  collect(key of #1) -> ${R1:-(empty)}"
+
+case "$R1" in
+	*"$T1"*) echo "  OK: the first key returned its own block" ;;
+	*"$T2"*) echo "  DEFECT: the first key returned command #2's block (${T2}, not ${T1})"
+	         DEFECTS=$((DEFECTS + 1)) ;;
+	*)       echo "  INCONCLUSIVE: neither time in the reply" ;;
+esac
+
+# -------------------------------------------------------------------------
+# 2. A later command whose echo merely CONTAINS the stored text
+# -------------------------------------------------------------------------
+echo ""
+echo "--- 2. cursor for 'D A', then issue 'D A,L' ---"
+
+KA=$(issue '{"cmd":"D A","async":"Y"}' | jq -r '.["cmd-response-key"] // ""')
+echo "  cursor for 'D A': key=${KA}"
+sleep 2
+issue '{"cmd":"D A,L"}' >/dev/null
+sleep 1
+
+RA=$(collect "$KA")
+echo "  collect(key of 'D A') returned $(printf '%s' "$RA" | grep -c .) line(s):"
+printf '%s\n' "$RA" | sed 's/^/    /'
+
+# A plain "D A" answers a four-line activity summary and never lists address
+# spaces; a per-address-space line is proof the D A,L block was returned.
+if printf '%s' "$RA" | grep -q 'IEFPROC'; then
+	echo "  DEFECT: the 'D A' key returned the 'D A,L' block"
+	DEFECTS=$((DEFECTS + 1))
+else
+	echo "  OK: the 'D A' key did not pick up the 'D A,L' block"
+fi
+
+echo ""
+echo "========================================"
+if [ "$DEFECTS" -gt 0 ]; then
+	echo " #214 collect half REPRODUCED (${DEFECTS}/2)"
+	echo "========================================"
+	exit 1
+fi
+echo " not reproduced this run"
+echo "========================================"


### PR DESCRIPTION
**This PR is a reproduction, not a fix — #214 stays open.** It is what the
ticket has been waiting on. `tests/repro-214-collect.sh`, standalone, exit 1 = reproduced.

**It needs no concurrency.** Both experiments are sequential, single-client,
and issue display commands only. That is a stronger statement than the ticket's
framing: `collect` does not need two clients racing to serve one client
another's data — one client issuing two commands is enough.

Measured on mvsdev, twice, 2/2 both runs:

```
--- 1. two async 'D T', collect the FIRST key ---
  command #1: key=E32C7EBBC3DA2880  its reply says TIME=09.25.08
  command #2: key=E32C7EC10D1DD8C0  its reply says TIME=09.25.14
  collect(key of #1) -> IEE136I LOCAL: TIME=09.25.14 ...
  DEFECT: the first key returned command #2's block (09.25.14, not 09.25.08)

--- 2. cursor for 'D A', then issue 'D A,L' ---
  collect(key of 'D A') returned 10 line(s):
    IEE102I 09.25.17 26.235 ACTIVITY 930
    ... JES2 / NET / TSO / UFSD / HTTPD / FTPD address-space lines ...
  DEFECT: the 'D A' key returned the 'D A,L' block
```

The hardcopy log confirms the correct block was in the trace table the whole
time — `D T` + `IEE136I ... TIME=09.21.39` and `D T` + `IEE136I ... TIME=09.21.44`
both present. So this is the anchor, not availability.

Experiment 2 is the part that widens the ticket: the anchor is `strstr()`, not
an equality test, so **any** later command whose echo contains the stored text
takes it. `D A` then `D A,L` is an ordinary operator sequence, and the cursor
for the first came back with ten lines of the second.

A third measurement, not in the script because its symptom is silence: once
mis-anchored, `cur.delivered = total` writes the *foreign* block's count back
to the cursor. Watched go 10 → 5 against a shorter block, after which that key
answers empty for good — a polling client reads "complete" having received the
wrong block, or nothing.

Only display commands are issued and nothing on the system is changed.


## Also

`TODO.md` on the branch: row 1 no longer waits on a reproduction but on a
design decision, and the entry records the two things it had too narrow — the
`strstr` surface, and that the refuted timestamp anchor was refuted on the
*sync capture* path, so that verdict should be re-tested rather than inherited
by `collect`.

