### PR TITLE
Make the dataset list handlers' rc signed, and stop get_operation() writing below its buffer

### DIFF
--- a/src/dsapi.c
+++ b/src/dsapi.c
@@ -1248,7 +1248,12 @@ dslist_in_page(const DSLIST *ds, const char *start_key, int have_start,
 
 int datasetListHandler(Session *session)
 {
-	unsigned	rc		= 0;
+	/* signed, and that is the whole point: `if ((rc = http_printf(...)) < 0)`
+	   is dead code on an unsigned rc, so every write below went unchecked and a
+	   client that disconnected mid-listing had the rest of the catalog formatted
+	   and sent after it (#267).  Only rc changes -- the counters below are
+	   compared and bounded as unsigned on purpose. */
+	int		rc		= 0;
 	unsigned	count		= 0;
 	unsigned	first		= 1;
 	unsigned	i		= 0;
@@ -1297,7 +1302,7 @@ int datasetListHandler(Session *session)
 			/* goto quit like every other exit here: dslist is still NULL at
 			   this point, so a bare return would be correct today and wrong
 			   the moment anything is allocated above it. */
-			rc = (unsigned) handle_error(session, ERR_INVALID_PARAM,
+			rc = handle_error(session, ERR_INVALID_PARAM,
 					"Dataset level is too long");
 			goto quit;
 		}
@@ -2291,7 +2296,11 @@ member_scan(Session *session, FILE *fp, const char *start_key, int start_after,
 
 int memberListHandler(Session *session)
 {
-	unsigned	rc		= 0;
+	/* signed for the reason spelled out in datasetListHandler() (#267).  Here it
+	   is the header and trailer writes that were unchecked; the directory walk
+	   itself is already guarded, because member_scan() returns int and the
+	   caller below tests it. */
+	int		rc		= 0;
 	unsigned	emitted		= 0;
 	unsigned	maxitems	= 0;
 	int		truncated	= 0;
@@ -2337,7 +2346,7 @@ int memberListHandler(Session *session)
 	   why the wrong one would survive review and then break when something is
 	   allocated above it. */
 	if (!normalize_dsn(dsname, dsn_buf, sizeof(dsn_buf))) {
-		rc = (unsigned) handle_error(session, ERR_INVALID_PARAM,
+		rc = handle_error(session, ERR_INVALID_PARAM,
 				"Dataset name is too long");
 		goto quit;
 	}
@@ -2440,7 +2449,7 @@ int memberListHandler(Session *session)
 	scanned = member_scan(session, fp, skipping ? start_key : NULL,
 			start_after, pattern_key, have_pattern, maxitems);
 	if (scanned < 0) {
-		rc = (unsigned) scanned;
+		rc = scanned;
 		goto quit;
 	}
 

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -1841,13 +1841,18 @@ get_operation(const char *line, char *op, size_t op_size)
     }
     op[i] = '\0';
 
-    // Right trim
-    for (i--; i >= 0; i--) {
-        if (isspace((unsigned char)op[i])) {
-            op[i] = '\0';
-        } else {
-            break;
-        }
+    /* Right trim.  `for (i--; i >= 0; i--)` was an underflow, not a loop
+       (#353): i is size_t, so on an empty operation field i-- is SIZE_MAX and
+       op[SIZE_MAX] is op[-1] -- the byte below the array.  A blank there was
+       overwritten with '\0' and the walk carried on down the caller's frame
+       for as long as it kept finding blanks.  `// ` and a name-only card both
+       produce an empty field, and find_job_card_range() calls this for every
+       line of submitted JCL.  Walking the length cannot step past zero.
+
+       The trim itself stays: the copy loop above stops at ' ', so a blank can
+       never land in op, but tab/CR/LF can and isspace() matches those. */
+    while (i > 0 && isspace((unsigned char)op[i - 1])) {
+        op[--i] = '\0';
     }
 }
 

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -385,6 +385,47 @@ test_submit_notify_sysuid_trailing_param() {
 	fi
 }
 
+test_submit_padded_null_statement() {
+	echo ""
+	echo "--- Submit Job: blank-padded null statement in the deck (issue #353) ---"
+
+	# get_operation() right-trimmed with `for (i--; i >= 0; i--)` on a size_t, so
+	# an empty operation field wrapped i to SIZE_MAX and the trim wrote below its
+	# own five-byte buffer, zeroing every blank it met in the caller's frame. A
+	# "//" card padded to column 80 is exactly that case -- and it is what a fixed
+	# RECFM=F deck looks like, so it ran on ordinary submits, this suite's own #130
+	# test included. The corruption is silent, so this is a regression guard rather
+	# than a reproduction: it asserts the deck still parses and the job card is
+	# still found, which a lost card would answer 400.
+	local jcl
+	jcl=$(printf '%-80s\n%-80s\n%-80s\n' \
+		'//NULLST   JOB CLASS=A,MSGCLASS=H' \
+		'//STEP1    EXEC PGM=IEFBR14' \
+		'//')
+
+	local resp
+	resp=$(do_curl PUT \
+		-H "Content-Type: text/plain" \
+		-H "X-IBM-Intrdr-Mode: TEXT" \
+		-H "X-IBM-Intrdr-Lrecl: 80" \
+		-H "X-IBM-Intrdr-Recfm: F" \
+		--data-binary "$jcl" \
+		"${BASE_URL}/zosmf/restjobs/jobs")
+	split_response "$resp"
+
+	assert_http_status "200" "$HTTP_STATUS" "submit deck with padded null statement"
+	assert_json_field "$BODY" '.jobname' "NULLST" "job card found despite padded null statement"
+
+	# Purge this job to avoid clutter
+	local jn ji
+	jn=$(echo "$BODY" | jq -r '.jobname')
+	ji=$(echo "$BODY" | jq -r '.jobid')
+	if [ "$jn" != "null" ] && [ "$ji" != "null" ]; then
+		wait_for_output "$jn" "$ji" || true
+		do_curl DELETE "${BASE_URL}/zosmf/restjobs/jobs/${jn}/${ji}" >/dev/null 2>&1 || true
+	fi
+}
+
 test_submit_without_notify_gets_retcode() {
 	echo ""
 	echo "--- Submit Job: card without NOTIFY still reports a retcode (issue #307) ---"
@@ -1577,6 +1618,7 @@ fi
 test_submit_inline_jcl
 test_submit_inline_jcl_with_intrdr_headers
 test_submit_notify_sysuid_trailing_param
+test_submit_padded_null_statement
 test_submit_without_notify_gets_retcode
 test_submit_literal_notify_not_duplicated
 test_submit_notify_inside_programmer_name


### PR DESCRIPTION
Two defects of one class: an unsigned type makes a comparison that reads
correct do nothing at all. The first is `#267`; the second is `#353`, found by
the whole-tree `-Wextra` sweep this fix prompted and carried here rather than
into its own PR.

## `#267` — the list handlers' send checks were dead code

`datasetListHandler()` and `memberListHandler()` declared `unsigned rc` and
then tested every write with `if ((rc = http_printf(...)) < 0)`. That is never
true on an unsigned rc: **45 such comparisons** in `dsapi.c`, each one a write
whose failure was assigned and discarded. A client that disconnected
mid-listing had the whole remaining catalog formatted and sent after it.

The flip is one word per handler and it *activates* eleven `goto quit` paths
for the first time, so both cleanups were read in that light before it went in:

- `datasetListHandler()` frees `dslist` — NULL until `__listds()`, correct on
  any early jump.
- `memberListHandler()` closes its registered `fp` via `session_fclose()` —
  NULL until `fopen()`, likewise.
- Nothing tries to answer on top of a partly written body: `handle_request()`
  returns the handler rc to `mvsmf.c`, which stores it in `irc` and returns 0
  regardless, and `router.c`'s `headers_sent` guard covers only the abend path.

Every function assigned to `rc` was checked for 0/-1 semantics first, since
activating a check on a function that returns negative for a benign reason
would break listings that work today: `http_printf()` (`httpprtv.c`),
`http_resp()`, `send_common_headers()` and `send_session_cookie()` all return
0 on success. `handle_error()`, `sendErrorResponse()` and
`http_resp_internal_error()` are assigned and returned unchanged, so the type
carries their bits either way.

**Only `rc` changes.** The counters stay unsigned deliberately —
`member_scan()`'s page guard depends on an over-large `X-IBM-Max-Items`
arriving as `UINT_MAX`, and a "flip the unsigneds" sweep would silently break
it.

The severity is lopsided, which the issue's framing hides:
`memberListHandler()`'s directory walk was **already** guarded, because
`member_scan()` returns `int` and its caller tests it. What was dead there is
the six header and five trailer writes. The unguarded emit loop — 22 writes
per entry, for the whole rest of the listing — is `datasetListHandler()`'s.

## `#353` — `get_operation()` wrote below its own buffer

Not inert, this one. `for (i--; i >= 0; i--)` on a `size_t`: with an empty
operation field `i` wraps to `SIZE_MAX`, and `op[SIZE_MAX]` is `op[-1]` — the
byte below a five-byte stack array. A blank there was overwritten with `'\0'`
and the walk carried on downwards for as long as it kept finding blanks.

`find_job_card_range()` calls it for **every** line of submitted JCL of at
least three characters, and a `//` card padded to column 80 is exactly the
empty-field case — what a fixed `RECFM=F` deck ends with, and what a dataset
submit reads back from an 80-byte record. The bare two-character `//` escapes
only through the `line_len < 3` guard above it. This suite's own `#130`
regression test has been hitting it.

Walking the length cannot step past zero. The trim stays rather than being
deleted: the copy loop stops at `' '`, so a blank can never land in `op`, but
tab/CR/LF can and `isspace()` matches them.

## Verification

Deployed to mvsdev and activated into the httpd STEPLIB — `?fn=version`
reports `49e1996`, equal to this branch's HEAD.

- **`tests/curl-datasets.sh`: 267 passed, 0 failed, 0 skipped.**
- **`tests/curl-jobs.sh --setup`: 125 passed, 0 failed, 0 skipped**, including
  the dataset-submit path that reads blank-padded 80-byte records — the `#353`
  trigger — and the new `test_submit_padded_null_statement`.
- Sixteen aborted mid-body listings (`--max-time 0.85`, first byte at 0.67 s,
  complete at 1.34 s, so 9–20 KB of 45 KB received before the RST): no abend,
  no wedged worker. `/zosmf/info` answered in 70–124 ms afterwards and the full
  SYS1 listing in 1.12 s, both unchanged from before the probe. Free-storage
  largest-block was identical either side of the second round, so no per-abort
  loss.
- Whole-tree `-Wextra` sweep: 45 `always false` in `dsapi.c` and 1
  `always true` in `jobsapi.c` before, **none after**, with the remaining
  warning set unchanged line for line.

**What is not verified, and why** — corrected after the first version of this
paragraph got it wrong. The failure path **is** reached: an aborted client's
RST lands within milliseconds, and a `send()` on a reset connection fails
however much room the host-side buffer has. That is what separates it from the
`rc == 0` stall, which `#298` measured as genuinely unreachable here (45 KB
largest listing against roughly 58 KB of buffering, so the buffer never
fills).

What is missing is an **observable**. Nothing on the client side distinguishes
a handler that stopped at the first failed write from one that wrote the rest
into a dead socket, and 3.8j exposes no CPU counter to weigh the two — `D A,L`
carries none, unlike its z/OS descendant. So the proof that the checks now run
is the compiler's rather than the wire's, and the suites prove the newly
activated paths break nothing. A measurement gap, not an unreachable branch.

Fixes #267
Fixes #353
