### PR TITLE
jobs: answer the submit response owner from the injected USER=

### DIFF
--- a/docs/endpoints/jobs/purge.md
+++ b/docs/endpoints/jobs/purge.md
@@ -32,6 +32,14 @@ The job is looked up before it is purged. That lookup is what supplies `owner`
 (it cannot be read afterwards, the job is gone) and what makes an unknown job
 answer 404 the same way `GET /jobs/{name}/{id}` does.
 
+`owner` therefore comes back empty for a job purged in the seconds before JES2
+writes `JCTUSEID` — the same window the submit response used to expose (#210).
+Submit closes it by answering from the userid whose `USER=` it put on the job
+card; **this endpoint deliberately does not.** The purge handler authorizes
+nothing (#345), so the caller is frequently not the owner, and filling the
+field from the caller's identity would report a userid that never submitted the
+job. An empty owner is the honest answer here.
+
 ## Error Responses
 - HTTP 400 (Bad Request)
     - Missing required parameters (jobname/jobid)

--- a/docs/endpoints/jobs/status.md
+++ b/docs/endpoints/jobs/status.md
@@ -43,6 +43,13 @@ With `exec-data=Y`, two further fields follow `retcode`:
 Format, `null` semantics and the missing `exec-submitted` are described under
 [Execution timestamps](list.md#execution-timestamps).
 
+`owner` comes from `JCTUSEID`, which JES2 writes during conversion, so it is
+empty for the second or two between a job being read in and being converted.
+This endpoint reports that emptiness rather than guessing: it is told a jobname
+and a jobid, not who submitted them, and the caller is under no obligation to
+be the owner. [Submit](submit.md) is the one place that can fill the field in
+early, because it put the `USER=` on the card itself (#210).
+
 ## Error Responses
 - HTTP 400 (Bad Request)
     - Missing required parameters (jobname/jobid)

--- a/docs/endpoints/jobs/submit.md
+++ b/docs/endpoints/jobs/submit.md
@@ -38,6 +38,18 @@ On successful completion, this request returns HTTP status code 200 (OK) and the
 
 `exec-data=Y` is honoured here too, since the response is built by the same code, but it is of little use: a job that has just been submitted has usually not started yet, so `exec-started` and `exec-ended` are typically `null`. A very short job can already have run by the time the response is built, in which case they carry real instants — do not rely on either outcome.
 
+`owner` is the submitting userid, and on this endpoint it is answered locally
+rather than read from JES2. The owner of a batch job lives in `JCTUSEID`, which
+JES2 fills in during conversion — a second or two after the internal reader
+closes, so at the instant this response is built it is still blank and the
+job's internal text is not on the spool to fall back on either (#210). mvsMF
+supplies the userid whose `USER=` it put on the job card, which is the same
+answer JES2 arrives at moments later. Once JES2 has written a userid, that one
+is reported; nothing overwrites it.
+
+The [status](status.md) endpoint has no such knowledge and does not do this, so
+a status poll issued inside that same window can still show an empty `owner`.
+
 ## Error Responses
 - HTTP 400 (Bad Request)
     - Invalid internal reader parameters

--- a/src/jobsapi.c
+++ b/src/jobsapi.c
@@ -109,7 +109,8 @@ static const unsigned char ASCII_CRLF[] = {CR, LF};
 //
 
 static int send_job_status_response(Session *session, JESJOB *job, const char *host);
-static int find_and_send_job_status(Session *session, const char *jobname, const char *jobid, const char *host);
+static int find_and_send_job_status(Session *session, const char *jobname, const char *jobid, const char *host,
+                                   const char *submitter);
 
 //
 // public functions
@@ -353,7 +354,8 @@ jobStatusHandler(Session *session)
 	const char *jobname = getPathParam(session, "job-name");
 	const char *jobid = getPathParam(session, "jobid");
 
-	find_and_send_job_status(session, jobname, jobid, host);	
+	/* NULL: this handler cannot vouch for an owner -- see #210 */
+	find_and_send_job_status(session, jobname, jobid, host, NULL);
 
 	return 0;
 }
@@ -553,7 +555,14 @@ int jobSubmitHandler(Session *session)
 
 	{
 		const char *host = getHeaderParam(session, "HOST");
-		rc = find_and_send_job_status(session, jobname, jobid, host);
+		UCHAR submitter[64] = {0};
+
+		/* the job carries this userid's USER= (process_jobcard), so it is a
+		   safe answer for the owner JES2 has not written yet -- issue #210 */
+		http_get_userid(session->httpc, submitter, sizeof(submitter));
+
+		rc = find_and_send_job_status(session, jobname, jobid, host,
+									  (const char *)submitter);
 	}
 
 quit:
@@ -1763,9 +1772,30 @@ send_job_status_response(Session *session, JESJOB *job, const char *host)
 	return rc;
 }
 
+/*
+ * Report a single job, optionally completing its owner from the identity that
+ * submitted it (issue #210).
+ *
+ * `submitter` is a value the *caller* has to be able to vouch for, and only
+ * jobSubmitHandler can: it passes the userid whose USER= process_jobcard() put
+ * on the job card, so a job that comes back without an owner is that userid's
+ * by construction. libc370 reads the owner from JCTUSEID, which JES2 fills in
+ * during conversion -- so for the couple of seconds between the internal
+ * reader closing and the converter running, it is blank, and the fallback in
+ * process_intxt() has nothing to read either because the internal text is not
+ * on the spool yet. Asking libc370 earlier cannot fix that; the data does not
+ * exist yet.
+ *
+ * Which is why this is a parameter and must stay one. jobStatusHandler is the
+ * other caller and passes NULL: it knows nothing about who submitted the job
+ * it was asked about, so resolving the userid inside this function instead
+ * would report the caller as the owner of somebody else's just-submitted job.
+ * That is not a fallback, it is invented data.
+ */
 __asm__("\n&FUNC    SETC 'find_and_send_job_status'");
 static int
-find_and_send_job_status(Session *session, const char *jobname, const char *jobid, const char *host)
+find_and_send_job_status(Session *session, const char *jobname, const char *jobid, const char *host,
+                         const char *submitter)
 {
     int rc = 0;
 
@@ -1789,6 +1819,13 @@ find_and_send_job_status(Session *session, const char *jobname, const char *jobi
                       msg, NULL, 0);
         rc = -1;
 		goto quit;
+    }
+
+    /* complete, never overwrite: once JES2 has written a userid it is the
+       truth, including a USER= the submitter put on the card themselves */
+    if (submitter && submitter[0] && job->owner[0] == '\0') {
+        strncpy((char *)job->owner, submitter, sizeof(job->owner) - 1);
+        job->owner[sizeof(job->owner) - 1] = '\0';
     }
 
     rc = send_job_status_response(session, job, host);

--- a/tests/curl-jobs.sh
+++ b/tests/curl-jobs.sh
@@ -38,6 +38,9 @@ fi
 
 BASE_URL="http://${MVSMF_HOST}:${MVSMF_PORT}"
 AUTH="${MVSMF_USER}:${MVSMF_PASS}"
+# mvsMF reads the userid from the ACEE, where RACF keeps it canonical (upper
+# case). .env may hold it in any case, so fold a copy for value comparisons.
+MVSMF_USER_UC=$(printf '%s' "${MVSMF_USER}" | tr '[:lower:]' '[:upper:]')
 JCL_DIR="${SCRIPT_DIR}/jcl"
 TEST_PDS="${MVSMF_USER}.MVSMF.TESTJCL"
 
@@ -307,7 +310,10 @@ test_submit_inline_jcl() {
 	assert_json_field_exists "$BODY" '.jobid' "submit response has jobid"
 	assert_json_field "$BODY" '.subsystem' "JES2" "submit response subsystem"
 	assert_json_field "$BODY" '.type' "JOB" "submit response type"
-	assert_json_field_exists "$BODY" '.owner' "submit response has owner"
+	# The value, not just the key (#210). JES2 has not written JCTUSEID this
+	# early, so mvsMF answers from the USER= it injected -- an empty owner here
+	# is the regression, and a present-but-empty key passes an exists check.
+	assert_json_field "$BODY" '.owner' "$MVSMF_USER_UC" "submit response owner"
 	assert_json_field_exists "$BODY" '.class' "submit response has class"
 	assert_json_field_exists "$BODY" '.url' "submit response has url"
 	assert_json_field_exists "$BODY" '.["files-url"]' "submit response has files-url"

--- a/tests/zowe-jobs.sh
+++ b/tests/zowe-jobs.sh
@@ -82,6 +82,9 @@ ZOWE_CONN=(--host "$MVSMF_HOST" --port "$MVSMF_PORT"
 	--user "$MVS_USER" --password "$MVSMF_PASS"
 	--reject-unauthorized false)
 TEST_PDS="${MVS_USER}.MVSMF.TESTJCL"
+# mvsMF reads the userid from the ACEE, where RACF keeps it canonical (upper
+# case). .env may hold it in any case, so fold a copy for value comparisons.
+MVS_USER_UC=$(printf '%s' "${MVS_USER}" | tr '[:lower:]' '[:upper:]')
 
 # --- state ---
 PASSED=0
@@ -318,7 +321,10 @@ test_submit_local_file() {
 		assert_json_field_exists "$output" '.data.jobid' "submit has jobid"
 		assert_json_field "$output" '.data.subsystem' "JES2" "submit subsystem"
 		assert_json_field "$output" '.data.type' "JOB" "submit type"
-		assert_json_field_exists "$output" '.data.owner' "submit has owner"
+		# The value, not just the key (#210). JES2 has not written JCTUSEID
+		# this early, so mvsMF answers from the USER= it injected -- and a
+		# present-but-empty key passes an exists check.
+		assert_json_field "$output" '.data.owner' "$MVS_USER_UC" "submit owner"
 		assert_json_field_exists "$output" '.data.status' "submit has status"
 
 		SUBMIT_JOBNAME=$(echo "$output" | jq -r '.data.jobname')


### PR DESCRIPTION
Fixes #210

`PUT /zosmf/restjobs/jobs` answered `"owner":""` for a job it had just
submitted under a known userid.

## The mechanism

A race, not a divergent path. Submit and status share `process_job()`, and
libc370 reads a batch job's owner from `JCTUSEID`, which JES2 writes during
conversion. At the instant the submit response is built the field is still
blank, and `process_intxt()`'s fallback has nothing to read either — the
internal text is not on the spool yet. Asking libc370 earlier cannot fix it;
the data does not exist at that point in time.

mvsMF already knows the answer without asking JES2: `process_jobcard()` puts
`USER=<caller>` on the job card before submission, so a job that comes back
without an owner belongs to that userid by construction.

## The change

`find_and_send_job_status()` takes a `submitter` argument and uses it only to
**complete** an empty owner — a userid JES2 has written is never overwritten,
including a `USER=` the submitter put on the card themselves.

It has to stay an argument. `jobStatusHandler` is the other caller and passes
NULL: it is told a jobname and a jobid, not who submitted them, so resolving
the userid inside the function would report the caller as the owner of
somebody else's just-submitted job. The comment above the function says so, to
keep the parameter from being tidied away later.

`jobPurgeHandler` is left alone deliberately, and `docs/endpoints/jobs/purge.md`
now records why: that handler authorizes nothing (#345), so the caller is
frequently not the owner, and an empty owner is the honest answer there.
`status.md` states the same for the status endpoint rather than leaving the two
documents looking inconsistent.

## Measured on mvsdev

Before, build `25e269d` — one submit, one hit, so the window is wide enough
for the test to mean something:

```
SUBMIT   owner=[]         status=[ACTIVE]
POLL 1   owner=[IBMUSER]  status=[OUTPUT]
```

After, build `ccc9a80` (deployed and activated, `fn=version` checked against
HEAD):

```
SUBMIT   owner=[IBMUSER]  status=[ACTIVE]
POLL 1   owner=[IBMUSER]  status=[OUTPUT]
```

`tests/curl-jobs.sh --setup --cleanup` 125/125, `tests/zowe-jobs.sh` 39/39
(2 skipped — the pre-existing dataset-submit setup gap in the Zowe suite).

## Tests

Both suites asserted only that the `owner` key was present, which a
present-but-empty value satisfies; that is how this survived a green suite.
They now assert the value, folded to upper case because the ACEE keeps the
userid RACF-canonical while `.env` need not.