### PR TITLE
Send the /zosmf/test header terminator on its own call so the reply is framed

### DIFF
--- a/src/testapi.c
+++ b/src/testapi.c
@@ -379,7 +379,15 @@ int testHandler(Session *session) {
   if ((rc = http_resp(session->httpc, 200)) < 0)
     goto quit;
   if ((rc = http_printf(session->httpc,
-                        "Content-Type: application/json\r\n\r\n")) < 0)
+                        "Content-Type: application/json\r\n")) < 0)
+    goto quit;
+  /* The blank line goes out on its own call, and that is load-bearing (#355):
+     httpd recognises the header terminator by shape -- httpprtv.c tests
+     len == 2 && "\r\n" -- and only then injects Transfer-Encoding: chunked.
+     Glued to the header above it, this response went out with no framing at
+     all while still announcing keep-alive, and every client waited out the
+     idle timeout for an EOF that told it the body had ended. */
+  if ((rc = http_printf(session->httpc, "\r\n")) < 0)
     goto quit;
 
   /* --- fn=listds ------------------------------------------------ */
@@ -1455,7 +1463,10 @@ int testWildcardHandler(Session *session) {
   if ((rc = http_resp(session->httpc, 200)) < 0)
     goto quit2;
   if ((rc = http_printf(session->httpc,
-                        "Content-Type: application/json\r\n\r\n")) < 0)
+                        "Content-Type: application/json\r\n")) < 0)
+    goto quit2;
+  /* separate call -- see the note at the dispatcher above (#355) */
+  if ((rc = http_printf(session->httpc, "\r\n")) < 0)
     goto quit2;
 
   rc = http_printf(session->httpc,

--- a/tests/curl-diag.sh
+++ b/tests/curl-diag.sh
@@ -168,6 +168,33 @@ Before ${BEFORE}, after ${AFTER}."
 fi
 
 # =========================================================================
+# 4. the response is framed (issue #355)
+#
+# httpd injects Transfer-Encoding: chunked only when it recognises the header
+# terminator, and it recognises it by shape: the blank line has to arrive as
+# its own http_printf() call. Glued to the Content-Type header, every
+# /zosmf/test reply went out with no Content-Length and no Transfer-Encoding
+# while announcing keep-alive, so the client had to wait for the socket to
+# close -- 4.6 s measured against 0.11 s for /zosmf/info.
+#
+# Assert the header, not the clock: a timing assertion would go green on any
+# stand whose idle timeout is short.
+# =========================================================================
+echo ""
+echo "--- the response is framed (issue #355) ---"
+HDRS=$(curl -s -D - -o /dev/null -u "$AUTH" "${TEST_URL}?fn=version")
+
+if echo "$HDRS" | grep -qi "^Transfer-Encoding: chunked"; then
+	pass "fn=version response is chunked"
+elif echo "$HDRS" | grep -qi "^Content-Length:"; then
+	pass "fn=version response carries a Content-Length"
+else
+	fail "fn=version response is framed" \
+		"neither Transfer-Encoding nor Content-Length -- the client must \
+wait out the idle timeout to learn the body ended"
+fi
+
+# =========================================================================
 # summary
 # =========================================================================
 echo ""


### PR DESCRIPTION
Two lines and a comment, plus the regression test.

`httpprtv.c` injects `Transfer-Encoding: chunked` only when it recognises the
header terminator, and it recognises it by shape: `len == 2 && "\r\n"`, so the
blank line has to arrive as its own `http_printf()`. Both `/zosmf/test` sites
wrote it glued to the `Content-Type` header, `len` was 33, the injector never
fired, and the reply went out with neither `Content-Length` nor
`Transfer-Encoding` while still announcing `Connection: keep-alive`.

Every other handler in the repo already sends it separately — `dsapi.c:311`,
`:1463`, `:2058` and the rest — which is why only this endpoint was affected.

## Measured on mvsdev

Before (build `49e1996`), the body arrived promptly and the client then sat
waiting for an EOF to tell it the body had ended:

```
/zosmf/test?fn=version   (no framing)                firstbyte=0.12s  total=4.64s
/zosmf/info              Content-Length: 189         firstbyte=0.09s  total=0.11s
/zosmf/restfiles/ds?...  Transfer-Encoding: chunked  total=0.26s
```

After (build `a277325`, deployed and activated):

```
/zosmf/test?fn=version   Transfer-Encoding: chunked  firstbyte=0.116s total=0.128s
/zosmf/test?fn=storage   Transfer-Encoding: chunked  firstbyte=0.059s total=0.120s
```

**`tests/curl-diag.sh`: 9/9 passed, 0 failed** — including the new framing
assertion and the storage guard, which reports seven abends costing 0 bytes.

The test asserts the header rather than the elapsed time. A timing assertion
would go green on any stand whose idle timeout happens to be short, which is
exactly the failure that hid this for as long as it did: the endpoint always
answered correctly, it just never said when it had finished.

Found while verifying #267 — a 5 s reading on `?fn=version` looked at first
like a server the abort probe had damaged.

Fixes #355
