### PR TITLE
consapi: pin a collect cursor to its own block, and end the block at the next command echo

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,11 @@ than code, and the per-issue hazard that makes an obvious-looking fix not one.
 **It carries nothing that is copied.** Where the reasoning already has an owner —
 the issue thread, the PR, `docs/uss-spec.md` — this file points at it and stops.
 
-*Last reconciled against the tracker: 2026-08-23, 20 issues open — nineteen
+*Last reconciled against the tracker: 2026-08-24, 19 issues open — eighteen
 entries below, because one of them pairs two issues. #245's doc half landed in
-PR #349; it stays open on its implement-vs-reject decision.*
+PR #349; it stays open on its implement-vs-reject decision. #214 closed on
+2026-08-24, which is why Tier 1 is short: it was the console campaign's
+largest piece.*
 
 ---
 
@@ -18,128 +20,30 @@ PR #349; it stays open on its implement-vs-reject decision.*
 
 | | Issue | Kind | Waiting on |
 |---|---|---|---|
-| 1 | #214 | serialization landed; collect half **reproduced** | a design decision, not a measurement |
-| 2 | #267 | latent; one word, activates ten paths | a read of `quit:` |
-| 3 | #336 | accepts the syntax, discards the operand | wire it or reject it |
-| 4 | #210 | client-visible, fix identified, local | nothing |
-| 5 | #251 | Optimistic Path stop pattern | nothing |
-| 6 | #209 | client-visible, cheap on 3.8j | nothing |
-| 7 | #245 | docs corrected; decision open | reader-vs-400 decision |
-| 8 | #326 | its trigger has fired | nothing |
-| 9 | #76 | the one externally reported defect | nothing |
-| 10 | #244 | the ordering constraint is the content | nothing |
-| 11 | #215 | latent, one place, every caller benefits | nothing |
-| 12 | #257, #335 | one class, two tickets | a repro without a proxy |
-| 13 | #347 | an authenticated user can stop the system | **a policy** — measured, nothing to delegate to |
-| 14 | #234 | `type:research` | measuring the reference |
-| 15 | #329 | `type:research` | **one measurement** — see *RAKF* |
-| 16 | #345 | `type:research` | **a policy** — see *RAKF* |
-| 17 | #195 | split from #214 — not the same bug | one two-snapshot measurement |
-| 18 | #291 | reclassified — hygiene, not stability | nothing |
-| 19 | #186 | unblocked; sysroot refreshed 2026-08-23 | nothing |
+| 1 | #267 | latent; one word, activates ten paths | a read of `quit:` |
+| 2 | #336 | accepts the syntax, discards the operand | wire it or reject it |
+| 3 | #210 | client-visible, fix identified, local | nothing |
+| 4 | #251 | Optimistic Path stop pattern | nothing |
+| 5 | #209 | client-visible, cheap on 3.8j | nothing |
+| 6 | #245 | docs corrected; decision open | reader-vs-400 decision |
+| 7 | #326 | its trigger has fired | nothing |
+| 8 | #76 | the one externally reported defect | nothing |
+| 9 | #244 | the ordering constraint is the content | nothing |
+| 10 | #215 | latent, one place, every caller benefits | nothing |
+| 11 | #257, #335 | one class, two tickets | a repro without a proxy |
+| 12 | #347 | an authenticated user can stop the system | **a policy** — measured, nothing to delegate to |
+| 13 | #234 | `type:research` | measuring the reference |
+| 14 | #329 | `type:research` | **one measurement** — see *RAKF* |
+| 15 | #345 | `type:research` | **a policy** — see *RAKF* |
+| 16 | #195 | split from #214 — not the same bug | one two-snapshot measurement |
+| 17 | #291 | reclassified — hygiene, not stability | nothing |
+| 18 | #186 | unblocked; sysroot refreshed 2026-08-23 | nothing |
 
 ---
 
 ## Tier 1 — now
 
-### 1 · #214 — concurrent issue-command requests pick up each other's lines
-
-*the worst live symptom: one client is served another client's data*
-
-Every worker shares one MTT source, so `has_src` cannot separate two concurrent
-requests. Second symptom, same cause: a `MODIFY` reply burns the whole
-`POLL_SECONDS` window because foreign lines keep the block's line count moving.
-
-**Reproduced and measured on 2026-08-23** — recipe, numbers and the raw MTT
-window are in the issue. Two background clients looping `F HTTPD,D P` against
-twelve foreground `D T`: **5/12 contaminated, up to 30 foreign lines, 2.39 s
-against a 0.39 s baseline**. Both symptoms are one mechanism — the worst
-contaminated response is also the slowest.
-
-**Serialization landed 2026-08-23** (branch
-`issue-214-serialize-console-correlation`): one command block open at a time,
-the bracket spanning MGCR through convergence, writers only — async and
-`/zosmf/test?fn=cmd` included — with a conditional `trylock()` from
-`cliblock.h`, a 429 when the budget is spent, and a DEQ in `session_cleanup()`
-because the router's ESTAE recovers the worker rather than ending its task.
-**Measured 0/12 contaminated against 5/12 before**, console suite 65/65.
-
-**Two of the three planned parts did not land, and the reason is worth more than
-the code would have been.** Both attempts at closing the stale-echo race
-measured *worse on target* than the race:
-
-- by issue timestamp — MTT entries carry `hh.mm.ss` and back-to-back requests
-  land in the same second routinely, so "oldest match at or after our second"
-  resolved to the **previous** command's echo;
-- by a match count taken under the lock before SVC 34 — **a count over a
-  wrapping window, which is #195's design error rebuilt**. After a burst of one
-  command its oldest echoes sit at the aging edge, each new entry evicts one as
-  ours is added, the count never grows, and every capture returns empty. `D T`
-  came back empty at 3.1 s while `D M`, same code path with its matches at the
-  young end, was correct three times running.
-
-What both needed is a **position**, and the MTT has none that survives a
-snapshot. That is the open problem, and it is also what blocks the echo-stop:
-recognising a later command echo has no field to do it with, and the obvious
-heuristic (an echo carries no message identifier) was tested against 407 real
-lines and fails — `IEFACTRT` and `SE '...'` carry none either.
-
-So what is left on this ticket is the **collect half**, and it is no longer
-waiting on a reproduction — PR #350 carries one
-(`tests/repro-214-collect.sh`, standalone, exit 1 = reproduced, 2/2 on two
-runs). **It needs no concurrency**, which is the finding: one client issuing
-two commands is enough, because collect re-correlates on every poll instead of
-resuming. Two `D T` five seconds apart, and the first key comes back with the
-second command's reply — provable because `IEE136I` carries the time and the
-hardcopy log holds both blocks.
-
-**It is also wider than this entry said.** The anchor is `strstr()`, not an
-equality test, so any later command whose echo merely *contains* the stored
-text takes it: a cursor for `D A` returned ten lines of a subsequent `D A,L`.
-Narrowing that match is independent of the anchor question and looks like the
-cheapest piece here.
-
-And once mis-anchored the cursor writes the foreign block's count back
-(`cur.delivered = total`, watched 10 → 5), after which that key answers empty
-for good — so a polling client reads "complete" having received the wrong block
-or nothing.
-
-**One reading recorded above needs re-testing rather than inheriting.** Both
-refuted anchor attempts were on the *sync capture*, where the failure is that
-our own echo may not be in the table yet. At collect time it certainly is, and
-collect is not racing its arrival, so that verdict does not obviously transfer.
-`SOL_CURSOR.issue_tod` is stamped at issue (`consapi.c:823`) and never read by
-collect; `correlate_once()` already computes `echo_secs`. Hypothesis only — it
-resolves both experiments on paper, the residual (two matches inside one
-second, an echo aged out) is unmeasured, and that measurement is the next step.
-
-**Two of the issue's three directions are refuted by that data, including its
-preferred one.** MVS interleaves the MTT *line by line*, not block by block: a
-foreign echo lands between our echo and our own reply, in the same second. So a
-time bound cannot cut it (the MTT is second-granular), and echo-stopping either
-loses our own reply or — in the obvious `line_idx == 0` repair — still appends
-the foreign reply lines, which share our source. **Serializing is the only one
-of the three left standing**, and the decision to take is whether its cost is
-acceptable: the lock must span MGCR through convergence, so the 2.1–3.1 s poll
-window becomes the throughput ceiling, and it reduces rather than eliminates —
-httpd's own WTOs carry the same source and still land inside an open block.
-
-**Do not gate that decision on reading the MTT entry header.** `mtenttag` /
-`mtentimm` have never been looked at, but `issue_command()` leaves the SVC 34
-buffer's bytes 2–3 zero for every worker, so any caller identity MVS records
-reads identically for two workers in one address space. Worth a probe run for
-the record; it is not a blocker.
-
-**Two further defects on the same path, neither addressed by any of the three
-options** — fold them into whatever fix lands. `correlate_once()` anchors on the
-*newest* `strstr` match over the whole table, and `consoleCollectHandler()`
-re-anchors on every poll, so `cur.delivered` is counted against a block that may
-have moved (`SOL_CURSOR.issue_tod` is stored, unused, and its comment already
-says "reserved: re-issue disamb."). And #174's `d <= 1` adoption window does not
-merely append a stray line under concurrency — it **redirects the whole block**
-to another address space, which is strictly worse than the reported symptom.
-
-### 2 · #267 — `unsigned rc` makes every send-error check dead code
+### 1 · #267 — `unsigned rc` makes every send-error check dead code
 
 `dsapi.c:1251` and `:2294`. A client that disconnects mid-listing has the whole
 remaining directory written after it.
@@ -150,7 +54,7 @@ in that light before flipping it. `member_scan()` (#265) is the only place in th
 member listing that detects a write failure today, and is the worked example.
 Grep the other handlers in the same pass — the declaration is copied around.
 
-### 3 · #336 — `{volume-serial}` is captured and never used
+### 2 · #336 — `{volume-serial}` is captured and never used
 
 Seven routes accept `-(VOLSER)` and discard the operand; a request naming the
 wrong volume is answered as if it had named the right one. Ranked here because
@@ -164,7 +68,7 @@ worth taking even as an interim.
 
 ## Tier 2 — cheap and client-visible
 
-### 4 · #210 — the submit response returns `owner:""`
+### 3 · #210 — the submit response returns `owner:""`
 
 A race, not a divergent path — and therefore **not fixable by asking libc370
 earlier**: `JCTUSEID` is unwritten and the internal text is not on the spool yet.
@@ -172,21 +76,21 @@ mvsMF already knows the answer, because `process_jobcard()` injected `USER=`.
 Fall back to that. Check the purge handler (`jobsapi.c:363,375`) for the same
 emptiness, and make `tests/curl-jobs.sh` assert the value, not the key.
 
-### 5 · #251 — console log answers 200 with an empty body on allocation failure
+### 4 · #251 — console log answers 200 with an empty body on allocation failure
 
 `consapi.c:1100` collapses a NULL `cmtt_new()` into `n = 0`. The MTT copy is the
 largest allocation on that path — the one most likely to fail exactly when a
 silent empty answer misleads most. The sibling `malloc()` three lines below
 already returns 500. Textbook **Optimistic Path**; check `:266` and `:457` too.
 
-### 6 · #209 — `exec-system` and `exec-member` are never emitted
+### 5 · #209 — `exec-system` and `exec-member` are never emitted
 
 3.8j has no sysplex, so `CVTSNAME` is a correct constant answer and needs no
 libc370 change. `JCTRDSID` is right in principle and re-opens the relink chain
 (`libc370#79`) for no gain here. Take the cheap one deliberately, and say so in
 the code.
 
-### 7 · #245 — `X-IBM-Data-Type: record` cannot be written back
+### 6 · #245 — `X-IBM-Data-Type: record` cannot be written back
 
 The read path length-prefixes each record; the write path sends `record` down the
 *text* loop, so the four bytes read back as a length are a length only by accident.
@@ -200,7 +104,7 @@ What is left is the choice: a length-prefixed reader (mind a prefix split
 across a chunk boundary, and `record_content_max()`), or a 400. Nothing
 misleads a client in the meantime.
 
-### 8 · #326 — five sources missing from the CLAUDE.md list
+### 7 · #326 — five sources missing from the CLAUDE.md list
 
 `abendmsg.c`, `hostparse.c`, `jclines.c`, `reclines.c`, `spoolln.c`. The issue said
 "next time `CLAUDE.md` is touched", so fold it into the next edit of that file
@@ -211,7 +115,7 @@ which is how the list drifted in the first place.
 
 ## Tier 3 — correctness, needs care
 
-### 9 · #76 — DSORG=DA in `datasetPutHandler` via BDAM
+### 8 · #76 — DSORG=DA in `datasetPutHandler` via BDAM
 
 *the only defect on this list someone outside the project reported*
 
@@ -225,7 +129,7 @@ is observed, reported from outside, and blocking a real workflow; #244 is curren
 harmless and #215 has never been seen at all. What holds it out of Tier 1 is that
 `ufsd-utils upload` does the job today — a workaround, not an absence of impact.
 
-### 10 · #244 — `#define VARIABLE 0x0002` is the wrong RECFM mask
+### 9 · #244 — `#define VARIABLE 0x0002` is the wrong RECFM mask
 
 **The ordering constraint is the whole content of this ticket.** The broken mask
 is the only thing keeping `write_record()`'s manual RDW dormant, and that RDW is
@@ -236,7 +140,7 @@ alone ships **two** RDWs. Remove the manual RDW first, then fix the mask. Drop
 The regression test wants a **VB** data set written binary and read back with
 lengths checked — `curl-binary.sh` uses FB, which is why this survived.
 
-### 11 · #215 — `addJsonStringEsc()` escapes five characters, not the control range
+### 10 · #215 — `addJsonStringEsc()` escapes five characters, not the control range
 
 One raw control byte makes the **whole** response unparseable, and `consapi.c`
 passes Master Trace Table text — whatever any address space wrote to the console.
@@ -246,7 +150,7 @@ Honest scope, per the issue: **no observed failure**. #212 fixed this locally in
 The subtlety from #212, easy to lose: `http_printf()` translates on the way out,
 so the printability test applies to the **translated** byte, via `xlate_cp037`.
 
-### 12 · #257 + #335 — early 4xx on a PUT with a body still in flight
+### 11 · #257 + #335 — early 4xx on a PUT with a body still in flight
 
 **One class, two tickets — rank and fix them together.** Every early return in the
 PUT handlers answers before draining the announced body (`dsapi.c:1156, 1180,
@@ -263,7 +167,7 @@ Draining probably closes #257 and reduces #335 to the proxy question.
 
 ## Tier 4 — decisions before code
 
-### 13 · #347 — restconsoles authorizes nothing at all
+### 12 · #347 — restconsoles authorizes nothing at all
 
 *an authenticated user can stop the system*
 
@@ -275,8 +179,9 @@ task. `GET /restconsoles/v1/log` separately returns the whole Master Trace Table
 to anyone. Neither latent nor intermittent: it is what the shipped endpoint does
 today.
 
-Ranked 1 because this file orders by impact on running systems. #214 hands a
-client a wrong answer; this hands it the machine.
+Ranked at the top of its tier because this file orders by impact on running
+systems: #214, now closed, handed a client a wrong answer; this hands it the
+machine.
 
 **It is #345's twin, and the hope that it was not has been measured and is
 gone.** The first version of this entry claimed a native MVS mechanism needing no
@@ -300,7 +205,7 @@ reaching for the obvious: a display-only allow-list **breaks a real workflow** �
 `P FTPD` / `S FTPD` are group-1 (SYS) commands and are in use today (#346's
 transcript). Decide with #345 and `ftpd#90`.
 
-### 14 · #234 — what should the API do with non-ASCII input?
+### 13 · #234 — what should the API do with non-ASCII input?
 
 Byte-wise through CP037 with no UTF-8 decoding — and **invisible through the API**,
 because `etoa` inverts `atoe`, so only ISPF and the program reading the member see
@@ -313,7 +218,7 @@ Research because the policy is the hard part. Measure the reference first
 `xmit370`'s split between well-formed UTF-8 and Latin-1 is worth borrowing. Decide
 GET and PUT together; a reject changes the round-trip property.
 
-### 15 · #329 — dataset create is authorized only by the ambient ACEE
+### 14 · #329 — dataset create is authorized only by the ambient ACEE
 
 **The endpoint is not unauthorized and the response shape is settled** (#315,
 #317): RAKF refuses the allocation and the refusal must stay indistinguishable
@@ -324,7 +229,7 @@ open is only **which identity decides** — SVC 99 runs under whatever sits in
 The cheap unblocked step is a measurement, and it decides whether the fix exists
 at all: what does RACHECK answer for a name with no catalog entry and no DSCB?
 
-### 16 · #345 — restjobs has no authorization model
+### 15 · #345 — restjobs has no authorization model
 
 `grep -c 'http_check_auth\|require_access' src/jobsapi.c` → **0**, against 25 in
 `dsapi.c`. `owner=*` switches the default off, and the four by-jobid paths —
@@ -338,7 +243,7 @@ Whatever refusal is chosen must keep #229's constraint: "not yours" must not be
 distinguishable from "does not exist". Establish `jescanj()`'s own behaviour on a
 foreign purge, on a throwaway job. Decide together with `mvslovers/ftpd#90`.
 
-### 17 · #195 — detections intermittently report `waiting` for a message that was emitted
+### 16 · #195 — detections intermittently report `waiting` for a message that was emitted
 
 **Split out of #214 on 2026-08-23: they are not the same bug.** Structural, no
 measurement needed — `detect_count()` never reads `MTT_SRC_OFF`, never anchors an
@@ -372,7 +277,7 @@ truncating the snapshot.
 
 ## Tier 5 — larger work
 
-### 18 · #291 — large bodies fully buffered, twice on submit
+### 17 · #291 — large bodies fully buffered, twice on submit
 
 **Reclassify: memory hygiene, not stability.** Its motivation — stopping long-held
 requests acting as the anvil for httpd#195's fragmentation — is gone: #287 closed,
@@ -386,7 +291,7 @@ holds 2 MB. Cheapest item, and independent of the streaming work.
 **`receive_raw_data()` stays byte-at-a-time** (PR #22 / #42, the TCP ring-buffer
 bug). Streaming changes what we do with the bytes, not how they are read.
 
-### 19 · #186 — console log: deep history beyond the MTT window
+### 18 · #186 — console log: deep history beyond the MTT window
 
 **No longer blocked — the issue text says it is, and that is out of date.** Its
 hard dependency `libc370#21` is **closed and verified on target** (PR#31,
@@ -451,6 +356,21 @@ policy vacuum.
 
 Pointers only — the reasoning lives in the closing comments.
 
+- **#214** — the console correlation. Closed on 2026-08-24 in three landings:
+  the serialization (PR #348), the reproduction of the collect half (PR #350)
+  and the fix (PR #351). The transferable parts, none of them about locks:
+  a correct anchor made a *missing* block end visible — the first key came back
+  with its own reply followed by the next command's, so the two halves had to
+  land together; the field that would have made the block end exact does not
+  exist, and that is now measured rather than assumed (`mtentflg`/`mtenttag`
+  read uniform `0000`/`0001` over 317 entries, echo and reply alike, via the
+  `fn=mtt&hdr=1` the PR adds); and what replaced it — an MVS message id carries
+  a digit in its first token, a command does not — is a heuristic held safe by
+  *where* it is applied, only to lines the walk would otherwise swallow. The
+  residual limits are in `docs/endpoints/console/collect.md`, promoted from
+  open work to documented behaviour: same-second identical commands, an echo
+  aged out of the window, and the sync-capture race that two measured attempts
+  failed to close.
 - **#346** — the sync console capture converging on 0.3 s of quiet. Closed on
   measurement, not on code: `P FTPD --wait-to-collect 5` returns all four lines
   where the plain call returns one, so the completion path already worked and
@@ -477,15 +397,15 @@ Pointers only — the reasoning lives in the closing comments.
 
 ## Campaigns, not twenty tickets
 
-- **Console correctness** — #214, #251 and #195, with #346 now closed out of
-  it. One subsystem and one reading of `consapi.c`, but **four separate bugs**.
-  #214 and #195 were ranked together on the guess that #195 might not survive
-  the first measurement of #214, and that premise is dead — see #195's entry.
-  #214 and #346 were the two halves of "MVS gives no end-of-response signal, so
-  both ends of the block are guessed", failing in opposite directions from
-  opposite preconditions; #346's half proved to be by design and closed as
-  documentation plus a test, which leaves #214 holding that pair alone. #251 is
-  independent of all three.
+- **Console correctness** — **#251 and #195 are what is left**, with #346 and
+  #214 both closed out of it. One subsystem and one reading of `consapi.c`, but
+  four separate bugs, and the two that closed were the two that shared a
+  premise: "MVS gives no end-of-response signal, so both ends of the block are
+  guessed". #346 was the *end* guessed too early (by design, closed as
+  documentation plus a test); #214 was the *start* guessed wrong and then no end
+  guessed at all. #195 was ranked with #214 on the guess that it might not
+  survive #214's first measurement, and that premise died before #214 did — see
+  #195's entry. #251 was always independent of all three.
 - **The endpoint advertises what it does not do** — #245 and #336, with #248 as
   the worked example of how it ends. **#245's doc half is done**, which is the
   campaign's proof that the cheap half is worth taking alone: the mode is still

--- a/docs/endpoints/console/collect.md
+++ b/docs/endpoints/console/collect.md
@@ -31,21 +31,33 @@ point are here and nowhere else. `P FTPD` is the worked example: one line from
 the issue call, four once collect is polled. Zowe CLI drives exactly this loop
 for `--wait-to-collect <seconds>`.
 
-**It re-correlates rather than resuming, and that part is not deterministic.**
-Every call finds the block again by searching the MTT for the *newest* entry
-matching the stored command text, so the same command text issued again between
-issue and collect — by another client, or by an operator at a console — moves
-the anchor to the newer echo, and the delta is then counted against a block the
-key was not handed out for. #214's serialization does not cover this: that lock
-is held by the issuing path only, and collect runs long afterwards and outside
-it. Closing it needs a stable position in the MTT and there is none across
-snapshots — tracked in #214.
+**It re-correlates rather than resuming, and the cursor is what keeps that
+pointed at one block.** Every call finds the block again in the Master Trace
+Table. Since #214 the search is not "the newest entry matching the command text"
+but "the echo carrying the second this key was issued in", so a later command —
+another client's, or an operator's at a console — no longer moves the anchor.
+The lock taken by the issuing path does not reach here and does not need to.
+
+Three limits follow from the MTT itself and are worth knowing before automating
+against this:
+
+- **Two identical commands inside the same second are ambiguous.** The table
+  stamps `hh.mm.ss` and nothing finer, so both cursors resolve to the first of
+  the two echoes.
+- **An echo that has aged out of the trace-table window matches nothing**, and
+  collect then answers `""` — the same "done" a drained block gives. The lines
+  are gone from the table; a longer history is the hardcopy log's job.
+- **If the echo had not landed before the synchronous capture gave up** (a very
+  slow system: the capture polls ~3 s), the cursor has no second to match and
+  collect falls back to the newest echo of that command — which is how a
+  late-arriving reply is still reachable, and is the one case where a later
+  identical command can still take the anchor.
 
 ## Error Responses
 Console error body (`return-code`/`reason-code`/`reason`). A bogus or evicted key yields HTTP 200 with an empty `cmd-response`, not an error.
 
 ## Implementation (MVS 3.8j)
-Each collect re-correlates the original command in the **Master Trace Table (MTT)** (echo + jobid + command-text + MLWTO-number, same as [Issue Command](issue-command.md)) and returns only the lines beyond what was already delivered. The `cmd-response-key` indexes a **delivered-line-count cursor** in the per-CGI key/value store (`ntstore`, lazy-init in the httpd `cgictx`): the MTT has no stable per-line sequence and `hh.mm.ss` is only second-granular, so the cursor tracks a *count*, returning lines `[delivered .. total)` and advancing `delivered` to `total`. The cursor is subject to LRU + TTL eviction; after eviction a collect re-correlates from whatever is still in the trace table.
+Each collect re-correlates the original command in the **Master Trace Table (MTT)** (echo + jobid + command-text + MLWTO-number, same as [Issue Command](issue-command.md)) and returns only the lines beyond what was already delivered. The `cmd-response-key` indexes a cursor in the per-CGI key/value store (`ntstore`, lazy-init in the httpd `cgictx`) holding two things: the **delivered line count** and the **MTT second of the command's own echo**. The MTT has no stable per-line sequence, so the delta is a *count* — lines `[delivered .. total)` — and the second is what pins that count to one block. The count only ever moves forward: a block shorter than what was already delivered is not counted back down, which is what used to leave a mis-anchored key answering empty for good. The cursor is subject to LRU + TTL eviction; after eviction a collect re-correlates from whatever is still in the trace table.
 
 ## Examples
 

--- a/docs/endpoints/console/collect.md
+++ b/docs/endpoints/console/collect.md
@@ -38,6 +38,13 @@ but "the echo carrying the second this key was issued in", so a later command �
 another client's, or an operator's at a console — no longer moves the anchor.
 The lock taken by the issuing path does not reach here and does not need to.
 
+The block also **ends** now, at the next command echo carrying the same source
+(see [Issue Command](issue-command.md#how-the-response-block-is-identified)).
+Both halves are needed and neither is sufficient: with the old anchor, a correct
+end still walked the wrong block; with a correct anchor and no end, collect
+returned its own block and then every later line the address space wrote —
+measured, a `D T` key answering with its own reply *and* the next `D T`'s.
+
 Three limits follow from the MTT itself and are worth knowing before automating
 against this:
 

--- a/docs/endpoints/console/issue-command.md
+++ b/docs/endpoints/console/issue-command.md
@@ -168,8 +168,10 @@ Two things it does **not** cover, both by construction:
   OPER, an automation task. Those cannot be locked against, and their lines can
   still end or contaminate a block.
 - **`collect`**, which re-correlates long afterwards and outside the lock. It
-  still anchors on the newest matching entry and can walk past the end of its own
-  block. Tracked in #214.
+  needs no lock: since #214 it asks the table for the echo it was handed out for,
+  by the second recorded at issue, rather than for whatever matches now. What it
+  still shares with the issuing path is the block *walk* — a foreign line
+  carrying our source, or a blank source, is taken into the block here too.
 
 On an httpd without the `cgictx` service there is no context to lock on and
 requests proceed **unserialized** — the same graceful degradation the cursor
@@ -177,7 +179,13 @@ store makes.
 
 ### How the response block is identified
 
-The newest MTT entry containing the command text is the **echo**.
+The **echo** is an MTT entry whose message text *is* the command — an exact
+match after trailing blanks, not a substring. That distinction is load-bearing:
+`strstr` over the formatted line also matches ordinary reply text (a `D A` cursor
+matches `RAKF0004 INVALI`**`D A`**`TTEMPT TO ACCESS SYSTEM`, measured) and any
+later command containing it (`D A,L`), and the search takes the newest match. At
+issue time the newest echo is taken; `collect` takes the one carrying the second
+recorded in its cursor (see [Collect](collect.md)).
 
 **Known race, not closed:** the first poll runs immediately after SVC 34, before
 the echo is guaranteed to be in the table, so a *previous* identical command

--- a/docs/endpoints/console/issue-command.md
+++ b/docs/endpoints/console/issue-command.md
@@ -197,11 +197,31 @@ the previous command's echo), and by a match count taken before issuing (a count
 over a *wrapping* window — after any burst of one command its oldest echoes sit
 at the aging edge, each new entry evicts one as ours is added, the count never
 grows, and every capture returns empty). Closing it needs a stable position in
-the MTT, and there is none across snapshots. Tracked in #214. Its source
-field (`"STC  nnn"`) seeds the block, and following entries are kept while they
-carry that source, a blank source (an MLWTO header such as `IEE102I`), or a
-matching MLWTO continuation number. A differently attributed originator ends the
-block.
+the MTT, and there is none across snapshots. Tracked in #214.
+
+The echo's source field (`"STC  nnn"`) seeds the block, and following entries are
+kept while they carry that source, a blank source (an MLWTO header such as
+`IEE102I`), or a matching MLWTO continuation number. **Two things end the block:**
+a differently attributed originator, and **the next command echo carrying our own
+source** — a command echo starts a new block, so everything from it on, its reply
+lines included, belongs to that command. A command with a *blank* source (JES2's
+`SE '$HASP165 … ENDED'` on every job end that notifies a user, a timer's
+`S ZTIMER`) is skipped rather than ending the block: it is no evidence that a new
+block from our source has started, and taking it returned it as one of *our*
+response lines.
+
+"Command" here is a shape, not a field, and the field was looked for first: the
+`MTENTRY` header `IEEZB806` documents as *flags set by caller* / *identifies
+caller* (`mtentflg`, `mtenttag`, `mtentimm`) was read on this system for exactly
+this question and does not separate an echo from a message — over 317 live entries
+every one reads `0000` / `0001`, a `D T` echo and the `IEE136I` answering it
+alike. What is used instead is the first token: an MVS message id carries a digit
+(`IEE136I`, `$HASP395`, `RAKF0004`), an operator command does not (`D T`,
+`P FTPD`, `V 500,ONLINE`). It is applied only to lines the walk would otherwise
+take into the block, which is what bounds the cost of it being a heuristic —
+`IEFACTRT` job accounting reads as command-shaped but carries a JOB source and
+ends the block one test later anyway. `/zosmf/test?fn=mtt&hdr=1` dumps the header
+if the question ever comes back.
 
 **A command routed to another address space is the exception.** The echo carries
 the *issuer's* source — mvsMF's own worker — while the reply to `F <stc>,...` is

--- a/src/consapi.c
+++ b/src/consapi.c
@@ -364,6 +364,36 @@ static int is_echo_line(const MTENTRY *e, const char *cmd_upper)
 	return memcmp(msg, cmd_upper, (size_t)cmdlen) == 0;
 }
 
+/* Does this message text read as a COMMAND rather than as a message? Used to
+ * find the end of a response block, where the command is somebody else's and
+ * its text is therefore unknown -- is_echo_line() cannot help.
+ *
+ * The test is the first token: an MVS message identifier carries a digit in it
+ * (IEE136I, HTTPD100I, $HASP395, RAKF0004, IGF991I) and an operator command
+ * does not (D T, F HTTPD,D P, P FTPD, V 500,ONLINE).
+ *
+ * It is a heuristic, and the honest statement of its cost is that it is only
+ * ever applied to lines the walk would otherwise take into the block -- our
+ * own source, or a blank one. Measured over a 317-entry live snapshot: every
+ * command-shaped line carrying our source was a command echo, and the only
+ * lines it misreads (IEFACTRT job accounting) carry a JOB source, which ends
+ * the block one test later anyway. An MLWTO continuation is excluded by the
+ * caller before this is reached; its first token is the message number and
+ * would read as a message regardless. */
+__asm__("\n&FUNC	SETC 'is_command_shaped'");
+static int is_command_shaped(const char *msg, int msglen)
+{
+	int i;
+
+	if (msglen <= 0) return 0;
+
+	/* EBCDIC keeps 0-9 contiguous, so the range test is safe here. */
+	for (i = 0; i < msglen && msg[i] != ' '; i++)
+		if (msg[i] >= '0' && msg[i] <= '9') return 0;
+
+	return 1;
+}
+
 __asm__("\n&FUNC	SETC 'correlate_once'");
 static int correlate_once(Session *session, const char *cmd_upper, char *out,
                           size_t outsz, unsigned skip, unsigned *total,
@@ -478,6 +508,36 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 				if (len - k >= (int)strlen(num) &&
 				    memcmp(&dat[k], num, strlen(num)) == 0)
 					cont = 1;
+			}
+
+			/* A COMMAND ECHO STARTS A NEW BLOCK, so ours ends at the first one
+			   carrying our source: everything after it -- its own reply lines
+			   included -- belongs to that command. Without this the block has
+			   no end at all and the walk runs to the end of the table, which
+			   is what a correct anchor exposed: the right block, then a later
+			   "D T" echo and the later reply appended to it (#214).
+
+			   A blank-source command is skipped instead of ending the block.
+			   It is nobody's evidence that a new block from OUR source has
+			   started, and it is not rare: JES2 writes SE '$HASP165 ... ENDED'
+			   on every job end that notifies a user, and a timer writes
+			   S ZTIMER, both with a blank source. Taking them was the
+			   "blank_src lines are accepted unconditionally" hole -- they came
+			   back as OUR response lines.
+
+			   "Command" is a shape, not a field. The MTENTRY header was read
+			   on 2026-08-24 for exactly this question and does not answer it:
+			   over 317 live entries mtentflg/mtenttag are uniformly
+			   0000/0001, for a "D T" echo and for the IEE136I that answers it
+			   alike, and mtentimm is an address that does not track the kind
+			   of entry. See is_command_shaped() for what is used instead and
+			   for what it costs. */
+			if (!cont && (has_src || blank_src) && len > MTT_MSG_OFF &&
+			    is_command_shaped(&dat[MTT_MSG_OFF],
+			                      rstrip_len(&dat[MTT_MSG_OFF],
+			                                 len - MTT_MSG_OFF))) {
+				if (has_src) break;
+				continue;
 			}
 
 			/* A differently attributed originator normally ends our block --

--- a/src/consapi.c
+++ b/src/consapi.c
@@ -298,10 +298,18 @@ quit:
 
 /* Per-key cursor, stored opaquely in the kv-store value (the store never reads
  * it).  The cursor is a delivered-LINE COUNT, not a timestamp: the MTT has no
- * stable per-line sequence and its hh.mm.ss is second-granular. */
+ * stable per-line sequence and its hh.mm.ss is second-granular.
+ *
+ * echo_secs is what keeps a cursor pointed at ONE block (#214): the MTT's own
+ * recorded second for the echo this cursor was created from -- read out of the
+ * table at issue time, not converted from a clock -- so collect can ask for
+ * that entry again instead of taking whatever matches now. -1 means the echo
+ * had not landed before the sync capture gave up; collect then falls back to
+ * the newest echo, which is where a slow reply is still reachable. */
 typedef struct sol_cursor {
 	unsigned long long  issue_tod;   /* STCK at issue (opaque response key)        */
 	unsigned            delivered;   /* # response lines already delivered         */
+	int                 echo_secs;   /* MTT hh.mm.ss of OUR echo; -1 = never seen  */
 	unsigned char       cmdlen;
 	char                cmd[126];    /* uppercased command, for MTT re-correlation  */
 } SOL_CURSOR;
@@ -332,9 +340,34 @@ static void key_to_name(const char *key, char name[MVSMF_KVS_NAMELEN])
 /* ------------------------------------------------------------------ */
 static int mtt_secs_of_day(const char *dat, int len);
 
+/* Is this entry the ECHO of cmd_upper -- is its message text exactly the
+ * command, rather than merely containing it?
+ *
+ * The predicate used to be strstr() over the whole formatted line, which
+ * matches far more than a later echo of the same command. Measured on mvsdev:
+ * a cursor for "D A" matches "RAKF0004 INVALI(D A)TTEMPT TO ACCESS SYSTEM",
+ * an ordinary reply line from another address space -- and the search takes
+ * the NEWEST match, so any such line steals the anchor. */
+__asm__("\n&FUNC	SETC 'is_echo_line'");
+static int is_echo_line(const MTENTRY *e, const char *cmd_upper)
+{
+	int len = mtt_len(e);
+	const char *msg;
+	int msglen, cmdlen;
+
+	if (len <= MTT_MSG_OFF) return 0;
+	msg = &e->mtentdat[MTT_MSG_OFF];
+	msglen = rstrip_len(msg, len - MTT_MSG_OFF);
+	cmdlen = rstrip_len(cmd_upper, (int)strlen(cmd_upper));
+	if (msglen <= 0 || msglen != cmdlen) return 0;
+
+	return memcmp(msg, cmd_upper, (size_t)cmdlen) == 0;
+}
+
 __asm__("\n&FUNC	SETC 'correlate_once'");
 static int correlate_once(Session *session, const char *cmd_upper, char *out,
-                          size_t outsz, unsigned skip, unsigned *total)
+                          size_t outsz, unsigned skip, unsigned *total,
+                          int want_secs, int *echo_secs_out)
 {
 	CMTT *cmtt = cmtt_new();
 	MTENTRY **arr = cmtt ? cmtt_get_array(cmtt) : NULL;
@@ -350,13 +383,30 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 	int adopted = 0;	/* the block's source was taken from the target  */
 
 	out[0] = '\0';
+	/* set on EVERY path: a later poll that finds no echo must not leave an
+	 * earlier poll's second standing in the caller's variable. */
+	if (echo_secs_out) *echo_secs_out = -1;
 
-	/* find OUR echo: newest entry whose text contains the command.
+	/* find OUR echo. want_secs picks between the two callers:
+	 *
+	 *   < 0   the newest echo of this command -- issue time, where ours is the
+	 *         newest by construction and no cursor exists yet to say otherwise.
+	 *   >= 0  the oldest echo carrying THAT MTT second -- collect time, where
+	 *         the cursor knows which block it was handed out for (#214). A
+	 *         later echo of the same command no longer takes the anchor, and
+	 *         when our own echo has aged out of the window nothing matches:
+	 *         collect answers empty ("done"), which is the honest answer and
+	 *         not a foreign block. Equality, not "at or after", so there is no
+	 *         midnight roll to get wrong -- an entry stamped 23.59.59 still
+	 *         reads 23.59.59 when collect runs at 00.00.05.
 	 *
 	 * Known race, NOT fixed here (#214): the first poll runs immediately after
 	 * MGCR, before the echo is guaranteed to be in the table, so a previous
 	 * identical command still in the window can be anchored on -- converging on
-	 * its stale block and returning the PREVIOUS response.
+	 * its stale block and returning the PREVIOUS response. Narrowing the match
+	 * to an echo does not close this: a previous identical command's echo is an
+	 * echo too. Same-second issue is the floor under want_secs for the same
+	 * reason.
 	 *
 	 * Two closures were tried on target and both measured worse than the race:
 	 *
@@ -375,15 +425,21 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 	 *
 	 * What this needs is a position, and the MTT offers no stable one across
 	 * snapshots. Leave the race until there is a reproduction for it. */
-	for (i = n; i > 0; i--) {
-		MTENTRY *e = arr[i - 1];
-		char tmp[160];
-		int len = mtt_len(e);
-		if (!e) continue;
-		if (len > (int)sizeof(tmp) - 1) len = sizeof(tmp) - 1;
-		memcpy(tmp, e->mtentdat, len);
-		tmp[len] = '\0';
-		if (strstr(tmp, cmd_upper)) { ei = (int)(i - 1); break; }
+	if (want_secs < 0) {
+		for (i = n; i > 0; i--) {
+			MTENTRY *e = arr[i - 1];
+			if (!e) continue;
+			if (is_echo_line(e, cmd_upper)) { ei = (int)(i - 1); break; }
+		}
+	} else {
+		for (i = 0; i < n; i++) {
+			MTENTRY *e = arr[i];
+			if (!e) continue;
+			if (!is_echo_line(e, cmd_upper)) continue;
+			if (mtt_secs_of_day(e->mtentdat, mtt_len(e)) != want_secs) continue;
+			ei = (int)i;
+			break;
+		}
 	}
 
 	if (ei >= 0) {
@@ -395,6 +451,7 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 		src[MTT_SRC_LEN] = '\0';
 
 		echo_secs = mtt_secs_of_day(ee->mtentdat, elen);
+		if (echo_secs_out) *echo_secs_out = echo_secs;
 
 		for (i = (unsigned)ei + 1; i < n; i++) {
 			MTENTRY *e = arr[i];
@@ -503,10 +560,13 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 }
 
 /* Issue-time sync capture: poll up to ~3 s and return the whole response block
- * in out; the return value is the number of lines it contains. */
+ * in out; the return value is the number of lines it contains. echo_secs_out
+ * receives the MTT second of the echo the LAST poll correlated -- the same poll
+ * the returned line count comes from, so the cursor stored from the two of them
+ * describes one block. */
 __asm__("\n&FUNC	SETC 'capture_response'");
 static int capture_response(Session *session, const char *cmd_upper, char *out,
-                            size_t outsz)
+                            size_t outsz, int *echo_secs_out)
 {
 	unsigned start = tod_hi();
 	int stable = 0;
@@ -515,7 +575,8 @@ static int capture_response(Session *session, const char *cmd_upper, char *out,
 
 	for (;;) {
 		if (server_quiescing(session)) return CONS_POLL_INTERRUPTED;
-		correlate_once(session, cmd_upper, out, outsz, 0, &total);
+		correlate_once(session, cmd_upper, out, outsz, 0, &total, -1,
+		               echo_secs_out);
 		if (total > 0) {
 			if (total == prev_total) {
 				if (++stable >= 3) break;
@@ -616,6 +677,7 @@ int consoleIssueHandler(Session *session)
 	const char *host = getHeaderParam(session, "Host");
 	const char *scheme = getRequestScheme(session);
 	int cmdlen, cnlen, i, is_async, sol_detected = 0;
+	int echo_secs = -1;
 	unsigned delivered = 0;
 	unsigned long long issue_tod;
 
@@ -785,7 +847,8 @@ int consoleIssueHandler(Session *session)
 	resp[0] = '\0';
 
 	{
-		int captured = capture_response(session, cmd_upper, resp, RESP_CAP);
+		int captured = capture_response(session, cmd_upper, resp, RESP_CAP,
+		                                &echo_secs);
 
 		/* The block is closed as far as we can tell -- let the next command in
 		 * before the (possibly long) unsolicited-detection wait below, which
@@ -822,6 +885,7 @@ int consoleIssueHandler(Session *session)
 			memset(&cur, 0, sizeof(cur));
 			cur.issue_tod = issue_tod;
 			cur.delivered = delivered;
+			cur.echo_secs = echo_secs;
 			cur.cmdlen    = (unsigned char)cmdlen;
 			strncpy(cur.cmd, cmd_upper, sizeof(cur.cmd) - 1);
 			key_to_name(key, name);
@@ -987,9 +1051,17 @@ int consoleCollectHandler(Session *session)
 	}
 	resp[0] = '\0';
 
-	/* return only the lines beyond what we already delivered, then advance */
-	correlate_once(session, cur.cmd, resp, RESP_CAP, cur.delivered, &total);
-	cur.delivered = total;
+	/* return only the lines beyond what we already delivered, then advance.
+	 *
+	 * cur.echo_secs pins the block to the one this key was handed out for
+	 * (#214). The cursor advances only FORWARD: a block that is shorter than
+	 * what we already delivered is not ours to count against, and writing its
+	 * length back is what used to leave a key answering empty for good after a
+	 * mis-anchor (watched going 10 -> 5). The entry is rewritten either way, so
+	 * a polling client keeps it alive against the store's LRU and TTL. */
+	correlate_once(session, cur.cmd, resp, RESP_CAP, cur.delivered, &total,
+	               cur.echo_secs, (int *)0);
+	if (total > cur.delivered) cur.delivered = total;
 	nt_set(store, name, &cur, sizeof(cur));
 
 	rc = send_collect(session, resp);

--- a/src/testapi.c
+++ b/src/testapi.c
@@ -617,10 +617,25 @@ int testHandler(Session *session) {
     }
 
     if (step >= 3 && arr) {
+      /* &hdr=1 prefixes each line with the MTENTRY header nobody had read:
+       * mtentflg (FLGS SET BY CALLER) / mtenttag (IDENTIFIES CALLER) /
+       * mtentimm (CALLER'S IMMEDIATE DATA), per IEEZB806. The question it
+       * exists for is whether a command echo can be told from a WTO without
+       * guessing at the text (#214). */
+      char *hdrv =
+          (char *)http_get_env(session->httpc, (const UCHAR *)"QUERY_HDR");
+      int hdr = hdrv ? atoi(hdrv) : 0;
+
       for (i = 0; i < n; i++) {
         MTENTRY *e = arr[i];
         if (!e)
           continue;
+        if (hdr) {
+          const unsigned char *h = (const unsigned char *)e->mtenthdr;
+          http_printf(session->httpc,
+                      "%02X%02X %02X%02X %02X%02X%02X%02X %04d |", h[0], h[1],
+                      h[2], h[3], h[4], h[5], h[6], h[7], (int)e->mtentlen);
+        }
         http_printf(session->httpc, "%-*.*s\r\n", (int)e->mtentlen,
                     (int)e->mtentlen, e->mtentdat);
       }

--- a/tests/curl-console.sh
+++ b/tests/curl-console.sh
@@ -287,6 +287,36 @@ CODE=$(echo "$RESP" | tail -1); CBODY=$(echo "$RESP" | sed '$d')
 assert_http_status "200" "$CODE" "collect bogus key"
 assert_json_field "$CBODY" '.["cmd-response"]' "" "collect bogus: empty"
 
+# ---- the anchor stays on the block the key was issued for (issue #214) ----
+#
+# A cursor for "D A", then an ordinary "D A,L" before the collect. The stored
+# text is a SUBSTRING of the later command's echo, which is how the anchor used
+# to move: the search took the newest MTT entry CONTAINING the command text, so
+# the "D A" key came back with the "D A,L" block.
+#
+# The discriminator is the content, not a line count: a plain "D A" answers a
+# four-line activity summary and never lists address spaces, so an IEFPROC line
+# can only have come from the "D A,L" block.  tests/repro-214-collect.sh is the
+# fuller version of this, including the same-command-twice case.
+RESP=$(issue '{"cmd":"D A","async":"Y"}')
+BODY=$(echo "$RESP" | sed '$d')
+KEY=$(echo "$BODY" | jq -r '.["cmd-response-key"]' 2>/dev/null)
+if [ -n "$KEY" ] && [ "$KEY" != "null" ]; then
+	sleep 2
+	issue '{"cmd":"D A,L"}' >/dev/null
+	sleep 1
+	CBODY=$(curl -s -u "$AUTH" "${CONSOLE}/solmsgs/${KEY}")
+	CRESP=$(echo "$CBODY" | jq -r '.["cmd-response"] // ""' 2>/dev/null)
+	case "$CRESP" in
+		*IEFPROC*) fail "collect: the 'D A' key kept its own block" \
+		                "returned the 'D A,L' block (IEFPROC lines present)" ;;
+		*IEE102I*) pass "collect: the 'D A' key kept its own block" ;;
+		*)         skip "collect: the 'D A' key kept its own block (block no longer in the trace table)" ;;
+	esac
+else
+	fail "collect anchor: async 'D A' returned no cmd-response-key"
+fi
+
 # =========================================================================
 # 6. Unsolicited keyword detection
 # =========================================================================

--- a/tests/repro-214-collect.sh
+++ b/tests/repro-214-collect.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 # =========================================================================
-# Reproduction for issue #214, collect half.
+# Regression test for issue #214, collect half. Written as a reproduction
+# (2/2 on the build before the fix); it is kept as the test because the two
+# experiments below are the measurement the fix was designed against.
 #
-# consoleCollectHandler() re-correlates on every poll instead of resuming:
-# correlate_once() anchors on the NEWEST MTT entry whose text contains the
-# stored command, so a matching entry written after the key was handed out
-# takes the anchor away from the block the key belongs to. #214's
-# serialization does not reach this -- the lock is held by the issuing path
-# only, and collect runs long afterwards and outside it.
+# consoleCollectHandler() re-correlates on every poll instead of resuming.
+# It used to anchor on the NEWEST MTT entry whose text CONTAINED the stored
+# command, so a matching entry written after the key was handed out took the
+# anchor away from the block the key belongs to. The fix records the MTT
+# second of the command's own echo in the cursor and asks for that entry
+# again, and narrows the match from "contains" to "is" the command.
+# #214's serialization never reached this -- the lock is held by the issuing
+# path only, and collect runs long afterwards and outside it.
 #
 # This script does NOT need two clients. Both experiments are sequential.
 #
@@ -16,14 +20,17 @@
 #      used so the cursor starts at delivered=0 and collect must return the
 #      whole block. The hardcopy log supplies the expected time independently.
 #
-#   2. A cursor for "D A" against a later "D A,L". The anchor is a strstr(),
-#      not an equality test, so any later command whose echo CONTAINS the
-#      stored text takes the anchor -- a wider surface than "the same command
-#      issued twice", and "D A" then "D A,L" is an ordinary operator sequence.
+#   2. A cursor for "D A" against a later "D A,L". The old anchor was a
+#      strstr(), not an equality test, so any later command whose echo merely
+#      CONTAINED the stored text took it -- a wider surface than "the same
+#      command issued twice", and "D A" then "D A,L" is an ordinary operator
+#      sequence. (Wider still: strstr ran over the whole formatted line, so
+#      "RAKF0004 INVALID ATTEMPT TO ACCESS SYSTEM" matches a "D A" cursor.)
 #
 # Only display commands are issued; nothing on the system is changed.
 #
-# Exit status: 0 = the defect did NOT reproduce, 1 = it did (expected today).
+# Exit status: 0 = correct (expected), 1 = the defect is back, 2 = inconclusive
+# (the system did not give the script what it needs -- rerun).
 #
 # Usage:  ./tests/repro-214-collect.sh
 # =========================================================================
@@ -131,9 +138,9 @@ fi
 echo ""
 echo "========================================"
 if [ "$DEFECTS" -gt 0 ]; then
-	echo " #214 collect half REPRODUCED (${DEFECTS}/2)"
+	echo " #214 collect half REPRODUCED (${DEFECTS}/2) -- REGRESSION"
 	echo "========================================"
 	exit 1
 fi
-echo " not reproduced this run"
+echo " both keys returned their own block -- OK"
 echo "========================================"


### PR DESCRIPTION
Closes #214.

## What was wrong

The collect half of #214, reproduced by `tests/repro-214-collect.sh` on `main`
(2/2), needed **two** fixes, and finding the second one is the story of this PR.

`consoleCollectHandler()` re-correlates on every poll instead of resuming, and
its anchor was "the newest MTT entry whose text **contains** the stored
command". So:

- a later command took the anchor — two `D T` five seconds apart, and the first
  key came back with the second command's reply;
- "contains" is wider than a repeat of the same command: a `D A` cursor took a
  subsequent `D A,L` block whole, and the match ran over the entire formatted
  line, so `RAKF0004 INVALI`**`D A`**`TTEMPT TO ACCESS SYSTEM` matches too;
- once mis-anchored, the foreign block's line count was written back into the
  cursor (watched 10 → 5), after which that key answered empty for good.

## What landed

**1 · The anchor.** The echo predicate is now an exact match on the message text
(offset 24, trailing blanks stripped), and the cursor records the MTT's own
second for the command's echo, which collect asks for again. The second is read
out of the table rather than converted from a clock, so there is no timezone
question; the comparison is equality, so there is no midnight roll. An echo aged
out of the window matches nothing and collect answers `""` — the same "done" a
drained block gives, rather than a foreign block.

**2 · The block end — which only became visible once the anchor was right.**
Deployed with just the anchor fix, the measurement came back with the *right*
block followed by the next command's echo and reply: `correlate_once()` walked
to the end of the table. A command echo starts a new block, so ours now ends at
the first one carrying our source. A **blank-source** command is skipped
instead of ending the block — JES2 writes `SE '$HASP165 … ENDED'` on every job
end that notifies a user and a timer writes `S ZTIMER`, and those were being
emitted as our own response lines.

Recognising a command is a shape, not a field — and the field was looked for
first. `/zosmf/test?fn=mtt&hdr=1` (added here) dumps the `MTENTRY` header that
had never been read on this system, the one `IEEZB806` documents as *flags set
by caller* / *identifies caller*. It does not separate an echo from a message:
over 317 live entries every entry reads `0000`/`0001`, a `D T` echo and the
`IEE136I` answering it alike. That settles a question #214 had left open with an
expectation attached. What is used instead is the first token — an MVS message
id carries a digit, an operator command does not — applied only to lines the
walk would otherwise take into the block, which is what bounds it being a
heuristic.

## Measured on mvsdev, live module `a6352f2`

| | before | after |
|---|---|---|
| `tests/repro-214-collect.sh` | 2/2 reproduced | **exit 0**, both keys return their own block |
| `tests/curl-console.sh` | 65/65 | **72/72** (new anchor test + `RUN_FTPD_TESTS=1`) |
| #346 completion path | — | `collect supplied what the capture missed (1 → 4 lines)` |
| 10 × `D T` under two `F HTTPD,D P` loops | — | **0/10 contaminated**, 0.68–1.14 s |

The FTPD run matters most: it is the one case where the reply arrives *after*
the sync capture, so a block end that fired too early would have shown up there.

## What this does not close, stated because it looks like it should

The sync-capture race is untouched: a previous identical command's echo is an
exact echo too. Two identical commands inside one second remain ambiguous — the
table stamps `hh.mm.ss` and nothing finer. When the echo never landed before the
capture gave up, the cursor has no second to match and collect falls back to the
newest echo, which is what keeps a late reply reachable. All three are now
documented in `docs/endpoints/console/collect.md` rather than tracked as open
work.

A cursor stored by the previous build fails the length check and answers empty —
correct degradation for keys handed out before activation.