### PR TITLE
Withdraw the seven -(volume-serial) routes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -480,10 +480,12 @@ Pointers only — the reasoning lives in the closing comments.
 
 mvsMF-only. Do not rank these here — update them where they live.
 
-Still open and ours to wait on — all three verified 2026-08-23: `libc370#79`
-(`exec-submitted`, and the accurate answer for #209), `libc370#30` (the nicer route
-for #186, not a gate for it), `httpd#176` (`blocked:rakf`), and `ftpd#90` (decide
-with #345).
+Still open and ours to wait on — the first four verified 2026-08-23:
+`libc370#79` (`exec-submitted`, and the accurate answer for #209), `libc370#30`
+(the nicer route for #186, not a gate for it), `httpd#176` (`blocked:rakf`),
+`ftpd#90` (decide with #345), and — filed 2026-08-25 — **`libc370#143`**
+(volume-addressed SCRATCH/RENAME, the half of #336 that is not ours; the read
+and write half needs nothing from there).
 
 **Cashed in on 2026-08-23** — libc370 rebuilt and installed into the cc370
 sysroot, mvsMF rebuilt, deployed and activated: `libc370#21` (which unblocked

--- a/TODO.md
+++ b/TODO.md
@@ -8,10 +8,11 @@ than code, and the per-issue hazard that makes an obvious-looking fix not one.
 **It carries nothing that is copied.** Where the reasoning already has an owner —
 the issue thread, the PR, `docs/uss-spec.md` — this file points at it and stops.
 
-*Last reconciled against the tracker: 2026-08-24, 18 issues open — seventeen
+*Last reconciled against the tracker: 2026-08-25, 18 issues open — seventeen
 entries below, because one of them pairs two issues. #245's doc half landed in
-PR #349; it stays open on its implement-vs-reject decision. #214 and #267 both
-closed on 2026-08-24, which is why Tier 1 is down to a single entry.*
+PR #349; it stays open on its implement-vs-reject decision. #336's reject half
+landed in PR #358 and moved it out of Tier 1 to the bottom of the list, which
+leaves **Tier 1 empty** — the top of the queue is now Tier 2's #210.*
 
 ---
 
@@ -19,43 +20,38 @@ closed on 2026-08-24, which is why Tier 1 is down to a single entry.*
 
 | | Issue | Kind | Waiting on |
 |---|---|---|---|
-| 1 | #336 | accepts the syntax, discards the operand | wire it or reject it |
-| 2 | #210 | client-visible, fix identified, local | nothing |
-| 3 | #251 | Optimistic Path stop pattern | nothing |
-| 4 | #209 | client-visible, cheap on 3.8j | nothing |
-| 5 | #245 | docs corrected; decision open | reader-vs-400 decision |
-| 6 | #326 | its trigger has fired | nothing |
-| 7 | #76 | the one externally reported defect | nothing |
-| 8 | #244 | the ordering constraint is the content | nothing |
-| 9 | #215 | latent, one place, every caller benefits | nothing |
-| 10 | #257, #335 | one class, two tickets | a repro without a proxy |
-| 11 | #347 | an authenticated user can stop the system | **a policy** — measured, nothing to delegate to |
-| 12 | #234 | `type:research` | measuring the reference |
-| 13 | #329 | `type:research` | **one measurement** — see *RAKF* |
-| 14 | #345 | `type:research` | **a policy** — see *RAKF* |
-| 15 | #195 | split from #214 — not the same bug | one two-snapshot measurement |
-| 16 | #291 | reclassified — hygiene, not stability | nothing |
-| 17 | #186 | unblocked; sysroot refreshed 2026-08-23 | nothing |
+| 1 | #210 | client-visible, fix identified, local | nothing |
+| 2 | #251 | Optimistic Path stop pattern | nothing |
+| 3 | #209 | client-visible, cheap on 3.8j | nothing |
+| 4 | #245 | docs corrected; decision open | reader-vs-400 decision |
+| 5 | #326 | its trigger has fired | nothing |
+| 6 | #76 | the one externally reported defect | nothing |
+| 7 | #244 | the ordering constraint is the content | nothing |
+| 8 | #215 | latent, one place, every caller benefits | nothing |
+| 9 | #257, #335 | one class, two tickets | a repro without a proxy |
+| 10 | #347 | an authenticated user can stop the system | **a policy** — measured, nothing to delegate to |
+| 11 | #234 | `type:research` | measuring the reference |
+| 12 | #329 | `type:research` | **one measurement** — see *RAKF* |
+| 13 | #345 | `type:research` | **a policy** — see *RAKF* |
+| 14 | #195 | split from #214 — not the same bug | one two-snapshot measurement |
+| 15 | #291 | reclassified — hygiene, not stability | nothing |
+| 16 | #186 | unblocked; sysroot refreshed 2026-08-23 | nothing |
+| 17 | #336 | routes withdrawn; now a feature request | `libc370#143` for half of it |
 
 ---
 
 ## Tier 1 — now
 
-### 1 · #336 — `{volume-serial}` is captured and never used
-
-Seven routes accept `-(VOLSER)` and discard the operand; a request naming the
-wrong volume is answered as if it had named the right one. Ranked here because
-the answer looks correct.
-
-The two resolutions differ by an order of magnitude: wire the volser through to
-`__dscbdv()`/OPEN, or reject the seven routes. **The rejection is nearly free** and
-worth taking even as an interim.
+**Empty.** #336 was its only entry and PR #358 took the cheap half — the seven
+routes are withdrawn, so nothing here answers a client wrongly any more. What
+is left of it is a feature request, ranked last; see Tier 5. The top of the
+queue is Tier 2's #210.
 
 ---
 
 ## Tier 2 — cheap and client-visible
 
-### 2 · #210 — the submit response returns `owner:""`
+### 1 · #210 — the submit response returns `owner:""`
 
 A race, not a divergent path — and therefore **not fixable by asking libc370
 earlier**: `JCTUSEID` is unwritten and the internal text is not on the spool yet.
@@ -63,21 +59,21 @@ mvsMF already knows the answer, because `process_jobcard()` injected `USER=`.
 Fall back to that. Check the purge handler (`jobsapi.c:363,375`) for the same
 emptiness, and make `tests/curl-jobs.sh` assert the value, not the key.
 
-### 3 · #251 — console log answers 200 with an empty body on allocation failure
+### 2 · #251 — console log answers 200 with an empty body on allocation failure
 
 `consapi.c:1100` collapses a NULL `cmtt_new()` into `n = 0`. The MTT copy is the
 largest allocation on that path — the one most likely to fail exactly when a
 silent empty answer misleads most. The sibling `malloc()` three lines below
 already returns 500. Textbook **Optimistic Path**; check `:266` and `:457` too.
 
-### 4 · #209 — `exec-system` and `exec-member` are never emitted
+### 3 · #209 — `exec-system` and `exec-member` are never emitted
 
 3.8j has no sysplex, so `CVTSNAME` is a correct constant answer and needs no
 libc370 change. `JCTRDSID` is right in principle and re-opens the relink chain
 (`libc370#79`) for no gain here. Take the cheap one deliberately, and say so in
 the code.
 
-### 5 · #245 — `X-IBM-Data-Type: record` cannot be written back
+### 4 · #245 — `X-IBM-Data-Type: record` cannot be written back
 
 The read path length-prefixes each record; the write path sends `record` down the
 *text* loop, so the four bytes read back as a length are a length only by accident.
@@ -91,7 +87,7 @@ What is left is the choice: a length-prefixed reader (mind a prefix split
 across a chunk boundary, and `record_content_max()`), or a 400. Nothing
 misleads a client in the meantime.
 
-### 6 · #326 — five sources missing from the CLAUDE.md list
+### 5 · #326 — five sources missing from the CLAUDE.md list
 
 `abendmsg.c`, `hostparse.c`, `jclines.c`, `reclines.c`, `spoolln.c`. The issue said
 "next time `CLAUDE.md` is touched", so fold it into the next edit of that file
@@ -102,7 +98,7 @@ which is how the list drifted in the first place.
 
 ## Tier 3 — correctness, needs care
 
-### 7 · #76 — DSORG=DA in `datasetPutHandler` via BDAM
+### 6 · #76 — DSORG=DA in `datasetPutHandler` via BDAM
 
 *the only defect on this list someone outside the project reported*
 
@@ -116,7 +112,7 @@ is observed, reported from outside, and blocking a real workflow; #244 is curren
 harmless and #215 has never been seen at all. What holds it out of Tier 1 is that
 `ufsd-utils upload` does the job today — a workaround, not an absence of impact.
 
-### 8 · #244 — `#define VARIABLE 0x0002` is the wrong RECFM mask
+### 7 · #244 — `#define VARIABLE 0x0002` is the wrong RECFM mask
 
 **The ordering constraint is the whole content of this ticket.** The broken mask
 is the only thing keeping `write_record()`'s manual RDW dormant, and that RDW is
@@ -127,7 +123,7 @@ alone ships **two** RDWs. Remove the manual RDW first, then fix the mask. Drop
 The regression test wants a **VB** data set written binary and read back with
 lengths checked — `curl-binary.sh` uses FB, which is why this survived.
 
-### 9 · #215 — `addJsonStringEsc()` escapes five characters, not the control range
+### 8 · #215 — `addJsonStringEsc()` escapes five characters, not the control range
 
 One raw control byte makes the **whole** response unparseable, and `consapi.c`
 passes Master Trace Table text — whatever any address space wrote to the console.
@@ -137,7 +133,7 @@ Honest scope, per the issue: **no observed failure**. #212 fixed this locally in
 The subtlety from #212, easy to lose: `http_printf()` translates on the way out,
 so the printability test applies to the **translated** byte, via `xlate_cp037`.
 
-### 10 · #257 + #335 — early 4xx on a PUT with a body still in flight
+### 9 · #257 + #335 — early 4xx on a PUT with a body still in flight
 
 **One class, two tickets — rank and fix them together.** Every early return in the
 PUT handlers answers before draining the announced body (`dsapi.c:1156, 1180,
@@ -154,7 +150,7 @@ Draining probably closes #257 and reduces #335 to the proxy question.
 
 ## Tier 4 — decisions before code
 
-### 11 · #347 — restconsoles authorizes nothing at all
+### 10 · #347 — restconsoles authorizes nothing at all
 
 *an authenticated user can stop the system*
 
@@ -192,7 +188,7 @@ reaching for the obvious: a display-only allow-list **breaks a real workflow** �
 `P FTPD` / `S FTPD` are group-1 (SYS) commands and are in use today (#346's
 transcript). Decide with #345 and `ftpd#90`.
 
-### 12 · #234 — what should the API do with non-ASCII input?
+### 11 · #234 — what should the API do with non-ASCII input?
 
 Byte-wise through CP037 with no UTF-8 decoding — and **invisible through the API**,
 because `etoa` inverts `atoe`, so only ISPF and the program reading the member see
@@ -205,7 +201,7 @@ Research because the policy is the hard part. Measure the reference first
 `xmit370`'s split between well-formed UTF-8 and Latin-1 is worth borrowing. Decide
 GET and PUT together; a reject changes the round-trip property.
 
-### 13 · #329 — dataset create is authorized only by the ambient ACEE
+### 12 · #329 — dataset create is authorized only by the ambient ACEE
 
 **The endpoint is not unauthorized and the response shape is settled** (#315,
 #317): RAKF refuses the allocation and the refusal must stay indistinguishable
@@ -216,7 +212,7 @@ open is only **which identity decides** — SVC 99 runs under whatever sits in
 The cheap unblocked step is a measurement, and it decides whether the fix exists
 at all: what does RACHECK answer for a name with no catalog entry and no DSCB?
 
-### 14 · #345 — restjobs has no authorization model
+### 13 · #345 — restjobs has no authorization model
 
 `grep -c 'http_check_auth\|require_access' src/jobsapi.c` → **0**, against 25 in
 `dsapi.c`. `owner=*` switches the default off, and the four by-jobid paths —
@@ -230,7 +226,7 @@ Whatever refusal is chosen must keep #229's constraint: "not yours" must not be
 distinguishable from "does not exist". Establish `jescanj()`'s own behaviour on a
 foreign purge, on a throwaway job. Decide together with `mvslovers/ftpd#90`.
 
-### 15 · #195 — detections intermittently report `waiting` for a message that was emitted
+### 14 · #195 — detections intermittently report `waiting` for a message that was emitted
 
 **Split out of #214 on 2026-08-23: they are not the same bug.** Structural, no
 measurement needed — `detect_count()` never reads `MTT_SRC_OFF`, never anchors an
@@ -270,7 +266,7 @@ truncating the snapshot.
 
 ## Tier 5 — larger work
 
-### 16 · #291 — large bodies fully buffered, twice on submit
+### 15 · #291 — large bodies fully buffered, twice on submit
 
 **Reclassify: memory hygiene, not stability.** Its motivation — stopping long-held
 requests acting as the anvil for httpd#195's fragmentation — is gone: #287 closed,
@@ -284,7 +280,7 @@ holds 2 MB. Cheapest item, and independent of the streaming work.
 **`receive_raw_data()` stays byte-at-a-time** (PR #22 / #42, the TCP ring-buffer
 bug). Streaming changes what we do with the bytes, not how they are read.
 
-### 17 · #186 — console log: deep history beyond the MTT window
+### 16 · #186 — console log: deep history beyond the MTT window
 
 **No longer blocked — the issue text says it is, and that is out of date.** Its
 hard dependency `libc370#21` is **closed and verified on target** (PR#31,
@@ -312,6 +308,37 @@ too: the failure was a `NOHOLD` class letting a printer purge the data set. The 
 operational requirements (`VARY SYSLOG,HARDCPY`, and spinning to a held class)
 belong in `docs/endpoints/console/hardcopy-log.md`, and mvsMF can issue
 `WRITELOG H` through the console API it already has.
+
+### 17 · #336 — `-({volume-serial})` addressing, now a feature rather than a lie
+
+**The routes are gone (PR #358), so this no longer misleads anyone** — that is
+the whole reason it fell from rank 1 to last. Until then seven routes accepted
+`-(VOLSER)`, discarded the operand and answered a wrong volume as if it were
+right. They are withdrawn, not commented out: `{dataset-name}` stops at `/`,
+`(` and `)` in `is_pattern_match()`, so the form reaches the router's own 404
+and cannot be served as a data set literally named `-(VOL)`.
+
+Ranked here rather than dropped because the capability is real and half of it
+is already sitting in libc370:
+
+- **Read and write need nothing new.** `__dsalc` parses `VOLSER=` and emits
+  DALVLSER via `__txvols()`; `fopen("DD:ddname")` and `"DD:ddname(MEMBER)"`
+  open the result; `__dscbdv(dsn, vol, &dscb)` always took a volume — mvsMF
+  merely feeds it `__locate()`'s answer. Roughly six `fopen()` call sites.
+- **DELETE and rename cannot be expressed at all.** `remove()`/`rename()` go
+  through IDCAMS DELETE/ALTER, i.e. the catalog, and ALTER operates on catalog
+  entries — an uncataloged rename has no spelling. That is **`libc370#143`**
+  (volume-addressed SCRATCH/RENAME). Reaching for IDCAMS instead walks back
+  into #342's SYSDSN ENQ escalation, which is why `__delmem()` is a
+  STOW-under-SHR path in the first place.
+
+Two things to carry into any attempt. `__dsalc` is verified to **parse**
+`VOLSER=`, not that SVC 99 **accepts** DALVLSER without DALUNIT for an
+uncataloged data set — the JCL rule says the pair is required, dynalloc may
+differ, and `__listvl()` has the `cuu` if it does not. And the catalog-based
+diagnosis (`why_open_failed()`, `dataset_cataloged()`) has to become
+OBTAIN-by-volume on these routes, or an uncataloged data set comes back with
+the wrong reason for its 404.
 
 ---
 
@@ -431,11 +458,13 @@ Pointers only — the reasoning lives in the closing comments.
   guessed at all. #195 was ranked with #214 on the guess that it might not
   survive #214's first measurement, and that premise died before #214 did — see
   #195's entry. #251 was always independent of all three.
-- **The endpoint advertises what it does not do** — #245 and #336, with #248 as
-  the worked example of how it ends. **#245's doc half is done**, which is the
-  campaign's proof that the cheap half is worth taking alone: the mode is still
-  unimplemented and nothing lies about it any more. #336's reject half is the
-  same move and is still open.
+- **The endpoint advertises what it does not do** — **#245 is what is left**,
+  with #248 and now #336 as the worked examples of how it ends. Both prove the
+  campaign's premise that the cheap half is worth taking alone: neither mode is
+  implemented and nothing lies about either any more. #336 went further than
+  #245's doc-only half — the routes themselves are withdrawn (PR #358), and the
+  six suite assertions that covered them turned out to have been green
+  throughout, because they were measuring the cataloged path.
 - **Checked, then swallowed** — **#251 and #215 are what is left**, with #267
   closed out of it as the worked example: the return code is inspected and the
   failure goes nowhere. One convention, not three decisions. #267 also says how

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -83,7 +83,9 @@ and outlive a token logout.
 | GET | [`/zosmf/restfiles/ds/{name}`](datasets/get.md) | Read sequential dataset |
 | PUT | [`/zosmf/restfiles/ds/{name}`](datasets/put.md) | Write sequential dataset |
 
-Volume-specific variants: `/zosmf/restfiles/ds/-({volser})/{name}` for GET and PUT.
+There are no volume-specific variants. The
+`/zosmf/restfiles/ds/-({volser})/{name}` routes were withdrawn in #336 — they
+captured the volume and discarded it — and are answered 404.
 
 ## PDS Members (`/zosmf/restfiles/ds`)
 

--- a/docs/endpoints/datasets/delete.md
+++ b/docs/endpoints/datasets/delete.md
@@ -8,13 +8,14 @@ DELETE
 ## URL Path
 `/zosmf/restfiles/ds/{dataset-name}`
 
-or with explicit volume:
-
-`/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}`
+> **There is no `-({volume-serial})` form.** That route was withdrawn in #336:
+> it accepted the volume operand and discarded it, so a request naming the
+> wrong volume was answered as if it had named the right one. Such a URL is
+> answered 404. Restoring it needs a volume-addressed SCRATCH/RENAME in
+> libc370 (mvslovers/libc370#143) for the delete and rename paths.
 
 ## Path Parameters
 - `dataset-name`: Name of the dataset to delete
-- `volume-serial` (optional): Volume serial number
 
 ## Response
 On successful completion, this request returns HTTP status code 204 (No Content).
@@ -48,10 +49,6 @@ status. See [authorization.md](authorization.md).
 # Delete a dataset
 curl -X DELETE \
   http://mvs:1080/zosmf/restfiles/ds/MIKE.DUMMY.DATA
-
-# Delete with explicit volume
-curl -X DELETE \
-  http://mvs:1080/zosmf/restfiles/ds/-(PUB001)/MIKE.DUMMY.DATA
 ```
 
 ### Using Zowe CLI

--- a/docs/endpoints/datasets/get.md
+++ b/docs/endpoints/datasets/get.md
@@ -8,13 +8,14 @@ GET
 ## URL Path
 `/zosmf/restfiles/ds/{dataset-name}`
 
-or with explicit volume:
-
-`/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}`
+> **There is no `-({volume-serial})` form.** That route was withdrawn in #336:
+> it accepted the volume operand and discarded it, so a request naming the
+> wrong volume was answered as if it had named the right one. Such a URL is
+> answered 404. Restoring it needs a volume-addressed SCRATCH/RENAME in
+> libc370 (mvslovers/libc370#143) for the delete and rename paths.
 
 ## Path Parameters
 - `dataset-name`: Name of the dataset to read
-- `volume-serial` (optional): Volume serial number
 
 ## Request Headers
 - `X-IBM-Data-Type` (optional): Data transfer mode
@@ -71,9 +72,6 @@ curl http://mvs:1080/zosmf/restfiles/ds/MIKE.TEST.DATA
 curl -H "X-IBM-Data-Type: binary" \
   http://mvs:1080/zosmf/restfiles/ds/MIKE.LOAD.XMI \
   -o download.xmi
-
-# With explicit volume
-curl http://mvs:1080/zosmf/restfiles/ds/-(PUB001)/MIKE.TEST.DATA
 ```
 
 ### Using Zowe CLI

--- a/docs/endpoints/datasets/members-delete.md
+++ b/docs/endpoints/datasets/members-delete.md
@@ -8,14 +8,15 @@ DELETE
 ## URL Path
 `/zosmf/restfiles/ds/{dataset-name}({member-name})`
 
-or with explicit volume:
-
-`/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}({member-name})`
+> **There is no `-({volume-serial})` form.** That route was withdrawn in #336:
+> it accepted the volume operand and discarded it, so a request naming the
+> wrong volume was answered as if it had named the right one. Such a URL is
+> answered 404. Restoring it needs a volume-addressed SCRATCH/RENAME in
+> libc370 (mvslovers/libc370#143) for the delete and rename paths.
 
 ## Path Parameters
 - `dataset-name`: Name of the partitioned dataset
 - `member-name`: Name of the member to delete
-- `volume-serial` (optional): Volume serial number
 
 ## Response
 On successful completion, this request returns HTTP status code 204 (No Content).
@@ -50,10 +51,6 @@ status. See [authorization.md](authorization.md).
 # Delete a PDS member
 curl -X DELETE \
   http://mvs:1080/zosmf/restfiles/ds/MIKE.TEST.JCL\(MYJOB\)
-
-# Delete with explicit volume
-curl -X DELETE \
-  http://mvs:1080/zosmf/restfiles/ds/-(PUB001)/MIKE.TEST.JCL\(MYJOB\)
 ```
 
 ### Using Zowe CLI

--- a/docs/endpoints/datasets/members-get.md
+++ b/docs/endpoints/datasets/members-get.md
@@ -8,14 +8,15 @@ GET
 ## URL Path
 `/zosmf/restfiles/ds/{dataset-name}({member-name})`
 
-or with explicit volume:
-
-`/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}({member-name})`
+> **There is no `-({volume-serial})` form.** That route was withdrawn in #336:
+> it accepted the volume operand and discarded it, so a request naming the
+> wrong volume was answered as if it had named the right one. Such a URL is
+> answered 404. Restoring it needs a volume-addressed SCRATCH/RENAME in
+> libc370 (mvslovers/libc370#143) for the delete and rename paths.
 
 ## Path Parameters
 - `dataset-name`: Name of the partitioned dataset
 - `member-name`: Name of the member to read
-- `volume-serial` (optional): Volume serial number
 
 ## Request Headers
 - `X-IBM-Data-Type` (optional): Data transfer mode

--- a/docs/endpoints/datasets/members-list.md
+++ b/docs/endpoints/datasets/members-list.md
@@ -8,13 +8,14 @@ GET
 ## URL Path
 `/zosmf/restfiles/ds/{dataset-name}/member`
 
-or with explicit volume:
-
-`/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}/member`
+> **There is no `-({volume-serial})` form.** That route was withdrawn in #336:
+> it accepted the volume operand and discarded it, so a request naming the
+> wrong volume was answered as if it had named the right one. Such a URL is
+> answered 404. Restoring it needs a volume-addressed SCRATCH/RENAME in
+> libc370 (mvslovers/libc370#143) for the delete and rename paths.
 
 ## Path Parameters
 - `dataset-name`: Name of the partitioned dataset
-- `volume-serial` (optional): Volume serial number
 
 ## Query Parameters
 - `start` (optional): Starting member name for pagination. The listing begins at

--- a/docs/endpoints/datasets/members-put.md
+++ b/docs/endpoints/datasets/members-put.md
@@ -8,14 +8,15 @@ PUT
 ## URL Path
 `/zosmf/restfiles/ds/{dataset-name}({member-name})`
 
-or with explicit volume:
-
-`/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}({member-name})`
+> **There is no `-({volume-serial})` form.** That route was withdrawn in #336:
+> it accepted the volume operand and discarded it, so a request naming the
+> wrong volume was answered as if it had named the right one. Such a URL is
+> answered 404. Restoring it needs a volume-addressed SCRATCH/RENAME in
+> libc370 (mvslovers/libc370#143) for the delete and rename paths.
 
 ## Path Parameters
 - `dataset-name`: Name of the partitioned dataset
 - `member-name`: Name of the member to write
-- `volume-serial` (optional): Volume serial number
 
 ## Request Headers
 - `Content-Length` or `Transfer-Encoding: chunked`: One of these is required

--- a/docs/endpoints/datasets/put.md
+++ b/docs/endpoints/datasets/put.md
@@ -8,13 +8,14 @@ PUT
 ## URL Path
 `/zosmf/restfiles/ds/{dataset-name}`
 
-or with explicit volume:
-
-`/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}`
+> **There is no `-({volume-serial})` form.** That route was withdrawn in #336:
+> it accepted the volume operand and discarded it, so a request naming the
+> wrong volume was answered as if it had named the right one. Such a URL is
+> answered 404. Restoring it needs a volume-addressed SCRATCH/RENAME in
+> libc370 (mvslovers/libc370#143) for the delete and rename paths.
 
 ## Path Parameters
 - `dataset-name`: Name of the dataset to write
-- `volume-serial` (optional): Volume serial number
 
 ## Request Headers
 - `Content-Length` or `Transfer-Encoding: chunked`: One of these is required

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -106,9 +106,11 @@ curl -s -u $USER:$PASS -X DELETE "$BASE/zosmf/restfiles/ds/IBMUSER.TEST.DATA"
 zowe files delete ds "IBMUSER.TEST.DATA" -f
 ```
 
-> **Volume-qualified variant** for uncataloged datasets (GET/PUT/DELETE):
-> `/zosmf/restfiles/ds/-(<volser>)/{dataset-name}`, e.g.
-> `curl -s -u $USER:$PASS "$BASE/zosmf/restfiles/ds/-(WORK01)/IBMUSER.TEST.DATA"`.
+> **There is no volume-qualified variant.** The
+> `/zosmf/restfiles/ds/-(<volser>)/{dataset-name}` routes were withdrawn in
+> #336 — they accepted the volume and discarded it, so an uncataloged data set
+> was never reached and a wrong volume was answered as if it were right. Such a
+> URL is answered 404.
 
 ---
 

--- a/docs/uss-spec.md
+++ b/docs/uss-spec.md
@@ -51,6 +51,10 @@ und Zowe Explorer genutzt werden können.
 
 **Gesamt:** 24 Routen (davon 2 Utility, 6 Jobs, 16 Datasets)
 
+> Snapshot as of USS Phase 1 planning, kept as written. Rows 11, 13, 16,
+> 18, 20, 22 and 24 — the seven `-({volume-serial})` routes — were
+> withdrawn in #336 and are no longer registered.
+
 ### 2.2 libufs — Verfügbare API-Funktionen (aus libufs.h)
 
 | Kategorie | Funktion | Beschreibung |

--- a/mbt.lock
+++ b/mbt.lock
@@ -1,7 +1,7 @@
 {
   "mvslovers/httpd": {
-    "sha256": "128bf975f05a24622d7873cc77c857dbc3520c94334c7b0ba0159e1819f75539",
-    "version": "4.0.0"
+    "sha256": "357ead9734ea43469a7e03bb85e6687144f6ccad6f75910309a3ce8e6248ddfc",
+    "version": "4.0.1"
   },
   "mvslovers/ufsd": {
     "sha256": "3efc6ed09d63cb06afd8b6adf4e411d85efd48511cca266f0ada7b5560ebd5b0",

--- a/project.toml
+++ b/project.toml
@@ -17,7 +17,7 @@ libc370 = "1.0.3"
 cflags = ["-I", "include", '-DVERSION=\"$(PROJECT_VERSION)\"']
 
 [dependencies]
-"mvslovers/httpd" = ">=4.0.0"
+"mvslovers/httpd" = ">=4.0.1"
 "mvslovers/ufsd" = ">=1.2.1"
 
 # Single load module: a CGI program that runs under httpd.  It includes its

--- a/project.toml
+++ b/project.toml
@@ -18,7 +18,7 @@ cflags = ["-I", "include", '-DVERSION=\"$(PROJECT_VERSION)\"']
 
 [dependencies]
 "mvslovers/httpd" = ">=4.0.0"
-"mvslovers/ufsd" = ">=1.2.0"
+"mvslovers/ufsd" = ">=1.2.1"
 
 # Single load module: a CGI program that runs under httpd.  It includes its
 # own request router + API handlers; the CGI launcher (cgistart, providing

--- a/src/mvsmf.c
+++ b/src/mvsmf.c
@@ -156,20 +156,41 @@ int main(int argc, char **argv)
 
 	add_route(&router, GET, "/zosmf/restfiles/ds", datasetListHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}", datasetGetHandler);
-	add_route(&router, GET, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}", datasetGetHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/{dataset-name}", datasetPutHandler);
-	add_route(&router, PUT, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}", datasetPutHandler);
 	add_route(&router, POST, "/zosmf/restfiles/ds/{dataset-name}", datasetCreateHandler);
 	add_route(&router, DELETE, "/zosmf/restfiles/ds/{dataset-name}", datasetDeleteHandler);
-	add_route(&router, DELETE, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}", datasetDeleteHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}/member", memberListHandler);
-	add_route(&router, GET, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}/member", memberListHandler);
 	add_route(&router, GET, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberGetHandler);
-	add_route(&router, GET, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}({member-name})", memberGetHandler);
 	add_route(&router, PUT, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberPutHandler);
-	add_route(&router, PUT, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}({member-name})", memberPutHandler);
 	add_route(&router, DELETE, "/zosmf/restfiles/ds/{dataset-name}({member-name})", memberDeleteHandler);
-	add_route(&router, DELETE, "/zosmf/restfiles/ds/-({volume-serial})/{dataset-name}({member-name})", memberDeleteHandler);
+
+	/* The seven -({volume-serial}) routes are withdrawn, not implemented
+	   (#336).  They used to be registered here pointing at the same handlers
+	   as the cataloged forms, and no handler ever read HTTP_volume-serial:
+	   the operand was captured and discarded, so a request naming the wrong
+	   volume was answered as if it had named the right one.  Accepting the
+	   syntax and ignoring it is worse than not offering it, because the
+	   answer looks correct.
+
+	   Withdrawing them is safe to do by deletion alone: {dataset-name} stops
+	   at '/', '(' and ')' (is_pattern_match(), router.c), so "-(VOL)/X.Y"
+	   matches none of the cataloged patterns above and falls through to the
+	   router's 404.  It cannot be silently served as a data set literally
+	   named "-(VOL)".
+
+	   Restoring them needs more than uncommenting.  The read and write half
+	   is ours: allocate naming the volume (__dsalcf with VOLSER=) and open
+	   the DD (fopen("DD:ddname")), with __listvl() resolving the volser to a
+	   device if UNIT turns out to be required.  DELETE and rename are not:
+	   remove() and rename() reach a data set through the catalog only, and
+	   there is no volume-addressed SCRATCH/RENAME in libc370 to call instead
+	   -- mvslovers/libc370#143.  Routing those through IDCAMS would
+	   reintroduce the SYSDSN ENQ escalation of #342.
+
+	   The catalog-based diagnosis in dsapi.c (why_open_failed(),
+	   dataset_cataloged()) has to move to OBTAIN-by-volume on these routes
+	   as well, or an uncataloged data set comes back with the wrong reason
+	   for its 404. */
 
 	add_route(&router, GET, "/zosmf/restfiles/fs", ussListHandler);
 	add_route(&router, PUT, "/zosmf/restconsoles/consoles/{console-name}", consoleIssueHandler);

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -577,16 +577,83 @@ else
 	fi
 fi
 
-# --- Read with volume prefix ---
+# --- The withdrawn -(volume-serial) routes ---
 echo ""
-echo "--- Read Sequential Dataset with Volume Prefix ---"
+echo "--- Volume Prefix Routes Are Withdrawn ---"
+
+# All seven -(VOLSER) routes were withdrawn in #336. Until then they were
+# registered against the same handlers as the cataloged forms and no handler
+# ever read the operand, so the six assertions that used to live here passed
+# while the feature did not exist -- they were measuring the cataloged path.
+#
+# Each case asserts 404 *and* reason 7. That pairing is what makes the test
+# mean something: 7 is the router's own "Not Found" (router.c), while a
+# handler that reached a missing data set answers reason 4. Without the reason
+# these assertions would go green for a route that still exists and merely
+# failed to find its target.
+#
+# $VOLUME is the volume the listing reported for $TEST_SEQ, i.e. the *correct*
+# one. That is the point: routing never reaches a volume lookup, so a right
+# volser is refused exactly like a wrong one. The same value is used for the
+# PDS routes; which volume it names cannot matter to a router 404.
+#
+# It also proves there is no fallthrough: {dataset-name} stops at '/', '(' and
+# ')', so "-(VOL)/X.Y" must not be served as a data set literally named
+# "-(VOL)" -- that would arrive as reason 4, or as a 200.
+assert_route_withdrawn() {
+	local what="$1"; shift
+	local body code content
+
+	body=$(curl -s -w '\n%{http_code}' -u "$AUTH" "$@")
+	code=$(echo "$body" | tail -1)
+	content=$(echo "$body" | sed '$d')
+
+	assert_http_status "404" "$code" "$what is withdrawn"
+	assert_json_field "$content" '.reason' "7" "$what: reason 7 (no such route)"
+}
+
 if [ -n "$VOLUME" ] && [ "$VOLUME" != "null" ]; then
-	BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
-		"${BASE_URL}/zosmf/restfiles/ds/-(${VOLUME})/${TEST_SEQ}")
-	HTTP_CODE=$(echo "$BODY" | tail -1)
-	assert_http_status "200" "$HTTP_CODE" "read dataset with volume prefix -(${VOLUME})"
+	VP="-(${VOLUME})"
+
+	assert_route_withdrawn "GET dataset with volume prefix" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VP}/${TEST_SEQ}"
+
+	assert_route_withdrawn "PUT dataset with volume prefix" \
+		-X PUT -H "Content-Type: application/octet-stream" \
+		--data-binary $'VOLUME PREFIX WRITE TEST\n' \
+		"${BASE_URL}/zosmf/restfiles/ds/${VP}/${TEST_SEQ}"
+
+	assert_route_withdrawn "DELETE dataset with volume prefix" \
+		-X DELETE "${BASE_URL}/zosmf/restfiles/ds/${VP}/${TEST_SEQ}"
+
+	assert_route_withdrawn "member list with volume prefix" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VP}/${TEST_PDS}/member"
+
+	assert_route_withdrawn "GET member with volume prefix" \
+		"${BASE_URL}/zosmf/restfiles/ds/${VP}/${TEST_PDS}(TESTMBR)"
+
+	assert_route_withdrawn "PUT member with volume prefix" \
+		-X PUT -H "Content-Type: application/octet-stream" \
+		--data-binary $'VOLUME PREFIX WRITE TEST\n' \
+		"${BASE_URL}/zosmf/restfiles/ds/${VP}/${TEST_PDS}(VOLMBR)"
+
+	assert_route_withdrawn "DELETE member with volume prefix" \
+		-X DELETE "${BASE_URL}/zosmf/restfiles/ds/${VP}/${TEST_PDS}(TESTMBR)"
+
+	# The refused writes must not have created anything -- a 404 that still
+	# wrote would be the old bug wearing a new status.
+	BODY=$(curl -s -u "$AUTH" "${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}")
+	if echo "$BODY" | grep -q "VOLUME PREFIX WRITE TEST"; then
+		fail "a withdrawn PUT writes nothing" "the refused PUT reached ${TEST_SEQ}"
+	else
+		pass "a withdrawn PUT writes nothing"
+	fi
+
+	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null -u "$AUTH" \
+		"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(VOLMBR)")
+	assert_http_status "404" "$HTTP_CODE" "a withdrawn PUT creates no member"
 else
-	fail "read dataset with volume prefix" "the listing reported no volume for ${TEST_SEQ} -- the value comes from the API under test"
+	fail "volume prefix routes are withdrawn" "the listing reported no volume for ${TEST_SEQ} -- the value comes from the API under test"
 fi
 
 # --- Delete sequential dataset ---
@@ -606,27 +673,6 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	-X DELETE -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}")
 assert_http_status "404" "$HTTP_CODE" "delete non-existent dataset"
-
-# --- Create and delete with volume prefix ---
-echo ""
-echo "--- Delete Sequential Dataset with Volume Prefix ---"
-
-# Create a fresh dataset to delete via volume prefix
-BODY='{"dsorg":"PS","recfm":"FB","lrecl":80,"blksize":3120,"alcunit":"TRK","primary":1,"secondary":1}'
-HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
-	-X POST -u "$AUTH" \
-	-H "Content-Type: application/json" \
-	-d "$BODY" \
-	"${BASE_URL}/zosmf/restfiles/ds/${TEST_SEQ}")
-
-if [ "$HTTP_CODE" = "201" ] && [ -n "$VOLUME" ] && [ "$VOLUME" != "null" ]; then
-	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
-		-X DELETE -u "$AUTH" \
-		"${BASE_URL}/zosmf/restfiles/ds/-(${VOLUME})/${TEST_SEQ}")
-	assert_http_status "204" "$HTTP_CODE" "delete dataset with volume prefix -(${VOLUME})"
-else
-	fail "delete dataset with volume prefix" "could not create the fixture, or the listing reported no volume for it"
-fi
 
 # --- Write PDS member ---
 echo ""
@@ -1028,25 +1074,6 @@ CONTENT=$(echo "$BODY" | sed '$d')
 assert_http_status "404" "$HTTP_CODE" "list members of a missing dataset"
 assert_json_field "$CONTENT" '.reason' "4" "missing dataset: reason 4 (dataset not found)"
 
-# --- List PDS members with volume prefix ---
-echo ""
-echo "--- List PDS Members with Volume Prefix ---"
-
-# Get volume from a dataset list query
-VOLBODY=$(curl -s -u "$AUTH" \
-	"${BASE_URL}/zosmf/restfiles/ds?dslevel=${MVSMF_USER}.CURL")
-PDS_VOLUME=$(echo "$VOLBODY" | jq -r --arg dsn "$TEST_PDS" \
-	'.items[] | select(.dsname == $dsn) | .vol // empty' 2>/dev/null) || PDS_VOLUME=""
-
-if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
-	BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
-		"${BASE_URL}/zosmf/restfiles/ds/-(${PDS_VOLUME})/${TEST_PDS}/member")
-	HTTP_CODE=$(echo "$BODY" | tail -1)
-	assert_http_status "200" "$HTTP_CODE" "list members with volume prefix -(${PDS_VOLUME})"
-else
-	fail "list members with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
-fi
-
 # --- Read PDS member ---
 echo ""
 echo "--- Read PDS Member ---"
@@ -1061,34 +1088,6 @@ if echo "$CONTENT" | grep -q "MEMBER TEST LINE 1"; then
 	pass "member content matches"
 else
 	fail "member content matches" "expected 'MEMBER TEST LINE 1' in output"
-fi
-
-# --- Read PDS member with volume prefix ---
-echo ""
-echo "--- Read PDS Member with Volume Prefix ---"
-
-if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
-	BODY=$(curl -s -w '\n%{http_code}' -u "$AUTH" \
-		"${BASE_URL}/zosmf/restfiles/ds/-(${PDS_VOLUME})/${TEST_PDS}(TESTMBR)")
-	HTTP_CODE=$(echo "$BODY" | tail -1)
-	assert_http_status "200" "$HTTP_CODE" "read member with volume prefix -(${PDS_VOLUME})"
-else
-	fail "read member with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
-fi
-
-# --- Write PDS member with volume prefix ---
-echo ""
-echo "--- Write PDS Member with Volume Prefix ---"
-
-if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
-	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
-		-X PUT -u "$AUTH" \
-		-H "Content-Type: application/octet-stream" \
-		--data-binary $'VOLUME PREFIX WRITE TEST\n' \
-		"${BASE_URL}/zosmf/restfiles/ds/-(${PDS_VOLUME})/${TEST_PDS}(VOLMBR)")
-	assert_http_status "204" "$HTTP_CODE" "write member with volume prefix -(${PDS_VOLUME})"
-else
-	fail "write member with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
 fi
 
 # --- Rename PDS member ---
@@ -1144,19 +1143,6 @@ HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
 	-X DELETE -u "$AUTH" \
 	"${BASE_URL}/zosmf/restfiles/ds/${TEST_PDS}(TESTMBR)")
 assert_http_status "204" "$HTTP_CODE" "delete PDS member"
-
-# --- Delete PDS member with volume prefix ---
-echo ""
-echo "--- Delete PDS Member with Volume Prefix ---"
-
-if [ -n "$PDS_VOLUME" ] && [ "$PDS_VOLUME" != "null" ]; then
-	HTTP_CODE=$(curl -s -w '%{http_code}' -o /dev/null \
-		-X DELETE -u "$AUTH" \
-		"${BASE_URL}/zosmf/restfiles/ds/-(${PDS_VOLUME})/${TEST_PDS}(VOLMBR)")
-	assert_http_status "204" "$HTTP_CODE" "delete member with volume prefix -(${PDS_VOLUME})"
-else
-	fail "delete member with volume prefix" "the listing reported no volume for ${TEST_PDS} -- the value comes from the API under test"
-fi
 
 # --- Delete PDS member: not found ---
 echo ""

--- a/tests/curl-datasets.sh
+++ b/tests/curl-datasets.sh
@@ -600,6 +600,11 @@ echo "--- Volume Prefix Routes Are Withdrawn ---"
 # It also proves there is no fallthrough: {dataset-name} stops at '/', '(' and
 # ')', so "-(VOL)/X.Y" must not be served as a data set literally named
 # "-(VOL)" -- that would arrive as reason 4, or as a 200.
+#
+# The two PUT cases send a body to a route that answers before draining it,
+# which is #257/#335's exact shape. ~25 bytes fits one segment, so they pass.
+# If either ever fails with a transport error rather than a status mismatch,
+# that is #257 and not the withdrawal.
 assert_route_withdrawn() {
 	local what="$1"; shift
 	local body code content

--- a/tests/jcl/mvsmfact.jcl
+++ b/tests/jcl/mvsmfact.jcl
@@ -26,6 +26,25 @@
 //*     GET /zosmf/restjobs/jobs/HTTPD/<stcid>/files/3/records
 //*       -> XXSTEPLIB DD DISP=SHR,DSN=<the answer>
 //*
+//*   That method needs mvsMF, so it is unavailable in the one
+//*   case where the name matters most: a server that cannot
+//*   load MVSMF at all. httpd's own /.dm answers it instead --
+//*   it reads HTTPD's storage from inside HTTPD, so the TIOT it
+//*   walks is the running task's own.
+//*
+//*     /.dm?m=21C&l=16      PSATOLD -> current TCB
+//*     /.dm?m=<tcb>&l=16    +0C = TCBTIO -> TIOT
+//*     /.dm?m=<tiot>&l=256  first entry is STEPLIB; +0C is the
+//*                          3-byte SWA address of its JFCB
+//*     /.dm?m=<jfcb>&l=80   +10 begins the JFCB, whose first 44
+//*                          bytes are the DSN
+//*
+//*   Measured that way on mvsdev 2026-08-25 against HTTPD 4.0.1
+//*   -- the value below. 4.0.1 installs into a library of its
+//*   own, so an httpd upgrade moves this name and leaves the
+//*   previous library behind: still populated, no longer read,
+//*   and a copy into it activates nothing.
+//*
 //*   The deploy library is the one `make deploy` reports as its
 //*   target, built from MBT_MVS_HLQ in .env.
 //*
@@ -45,7 +64,7 @@
 //ACTIVATE EXEC PGM=IEBCOPY
 //SYSPRINT DD SYSOUT=*
 //IN       DD DSN=IBMUSER.MVSMF.V1R0M0D.LINKLIB,DISP=SHR
-//OUT      DD DSN=HTTPD.LINKLIB,DISP=SHR
+//OUT      DD DSN=HTTPD.V4R0M1.LINKLIB,DISP=SHR
 //SYSIN    DD *
   COPY INDD=((IN,R)),OUTDD=OUT
   SELECT MEMBER=MVSMF


### PR DESCRIPTION
Withdraws the seven `-({volume-serial})` routes rather than leaving them
advertising something they do not do. Interim resolution of #336 — the issue
stays open for the implementation, which is now scoped and partly blocked.

## What changed

- **`src/mvsmf.c`** — the seven registrations are gone, replaced by a comment
  recording why and what restoring them needs.
- **`tests/curl-datasets.sh`** — six scattered assertions replaced by one
  section.
- **Docs** — seven endpoint pages, `docs/endpoints/README.md`,
  `docs/examples.md`, and a snapshot note on the route table in
  `docs/uss-spec.md`.

## Deleting the registrations is the whole fix

No fallthrough is possible: `{dataset-name}` stops at `/`, `(` and `)` in
`is_pattern_match()`, so `-(VOL)/X.Y` matches none of the cataloged patterns
and reaches the router's own not-found path. It cannot be served as a data set
literally named `-(VOL)`.

## The old tests were green the whole time

Six assertions covered these routes and all six passed — against the cataloged
path, because the handlers ignored the volser and did the ordinary thing. The
replacement asserts **404 and reason 7**: 7 is the router's not-found, while a
handler that reached a missing data set answers reason 4. Without the reason,
the assertions would go green again for a route that exists and merely failed
to find its target.

Two further checks: the refused PUTs must not have written to the data set or
created the member. A 404 that still wrote would be the old bug wearing a new
status.

The volser used is the *correct* one for the fixture, taken from the listing.
That is deliberate — routing never reaches a volume lookup, so a right volume
must be refused exactly like a wrong one.

## What implementing them actually needs

Half is ours, half is not, which is why this lands as a withdrawal.

**Read and write need nothing new.** `__dsalc` already parses `VOLSER=` and
emits DALVLSER via `__txvols()`; `fopen()` opens `"DD:ddname"` and
`"DD:ddname(MEMBER)"`; `__dscbdv(dsn, vol, &dscb)` has always taken a volume
(mvsMF just feeds it `__locate()`'s answer); and `__listvl()` resolves a volser
to a `cuu` should UNIT turn out to be required. That is roughly six `fopen()`
call sites in `dsapi.c`.

**DELETE and rename cannot be expressed at all.** `remove()` and `rename()`
reach a data set through IDCAMS DELETE / ALTER, i.e. the catalog — and ALTER
operates on catalog entries, so an uncataloged rename has no spelling. libc370
has no volume-addressed SCRATCH (SVC 29) or RENAME (SVC 30) wrapper. Filed as
**mvslovers/libc370#143**. Routing them through IDCAMS instead would walk back
into the SYSDSN ENQ escalation of #342, which is why `__delmem()` exists as a
STOW-under-SHR path in the first place.

One assumption in that plan is measured only as far as the parser: `__dsalc`
*parses* `VOLSER=`, but it is unverified that SVC 99 *accepts* DALVLSER without
DALUNIT for an uncataloged data set. Noted in the libc370 issue with a
JCL-level probe that needs no build.

There is also a mvsMF-side consequence worth recording before anyone starts:
the catalog-based diagnosis (`why_open_failed()`, `dataset_cataloged()`) has to
move to OBTAIN-by-volume on these routes, or an uncataloged data set comes back
with the wrong reason for its 404.

## Verification

Measured on **mvsdev**, HTTPD 4.0.1 (`744A836`), against a module confirmed to
be this branch — `GET /zosmf/test?fn=version` returns `25e269d`, equal to the
branch HEAD, so the run is not measuring the previous build.

- `tests/curl-datasets.sh` — **277 passed, 0 failed**, including the sixteen new
  assertions.
- `tests/curl-jobs.sh` — **121 passed, 0 failed, 2 skipped**. Run because the
  httpd bump touches the jobs API's substrate; the STC's TIOT shows `HASPCKPT`
  and `HASPACE1` allocated, so httpd#256 does not apply to this stand.
- Console clean afterwards: no abend, no `HTTPD908E`, server still answering.

Spot-checked on the wire beyond the suite — all three withdrawn shapes return
`{"rc":4,"category":6,"reason":7,"message":"Not Found"}`, i.e. the router's
not-found and not a handler's reason 4, while the cataloged
`GET /zosmf/restfiles/ds/SYS1.MACLIB/member` still answers 200.

One note for whoever activates this next: the stand had been upgraded to httpd
4.0.1, which installs into `HTTPD.V4R0M1.LINKLIB`. The STC read the new library,
MVSMF was not in it, and every `/zosmf/*` answered 503 with `IEA703I 806-04` —
module not found, not the storage case `HTTPD908E` is usually blamed for. That
also means `make deploy` cannot recover it, since it uploads and submits through
the mvsMF API itself. `tests/jcl/mvsmfact.jcl` is corrected here and now records
how to read the STEPLIB out of the running task with `/.dm` when the jobs API is
the thing that is down.

## Also in this branch

### Dependencies

- **httpd `>=4.0.0` → `>=4.0.1`** (`project.toml` + `mbt.lock`). 4.0.0 was
  withdrawn and is gone from the release list, so the old floor named a version
  that can no longer be fetched. **No code changed between the two** — the load
  modules are functionally identical and the FMID is unchanged. What 4.0.1
  corrects is the shipped STC procedure, which had stopped allocating
  `HASPCKPT` and `HASPACE1` when `HTTPJES2` was removed. Nothing else in the
  *server* opens them, but a CGI module is dispatched by LINK into HTTPD's own
  task and opens every ddname against the STC's — and mvsMF's jobs API opens
  both by name. Without them the job list and spool retrieval answer 500 while
  a by-jobid path answers 404 for a job that exists; submit is unaffected
  (httpd#256).

  **That fix does not arrive through this bump.** It lands on a stand by adding
  the two DD statements to the PROCLIB member — and not by copying the new
  procedure, whose `STEPLIB` names the 4.0.1 library.

- **ufsd `>=1.2.0` → `>=1.2.1`**. The lock already resolved to 1.2.1, so
  nothing staged or linked changes; this only stops the declared range from
  admitting a build the lock would never pick. 1.2.1 is the S0C4-at-startup fix
  (ufsd#64), which bites only when the LINKLIB is in the APF list.

One trap met on the way, worth recording: a plain `make deps` takes the version
straight from `mbt.lock` without re-checking the declared range
(`mbtdeps.py:197`). It reported `>=4.0.1 -> 4.0.0` and changed nothing. The lock
only moves under `make deps ARGS=--update`.

### Ranking

- **`TODO.md`** — #336 drops from rank 1 to last and Tier 1 is now empty.
