### PR TITLE
consapi: end a response block on the issuer's source, not the adopted one

### DIFF
--- a/src/consapi.c
+++ b/src/consapi.c
@@ -407,6 +407,7 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 	int appended = 0;
 	size_t used = 0;
 	char src[MTT_SRC_LEN + 1];
+	char isrc[MTT_SRC_LEN + 1];	/* the ISSUER's source; src may be adopted */
 	char num[12];
 	int have_num = 0;
 	int echo_secs = -1;	/* hh.mm.ss of the echo, for the adoption below */
@@ -479,6 +480,9 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 		if (elen >= MTT_SRC_OFF + MTT_SRC_LEN)
 			memcpy(src, &ee->mtentdat[MTT_SRC_OFF], MTT_SRC_LEN);
 		src[MTT_SRC_LEN] = '\0';
+		/* src can be re-pointed at the TARGET by the #174 adoption below; isrc
+		 * stays the issuer's and is what the block-end test wants -- see there. */
+		memcpy(isrc, src, MTT_SRC_LEN + 1);
 
 		echo_secs = mtt_secs_of_day(ee->mtentdat, elen);
 		if (echo_secs_out) *echo_secs_out = echo_secs;
@@ -489,13 +493,16 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 			const char *dat = e ? e->mtentdat : "";
 			const char *msg;
 			int msglen, k;
-			int has_src, blank_src, cont;
+			int has_src, blank_src, cont, is_issuer;
 
 			if (!e) continue;
 
 			/* classify the line relative to our command's block */
 			has_src = (len >= MTT_SRC_OFF + MTT_SRC_LEN &&
 			           memcmp(&dat[MTT_SRC_OFF], src, MTT_SRC_LEN) == 0);
+
+			is_issuer = (len >= MTT_SRC_OFF + MTT_SRC_LEN &&
+			             memcmp(&dat[MTT_SRC_OFF], isrc, MTT_SRC_LEN) == 0);
 
 			blank_src = (len >= MTT_SRC_OFF + MTT_SRC_LEN);
 			for (k = MTT_SRC_OFF; blank_src && k < MTT_SRC_OFF + MTT_SRC_LEN; k++)
@@ -511,11 +518,20 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 			}
 
 			/* A COMMAND ECHO STARTS A NEW BLOCK, so ours ends at the first one
-			   carrying our source: everything after it -- its own reply lines
-			   included -- belongs to that command. Without this the block has
-			   no end at all and the walk runs to the end of the table, which
-			   is what a correct anchor exposed: the right block, then a later
-			   "D T" echo and the later reply appended to it (#214).
+			   carrying the ISSUER's source: everything after it -- its own
+			   reply lines included -- belongs to that command. Without this the
+			   block has no end at all and the walk runs to the end of the
+			   table, which is what a correct anchor exposed: the right block,
+			   then a later "D T" echo and the later reply appended to it
+			   (#214).
+
+			   ISSUER, not the block's current source: a MODIFY adopts the
+			   TARGET's source (#174), and a target's reply line is not a
+			   command however it reads. Testing the adopted source here would
+			   truncate the reply of any started task that answers without a
+			   message id -- unreproducible on this stand, where UFSD answers
+			   UFSD010I..UFSD018I, and silent when it happens. A new command
+			   echo comes from our worker, never from the target.
 
 			   A blank-source command is skipped instead of ending the block.
 			   It is nobody's evidence that a new block from OUR source has
@@ -532,11 +548,11 @@ static int correlate_once(Session *session, const char *cmd_upper, char *out,
 			   alike, and mtentimm is an address that does not track the kind
 			   of entry. See is_command_shaped() for what is used instead and
 			   for what it costs. */
-			if (!cont && (has_src || blank_src) && len > MTT_MSG_OFF &&
+			if (!cont && (is_issuer || blank_src) && len > MTT_MSG_OFF &&
 			    is_command_shaped(&dat[MTT_MSG_OFF],
 			                      rstrip_len(&dat[MTT_MSG_OFF],
 			                                 len - MTT_MSG_OFF))) {
-				if (has_src) break;
+				if (is_issuer) break;
 				continue;
 			}
 


### PR DESCRIPTION
Follow-up to #351 (issue #214). Narrows the block terminator that PR added.

## The defect

`a6352f2` ends a response block at the next command-shaped line carrying "our
source" — but it tested the block's **current** source, and a `MODIFY` re-points
that at the **target** started task (#174's adoption). So from the adoption on,
every reply line written by that task is a candidate, and a target answering
without a message id in its first token ends our block mid-reply.

Trace `F UFSD,STATS`:

1. echo → `src` = the issuer, `STC nnnn`
2. UFSD's first reply line — neither `has_src` nor blank → **adopted**, `src`
   becomes UFSD's `STC`
3. every following UFSD line now has `has_src` → a digit-less first token would
   `break`

## Why no test caught it

UFSD answers `UFSD010I` … `UFSD018I`, so the suite's `F <stc>,STATUS` test passes
for a reason unrelated to the rule being right. The failure is silent — a short
`cmd-response`, HTTP 200, no indicator — and it needs a `MODIFY` target that
replies in plain text, which this stand does not have. Reported by review, not by
measurement, and stated as such.

## The change

Keep the echo's own source in `isrc` and test the terminator against that. A new
command echo comes from our worker, never from the target; the adopted source
keeps doing what it was added for, deciding which lines to *accept*. Before the
adoption `isrc == src`, so nothing else moves.

## Measured on mvsdev, live module `439e296`

- `tests/repro-214-collect.sh` → exit 0
- `tests/curl-console.sh` → 66/66, twice
- `RUN_FTPD_TESTS=1` → the MODIFY, `P FTPD` completion and `S FTPD` cases pass
- `F UFSD,STATS` returns all 11 lines through `UFSD018I MOUNT /tmp`

One run of the FTPD suite showed the two `detections` tests failing and passing
again on both re-runs. That path (`detect_count()`) is a `strstr` count over the
snapshot and is not touched here; it is #195, and the failing run was the one
with the most MTT traffic — which is the "entries aging out of the wrapping
window" branch of that ticket's discriminator. Noted there.